### PR TITLE
fix: mysql struct to clickhouse struct comment issue

### DIFF
--- a/dt-connector/src/sinker/clickhouse/clickhouse_struct_sinker.rs
+++ b/dt-connector/src/sinker/clickhouse/clickhouse_struct_sinker.rs
@@ -154,7 +154,7 @@ impl ClickhouseStructSinker {
         };
 
         if !column.column_comment.is_empty() {
-            dst_col = format!("{} COMMENT='{}'", dst_col, column.column_comment);
+            dst_col = format!("{} COMMENT '{}'", dst_col, column.column_comment);
         }
 
         Ok(dst_col)


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/apecloud/ape-dts/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --workspace`
- you have updated the changelog (if needed):
  https://github.com/apecloud/ape-dts/blob/main/CHANGELOG.md
-->
Fix comment issue when mysql struct sync to clickhouse struct 