### PR TITLE
improvement: [mysql] aggregate btree index in alter table sql

### DIFF
--- a/dt-tests/tests/mysql_to_mysql/struct/basic_test/expect_ddl_5.7.sql
+++ b/dt-tests/tests/mysql_to_mysql/struct/basic_test/expect_ddl_5.7.sql
@@ -101,12 +101,19 @@ CREATE TABLE `full_index_type` (
   `f_7` text,
   `f_8` text,
   `f_9` point NOT NULL,
+  `f_10` varchar(10) DEFAULT NULL,
+  `f_11` varchar(10) DEFAULT NULL,
+  `f_12` varchar(10) DEFAULT NULL,
+  `f_13` varchar(10) DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_unique_1` (`f_1`,`f_2`,`f_3`),
   UNIQUE KEY `idx_unique_2` (`f_3`),
   SPATIAL KEY `idx_spatial_1` (`f_9`),
   FULLTEXT KEY `idx_full_text_1` (`f_6`,`f_7`,`f_8`),
-  FULLTEXT KEY `idx_full_text_2` (`f_8`)
+  FULLTEXT KEY `idx_full_text_2` (`f_8`),
+  KEY `idx_btree_text_1` (`f_10`),
+  KEY `idx_btree_text_2` (`f_11`),
+  KEY `idx_btree_text_3` (`f_13`,`f_12`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8
 
 struct_it_mysql2mysql_1.constraint_table

--- a/dt-tests/tests/mysql_to_mysql/struct/basic_test/expect_ddl_8.0.sql
+++ b/dt-tests/tests/mysql_to_mysql/struct/basic_test/expect_ddl_8.0.sql
@@ -101,12 +101,19 @@ CREATE TABLE `full_index_type` (
   `f_7` text CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci,
   `f_8` text CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci,
   `f_9` point NOT NULL,
+  `f_10` varchar(10) CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci DEFAULT NULL,
+  `f_11` varchar(10) CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci DEFAULT NULL,
+  `f_12` varchar(10) CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci DEFAULT NULL,
+  `f_13` varchar(10) CHARACTER SET utf8mb3 COLLATE utf8mb3_general_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_unique_1` (`f_1`,`f_2`,`f_3`),
   UNIQUE KEY `idx_unique_2` (`f_3`),
   SPATIAL KEY `idx_spatial_1` (`f_9`),
   FULLTEXT KEY `idx_full_text_1` (`f_6`,`f_7`,`f_8`),
-  FULLTEXT KEY `idx_full_text_2` (`f_8`)
+  FULLTEXT KEY `idx_full_text_2` (`f_8`),
+  KEY `idx_btree_text_1` (`f_10`),
+  KEY `idx_btree_text_2` (`f_11`),
+  KEY `idx_btree_text_3` (`f_13`,`f_12`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3
 
 struct_it_mysql2mysql_1.constraint_table

--- a/dt-tests/tests/mysql_to_mysql/struct/basic_test/src_prepare.sql
+++ b/dt-tests/tests/mysql_to_mysql/struct/basic_test/src_prepare.sql
@@ -112,7 +112,12 @@ CREATE TABLE struct_it_mysql2mysql_1.full_index_type(
     f_6 TEXT,
     f_7 TEXT, 
     f_8 TEXT, 
-    f_9 POINT NOT NULL
+    f_9 POINT NOT NULL,
+    f_10 varchar(10),
+    f_11 varchar(10),
+    f_12 varchar(10),
+    f_13 varchar(10),
+    KEY idx_btree_text_1 (f_10)
 );
 ```
 
@@ -134,6 +139,10 @@ CREATE FULLTEXT INDEX idx_full_text_2 ON struct_it_mysql2mysql_1.full_index_type
 -- spatial index
 -- only 1 column supported in spatial key
 CREATE SPATIAL INDEX idx_spatial_1 ON struct_it_mysql2mysql_1.full_index_type(f_9);
+
+CREATE INDEX idx_btree_text_2 ON struct_it_mysql2mysql_1.full_index_type(f_11);
+
+CREATE INDEX idx_btree_text_3 ON struct_it_mysql2mysql_1.full_index_type(f_13, f_12);
 
 -- full constraint
 ```


### PR DESCRIPTION
aggregate btree indexes in alter table sql to increase index creation speed for MySQL.

eg: 
```
-- struct: 
create table db1.test1 (
  f_10 varchar(10), 
  f_11 varchar(10),  
  f_12 varchar(10), 
  f_13 varchar(10),
  KEY idx_btree_text_1 (f_10) 
)
CREATE INDEX idx_btree_text_2 ON test1(f_11);
CREATE INDEX idx_btree_text_3 ON test1(f_13, f_12);

-- migration sql before:
CREATE INDEX `idx_btree_text_1` ON `db1`.`test1` (`f_10`);
CREATE INDEX `idx_btree_text_2` ON `db1`.`test1` (`f_11`);  
CREATE INDEX `idx_btree_text_3` ON `db1`.`test1` (`f_13`,`f_12`);

-- migration sql after:
ALTER TABLE `db1`.`test1` 
ADD INDEX `idx_btree_text_1` (`f_10`),
ADD INDEX `idx_btree_text_2` (`f_11`),
ADD INDEX `idx_btree_text_3` (`f_13`,`f_12`);
```