### PR TITLE
feat: mysql cdc simple support dcls

### DIFF
--- a/dt-common/src/config/filter_config.rs
+++ b/dt-common/src/config/filter_config.rs
@@ -8,6 +8,7 @@ pub struct FilterConfig {
     pub do_events: String,
     pub do_structures: String,
     pub do_ddls: String,
+    pub do_dcls: String,
     pub ignore_cmds: String,
     pub where_conditions: String,
 }

--- a/dt-common/src/config/task_config.rs
+++ b/dt-common/src/config/task_config.rs
@@ -609,6 +609,7 @@ impl TaskConfig {
             ignore_cols: loader.get_optional(FILTER, "ignore_cols"),
             do_events: loader.get_optional(FILTER, "do_events"),
             do_ddls: loader.get_optional(FILTER, "do_ddls"),
+            do_dcls: loader.get_optional(FILTER, "do_dcls"),
             do_structures: loader.get_with_default(FILTER, "do_structures", ASTRISK.to_string()),
             ignore_cmds: loader.get_optional(FILTER, "ignore_cmds"),
             where_conditions: loader.get_optional(FILTER, "where_conditions"),

--- a/dt-common/src/meta/dcl_meta/dcl_data.rs
+++ b/dt-common/src/meta/dcl_meta/dcl_data.rs
@@ -1,0 +1,26 @@
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+use super::dcl_type::DclType;
+use crate::config::config_enums::DbType;
+use crate::meta::dcl_meta::dcl_statement::DclStatement;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct DclData {
+    pub default_schema: String,
+    pub dcl_type: DclType,
+    pub db_type: DbType,
+    pub statement: DclStatement,
+}
+
+impl std::fmt::Display for DclData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", json!(self))
+    }
+}
+
+impl DclData {
+    pub fn to_sql(&self) -> String {
+        self.statement.to_sql(&self.db_type)
+    }
+}

--- a/dt-common/src/meta/dcl_meta/dcl_parser.rs
+++ b/dt-common/src/meta/dcl_meta/dcl_parser.rs
@@ -1,0 +1,538 @@
+use crate::config::config_enums::DbType;
+use crate::error::Error;
+use crate::meta::dcl_meta::dcl_data::DclData;
+use crate::meta::dcl_meta::dcl_statement::{DclStatement, OriginStatement};
+use crate::meta::dcl_meta::dcl_type::DclType;
+use anyhow::bail;
+use nom::branch::alt;
+use nom::bytes::complete::tag_no_case;
+use nom::character::complete::{multispace0, multispace1};
+use nom::sequence::tuple;
+use nom::IResult;
+use regex::Regex;
+use std::borrow::Cow;
+
+pub struct DclParser {
+    db_type: DbType,
+}
+
+pub type DclSchemaTable = (Option<Vec<u8>>, Vec<u8>);
+
+impl DclParser {
+    pub fn new(db_type: DbType) -> Self {
+        Self { db_type }
+    }
+
+    pub fn parse(&self, sql: &str) -> anyhow::Result<DclData> {
+        let sql = Self::remove_comments(sql);
+        let input = sql.trim().as_bytes();
+        match self.sql_query(input) {
+            Ok((_, mut dcl)) => {
+                dcl.db_type = self.db_type.clone();
+                Ok(dcl)
+            }
+            Err(err) => {
+                let error = match err {
+                    nom::Err::Incomplete(_) => "incomplete".to_string(),
+                    nom::Err::Error(e) | nom::Err::Failure(e) => {
+                        format!("code: {:?}, input: {}", e.code, to_string(e.input))
+                    }
+                };
+                bail! {Error::Unexpected(format!("failed to parse sql: {}, error: {}", sql, error))}
+            }
+        }
+    }
+
+    fn remove_comments(sql: &str) -> Cow<str> {
+        // "create /*some comments,*/table/*some comments*/ `aaa`.`bbb`"
+        let regex = Regex::new(r"(/\*([^*]|\*+[^*/*])*\*+/)|(--[^\n]*\n)").unwrap();
+        regex.replace_all(sql, "")
+    }
+
+    fn sql_query<'a>(&'a self, i: &'a [u8]) -> IResult<&[u8], DclData> {
+        alt((
+            |i| self.create_user(i),
+            |i| self.alter_user(i),
+            |i| self.create_role(i),
+            |i| self.drop_user(i),
+            |i| self.drop_role(i),
+            |i| self.grant(i),
+            |i| self.revoke(i),
+            |i| self.set_role(i),
+        ))(i)
+    }
+
+    fn create_user<'a>(&'a self, i: &'a [u8]) -> IResult<&[u8], DclData> {
+        let _ = tuple((
+            tag_no_case("create"),
+            multispace1,
+            tag_no_case("user"),
+            multispace0,
+        ))(i)?;
+
+        let statement = OriginStatement {
+            origin: to_string(i),
+        };
+
+        let dcl = DclData {
+            dcl_type: DclType::CreateUser,
+            statement: DclStatement::CreateUser(statement),
+            ..Default::default()
+        };
+        Ok((&[], dcl))
+    }
+
+    fn alter_user<'a>(&'a self, i: &'a [u8]) -> IResult<&[u8], DclData> {
+        let _ = tuple((
+            tag_no_case("alter"),
+            multispace1,
+            tag_no_case("user"),
+            multispace0,
+        ))(i)?;
+
+        let statement = OriginStatement {
+            origin: to_string(i),
+        };
+
+        let dcl = DclData {
+            dcl_type: DclType::AlterUser,
+            statement: DclStatement::AlterUser(statement),
+            ..Default::default()
+        };
+        Ok((&[], dcl))
+    }
+
+    fn create_role<'a>(&'a self, i: &'a [u8]) -> IResult<&[u8], DclData> {
+        let _ = tuple((
+            tag_no_case("create"),
+            multispace1,
+            tag_no_case("role"),
+            multispace0,
+        ))(i)?;
+
+        let statement = OriginStatement {
+            origin: to_string(i),
+        };
+
+        let dcl = DclData {
+            dcl_type: DclType::CreateRole,
+            statement: DclStatement::CreateRole(statement),
+            ..Default::default()
+        };
+        Ok((&[], dcl))
+    }
+
+    fn drop_user<'a>(&'a self, i: &'a [u8]) -> IResult<&[u8], DclData> {
+        let _ = tuple((
+            tag_no_case("drop"),
+            multispace1,
+            tag_no_case("user"),
+            multispace0,
+        ))(i)?;
+
+        let statement = OriginStatement {
+            origin: to_string(i),
+        };
+
+        let dcl = DclData {
+            dcl_type: DclType::DropUser,
+            statement: DclStatement::DropUser(statement),
+            ..Default::default()
+        };
+        Ok((&[], dcl))
+    }
+
+    fn drop_role<'a>(&'a self, i: &'a [u8]) -> IResult<&[u8], DclData> {
+        let _ = tuple((
+            tag_no_case("drop"),
+            multispace1,
+            tag_no_case("role"),
+            multispace0,
+        ))(i)?;
+
+        let statement = OriginStatement {
+            origin: to_string(i),
+        };
+
+        let dcl = DclData {
+            dcl_type: DclType::DropRole,
+            statement: DclStatement::DropRole(statement),
+            ..Default::default()
+        };
+        Ok((&[], dcl))
+    }
+
+    fn grant<'a>(&'a self, i: &'a [u8]) -> IResult<&[u8], DclData> {
+        let (remaining_input, _) = tuple((tag_no_case("grant"), multispace1))(i)?;
+
+        let statement = OriginStatement {
+            origin: to_string(i),
+        };
+
+        let dcl = DclData {
+            dcl_type: DclType::Grant,
+            statement: DclStatement::Grant(statement),
+            db_type: self.db_type.clone(),
+            default_schema: "".to_string(),
+        };
+        Ok((remaining_input, dcl))
+    }
+
+    fn revoke<'a>(&'a self, i: &'a [u8]) -> IResult<&[u8], DclData> {
+        let (remaining_input, _) = tuple((tag_no_case("revoke"), multispace1))(i)?;
+
+        let statement = OriginStatement {
+            origin: to_string(i),
+        };
+
+        let dcl = DclData {
+            dcl_type: DclType::Revoke,
+            statement: DclStatement::Revoke(statement),
+            db_type: self.db_type.clone(),
+            default_schema: "".to_string(),
+        };
+        Ok((remaining_input, dcl))
+    }
+
+    fn set_role<'a>(&'a self, i: &'a [u8]) -> IResult<&[u8], DclData> {
+        let _ = tuple((
+            tag_no_case("set"),
+            multispace1,
+            tag_no_case("default"),
+            multispace1,
+            tag_no_case("role"),
+        ))(i)?;
+
+        let statement = OriginStatement {
+            origin: to_string(i),
+        };
+
+        let dcl = DclData {
+            dcl_type: DclType::SetRole,
+            statement: DclStatement::SetRole(statement),
+            ..Default::default()
+        };
+        Ok((&[], dcl))
+    }
+}
+
+fn to_string(i: &[u8]) -> String {
+    String::from_utf8_lossy(i).to_string()
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    fn create_mysql_parser() -> DclParser {
+        DclParser::new(DbType::Mysql)
+    }
+
+    fn check_internal(expect_sqls: Vec<&str>, not_expect_sqls: Vec<&str>, dcl_type: DclType) {
+        let parser = create_mysql_parser();
+        for sql in expect_sqls {
+            let result = parser.parse(sql).unwrap();
+            assert_eq!(result.dcl_type, dcl_type);
+        }
+        for sql in not_expect_sqls {
+            match parser.parse(sql) {
+                Ok(dcl_data) => {
+                    assert_ne!(dcl_data.dcl_type, dcl_type);
+                }
+                Err(_) => {}
+            };
+        }
+    }
+
+    #[test]
+    fn test_mysql_create_user() {
+        let sqls = vec![
+            // basic
+            "CREATE USER 'user1'@'localhost' IDENTIFIED BY 'password123'",
+            // comment
+            "CREATE /*comment1*/ USER /*comment2*/ 'user2'@'localhost' IDENTIFIED BY 'pass123'",
+            // multi-line comment
+            r#"CREATE /*multi-line
+        comment*/ USER -- line comment
+        'user3'@'localhost' IDENTIFIED BY 'pass123'"#,
+            // case-insensitive
+            "Create User 'USER4'@'localhost' IDENTIFIED BY 'pass123'",
+            // multi-spaces and newlines
+            r#"CREATE    USER    
+        'user5'@'localhost'    
+        IDENTIFIED    BY    'pass123'"#,
+            // multi-users
+            r#"CREATE USER 
+        'user6'@'localhost' IDENTIFIED BY 'pass123',
+        'user7'@'%' IDENTIFIED BY 'pass456'"#,
+            // IF NOT EXISTS
+            "CREATE USER IF NOT EXISTS 'user8'@'localhost' IDENTIFIED BY 'pass123'",
+            // ssl
+            r#"CREATE USER 'user9'@'localhost' 
+        IDENTIFIED BY 'pass123' 
+        REQUIRE SSL"#,
+            // account lock
+            "CREATE USER 'user10'@'localhost' IDENTIFIED BY 'pass123' ACCOUNT LOCK",
+            // full options
+            r#"CREATE USER IF NOT EXISTS 'user11'@'localhost'
+        IDENTIFIED WITH mysql_native_password BY 'pass123'
+        REQUIRE SSL
+        PASSWORD EXPIRE INTERVAL 90 DAY
+        FAILED_LOGIN_ATTEMPTS 3
+        PASSWORD_LOCK_TIME 2
+        ACCOUNT LOCK
+        COMMENT 'test user'
+        ATTRIBUTE '{"fname": "James", "lname": "Scott"}'"#,
+        ];
+
+        let not_expect_sqls = vec![
+            r#"CREATE TABLE IF NOT EXISTS Test_DB.Test_TB(id int, "Value" int);"#,
+            "ALTER USER 'test'@'localhost' IDENTIFIED BY 'new_password",
+            "DROP USER 'test'@'localhost'",
+        ];
+
+        check_internal(sqls, not_expect_sqls, DclType::CreateUser);
+    }
+
+    #[test]
+    fn test_mysql_alter_user() {
+        let sqls = vec![
+            // basic
+            "ALTER USER 'user1'@'localhost' IDENTIFIED BY 'password123'",
+            // comment
+            "ALTER /*comment1*/ USER /*comment2*/ 'user2'@'localhost' IDENTIFIED BY 'pass123'",
+            // multi-line comment
+            r#"ALTER /*multi-line
+        comment*/ USER -- line comment
+        'user3'@'localhost' IDENTIFIED BY 'pass123'"#,
+            // case-insensitive
+            "Alter User 'USER4'@'localhost' IDENTIFIED BY 'pass123'",
+            // multi-spaces and newlines
+            r#"ALTER    USER    
+        'user5'@'localhost'    
+        IDENTIFIED    BY    'pass123'"#,
+            // multi-users
+            r#"ALTER USER 
+        'user6'@'localhost' IDENTIFIED BY 'pass123',
+        'user7'@'%' IDENTIFIED BY 'pass456'"#,
+            // IF EXISTS
+            "ALTER USER IF EXISTS 'user8'@'localhost' IDENTIFIED BY 'pass123'",
+            // ssl
+            r#"ALTER USER 'user9'@'localhost' 
+        IDENTIFIED BY 'pass123' 
+        REQUIRE SSL"#,
+            // account lock
+            "ALTER USER 'user10'@'localhost' IDENTIFIED BY 'pass123' ACCOUNT LOCK",
+            // full options
+            r#"ALTER USER IF EXISTS 'user11'@'localhost'
+        IDENTIFIED WITH mysql_native_password BY 'pass123'
+        REQUIRE SSL
+        PASSWORD EXPIRE INTERVAL 90 DAY
+        FAILED_LOGIN_ATTEMPTS 3
+        PASSWORD_LOCK_TIME 2
+        ACCOUNT LOCK
+        COMMENT 'test user'
+        ATTRIBUTE '{"fname": "James", "lname": "Scott"}'"#,
+        ];
+
+        let not_expect_sqls = vec![
+            r#"CREATE TABLE IF NOT EXISTS Test_DB.Test_TB(id int, "Value" int);"#,
+            "alter table aaa.bbb add column value int",
+            "/*alter user*/alter table aaa.bbb add column value int",
+        ];
+
+        check_internal(sqls, not_expect_sqls, DclType::AlterUser);
+    }
+
+    #[test]
+    fn test_mysql_create_role() {
+        let sqls = vec![
+            // basic
+            "CREATE ROLE role1",
+            // comment
+            "CREATE /*comment1*/ ROLE /*comment2*/ role2",
+            // multi-line comment
+            r#"CREATE /*multi-line
+        comment*/ ROLE -- line comment
+        role3"#,
+            // case-insensitive
+            "Create Role ROLE4",
+            // multi-spaces and newlines
+            r#"CREATE    ROLE    
+        role5"#,
+            // multi-roles
+            r#"CREATE ROLE 
+        role6,
+        role7"#,
+            // IF NOT EXISTS
+            "CREATE ROLE IF NOT EXISTS role8",
+        ];
+
+        let not_expect_sqls = vec![
+            r#"CREATE TABLE IF NOT EXISTS Test_DB.Test_TB(id int, "Value" int);"#,
+            "CREATE USER 'test'@'localhost' IDENTIFIED BY 'password'",
+            "DROP ROLE role1",
+        ];
+
+        check_internal(sqls, not_expect_sqls, DclType::CreateRole);
+    }
+
+    #[test]
+    fn test_mysql_drop_user() {
+        let sqls = vec![
+            // basic
+            "DROP USER 'user1'@'localhost'",
+            // comment
+            "DROP /*comment1*/ USER /*comment2*/ 'user2'@'localhost'",
+            // multi-line comment
+            r#"DROP /*multi-line
+        comment*/ USER -- line comment
+        'user3'@'localhost'"#,
+            // case-insensitive
+            "Drop User 'USER4'@'localhost'",
+            // multi-spaces and newlines
+            r#"DROP    USER    
+        'user5'@'localhost'"#,
+            // multi-users
+            r#"DROP USER 
+        'user6'@'localhost',
+        'user7'@'%'"#,
+            // IF EXISTS
+            "DROP USER IF EXISTS 'user8'@'localhost'",
+        ];
+
+        let not_expect_sqls = vec![
+            r#"CREATE TABLE IF NOT EXISTS Test_DB.Test_TB(id int, "Value" int);"#,
+            "CREATE USER 'test'@'localhost' IDENTIFIED BY 'password'",
+            "ALTER USER 'test'@'localhost' IDENTIFIED BY 'new_password'",
+        ];
+
+        check_internal(sqls, not_expect_sqls, DclType::DropUser);
+    }
+
+    #[test]
+    fn test_mysql_drop_role() {
+        let sqls = vec![
+            // basic
+            "DROP ROLE role1",
+            // comment
+            "DROP /*comment1*/ ROLE /*comment2*/ role2",
+            // multi-line comment
+            r#"DROP /*multi-line
+        comment*/ ROLE -- line comment
+        role3"#,
+            // case-insensitive
+            "Drop Role ROLE4",
+            // multi-spaces and newlines
+            r#"DROP    ROLE    
+        role5"#,
+            // multi-roles
+            r#"DROP ROLE 
+        role6,
+        role7"#,
+            // IF EXISTS
+            "DROP ROLE IF EXISTS role8",
+        ];
+
+        let not_expect_sqls = vec![
+            r#"CREATE TABLE IF NOT EXISTS Test_DB.Test_TB(id int, "Value" int);"#,
+            "CREATE ROLE role1",
+            "DROP USER 'test'@'localhost'",
+        ];
+
+        check_internal(sqls, not_expect_sqls, DclType::DropRole);
+    }
+
+    #[test]
+    fn test_mysql_grant() {
+        let sqls = vec![
+            // basic
+            "GRANT ALL ON db.* TO 'user1'@'localhost'",
+            // comment
+            "GRANT /*comment1*/ ALL /*comment2*/ ON db.* TO 'user2'@'localhost'",
+            // multi-line comment
+            r#"GRANT /*multi-line
+        comment*/ ALL -- line comment
+        ON db.* TO 'user3'@'localhost'"#,
+            // case-insensitive
+            "Grant All On db.* To 'USER4'@'localhost'",
+            // multi-spaces and newlines
+            r#"GRANT    ALL    ON    
+        db.*    TO    'user5'@'localhost'"#,
+            // specific privileges
+            "GRANT SELECT, INSERT, UPDATE ON db.table TO 'user6'@'localhost'",
+            // with grant option
+            "GRANT ALL ON *.* TO 'user7'@'localhost' WITH GRANT OPTION",
+        ];
+
+        let not_expect_sqls = vec![
+            r#"CREATE TABLE IF NOT EXISTS Test_DB.Test_TB(id int, "Value" int);"#,
+            "CREATE USER 'test'@'localhost' IDENTIFIED BY 'password'",
+            "REVOKE ALL ON db.* FROM 'test'@'localhost'",
+        ];
+
+        check_internal(sqls, not_expect_sqls, DclType::Grant);
+    }
+
+    #[test]
+    fn test_mysql_revoke() {
+        let sqls = vec![
+            // basic
+            "REVOKE ALL ON db.* FROM 'user1'@'localhost'",
+            // comment
+            "REVOKE /*comment1*/ ALL /*comment2*/ ON db.* FROM 'user2'@'localhost'",
+            // multi-line comment
+            r#"REVOKE /*multi-line
+        comment*/ ALL -- line comment
+        ON db.* FROM 'user3'@'localhost'"#,
+            // case-insensitive
+            "Revoke All On db.* From 'USER4'@'localhost'",
+            // multi-spaces and newlines
+            r#"REVOKE    ALL    ON    
+        db.*    FROM    'user5'@'localhost'"#,
+            // specific privileges
+            "REVOKE SELECT, INSERT, UPDATE ON db.table FROM 'user6'@'localhost'",
+            // grant option
+            "REVOKE GRANT OPTION ON *.* FROM 'user7'@'localhost'",
+        ];
+
+        let not_expect_sqls = vec![
+            r#"CREATE TABLE IF NOT EXISTS Test_DB.Test_TB(id int, "Value" int);"#,
+            "CREATE USER 'test'@'localhost' IDENTIFIED BY 'password'",
+            "GRANT ALL ON db.* TO 'test'@'localhost'",
+        ];
+
+        check_internal(sqls, not_expect_sqls, DclType::Revoke);
+    }
+
+    #[test]
+    fn test_mysql_set_role() {
+        let sqls = vec![
+            // basic
+            "SET DEFAULT ROLE role1 TO 'user1'@'localhost'",
+            // comment
+            "SET /*comment1*/ DEFAULT /*comment2*/ ROLE role2 TO 'user2'@'localhost'",
+            // multi-line comment
+            r#"SET /*multi-line
+        comment*/ DEFAULT -- line comment
+        ROLE role3 TO 'user3'@'localhost'"#,
+            // case-insensitive
+            "Set Default Role ROLE4 To 'USER4'@'localhost'",
+            // multi-spaces and newlines
+            r#"SET    DEFAULT    ROLE    
+        role5    TO    'user5'@'localhost'"#,
+            // multi-roles
+            r#"SET DEFAULT ROLE 
+        role6, role7 TO 'user8'@'localhost'"#,
+            // ALL
+            "SET DEFAULT ROLE ALL TO 'user9'@'localhost'",
+            // NONE
+            "SET DEFAULT ROLE NONE TO 'user10'@'localhost'",
+        ];
+
+        let not_expect_sqls = vec![];
+
+        check_internal(sqls, not_expect_sqls, DclType::SetRole);
+    }
+}

--- a/dt-common/src/meta/dcl_meta/dcl_statement.rs
+++ b/dt-common/src/meta/dcl_meta/dcl_statement.rs
@@ -1,0 +1,49 @@
+use serde::{Deserialize, Serialize};
+
+use crate::config::config_enums::DbType;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub enum DclStatement {
+    CreateUser(OriginStatement),
+    AlterUser(OriginStatement),
+    CreateRole(OriginStatement),
+    DropUser(OriginStatement),
+    DropRole(OriginStatement),
+    Grant(OriginStatement),
+    Revoke(OriginStatement),
+    SetRole(OriginStatement),
+
+    #[default]
+    Unknown,
+}
+
+impl DclStatement {
+    pub fn get_schema_tb(&self) -> (String, String) {
+        // Todo: support get schema and tb by dcl parser
+        (String::new(), String::new())
+    }
+
+    pub fn route(&mut self, _dst_schema: String, _dst_tb: String) {
+        // Todo: support route
+    }
+
+    pub fn to_sql(&self, _db_type: &DbType) -> String {
+        match self {
+            DclStatement::CreateUser(s)
+            | DclStatement::AlterUser(s)
+            | DclStatement::CreateRole(s)
+            | DclStatement::DropUser(s)
+            | DclStatement::DropRole(s)
+            | DclStatement::SetRole(s)
+            | DclStatement::Grant(s)
+            | DclStatement::Revoke(s) => s.origin.clone(),
+
+            DclStatement::Unknown => String::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct OriginStatement {
+    pub origin: String,
+}

--- a/dt-common/src/meta/dcl_meta/dcl_type.rs
+++ b/dt-common/src/meta/dcl_meta/dcl_type.rs
@@ -1,0 +1,32 @@
+use serde::{Deserialize, Serialize};
+use strum::{Display, EnumString, IntoStaticStr};
+
+#[derive(
+    Debug, Clone, PartialEq, Display, EnumString, IntoStaticStr, Serialize, Deserialize, Eq,
+)]
+pub enum DclType {
+    #[strum(serialize = "create_user")]
+    CreateUser,
+    #[strum(serialize = "alter_user")]
+    AlterUser,
+    #[strum(serialize = "create_role")]
+    CreateRole,
+    #[strum(serialize = "drop_user")]
+    DropUser,
+    #[strum(serialize = "drop_role")]
+    DropRole,
+    #[strum(serialize = "grant")]
+    Grant,
+    #[strum(serialize = "revoke")]
+    Revoke,
+    #[strum(serialize = "set_role")]
+    SetRole,
+    #[strum(serialize = "unknown")]
+    Unknown,
+}
+
+impl Default for DclType {
+    fn default() -> Self {
+        Self::Unknown
+    }
+}

--- a/dt-common/src/meta/dcl_meta/mod.rs
+++ b/dt-common/src/meta/dcl_meta/mod.rs
@@ -1,0 +1,4 @@
+pub mod dcl_data;
+pub mod dcl_parser;
+pub mod dcl_statement;
+pub mod dcl_type;

--- a/dt-common/src/meta/dt_data.rs
+++ b/dt-common/src/meta/dt_data.rs
@@ -1,12 +1,12 @@
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
-use crate::meta::{position::Position, redis::redis_entry::RedisEntry};
-
 use super::{
     ddl_meta::ddl_data::DdlData, foxlake::s3_file_meta::S3FileMeta, row_data::RowData,
     struct_meta::struct_data::StructData,
 };
+use crate::meta::dcl_meta::dcl_data::DclData;
+use crate::meta::{position::Position, redis::redis_entry::RedisEntry};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DtItem {
@@ -28,6 +28,9 @@ pub enum DtData {
     },
     Ddl {
         ddl_data: DdlData,
+    },
+    Dcl {
+        dcl_data: DclData,
     },
     Dml {
         row_data: RowData,

--- a/dt-common/src/meta/mod.rs
+++ b/dt-common/src/meta/mod.rs
@@ -21,3 +21,4 @@ pub mod row_type;
 pub mod struct_meta;
 pub mod syncer;
 pub mod time;
+pub mod dcl_meta;

--- a/dt-common/src/meta/struct_meta/statement/mysql_create_table_statement.rs
+++ b/dt-common/src/meta/struct_meta/statement/mysql_create_table_statement.rs
@@ -1,6 +1,7 @@
 use crate::meta::struct_meta::structure::column::ColumnDefault;
 use crate::{config::config_enums::DbType, rdb_filter::RdbFilter};
 
+use crate::meta::struct_meta::structure::index::IndexType;
 use crate::meta::struct_meta::structure::{
     column::Column,
     constraint::Constraint,
@@ -8,7 +9,6 @@ use crate::meta::struct_meta::structure::{
     structure_type::StructureType,
     table::Table,
 };
-use crate::meta::struct_meta::structure::index::IndexType;
 
 #[derive(Debug, Clone)]
 pub struct MysqlCreateTableStatement {
@@ -44,7 +44,7 @@ impl MysqlCreateTableStatement {
             sqls.push((key, Self::table_to_sql(&mut self.table)));
         }
 
-        if self.indexes.len() > 0 {
+        if !self.indexes.is_empty() {
             let mut idx_appends = Vec::new();
             for i in self.indexes.iter_mut() {
                 match i.index_kind {
@@ -52,7 +52,7 @@ impl MysqlCreateTableStatement {
                         if filter.filter_structure(&StructureType::Table) {
                             continue;
                         }
-                    },
+                    }
                     _ => {
                         if filter.filter_structure(&StructureType::Index) {
                             continue;
@@ -64,7 +64,7 @@ impl MysqlCreateTableStatement {
                     // join Btree index for same table
                     IndexType::Btree => {
                         idx_appends.push(Self::index_to_sql_appends(i));
-                    },
+                    }
                     _ => {
                         let standalone_key = format!(
                             "index.{}.{}.{}",
@@ -74,7 +74,7 @@ impl MysqlCreateTableStatement {
                     }
                 }
             }
-            if idx_appends.len() > 0 {
+            if !idx_appends.is_empty() {
                 let key = format!(
                     "index.{}.{}",
                     self.indexes[0].database_name, self.indexes[0].table_name

--- a/dt-connector/src/lib.rs
+++ b/dt-connector/src/lib.rs
@@ -14,7 +14,7 @@ pub mod sinker;
 use async_trait::async_trait;
 use check_log::check_log::CheckLog;
 use dt_common::meta::{
-    ddl_meta::ddl_data::DdlData, dt_data::DtItem, row_data::RowData,
+    dcl_meta::dcl_data::DclData, ddl_meta::ddl_data::DdlData, dt_data::DtItem, row_data::RowData,
     struct_meta::struct_data::StructData,
 };
 
@@ -25,6 +25,10 @@ pub trait Sinker {
     }
 
     async fn sink_ddl(&mut self, mut _data: Vec<DdlData>, _batch: bool) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn sink_dcl(&mut self, mut _data: Vec<DclData>, _batch: bool) -> anyhow::Result<()> {
         Ok(())
     }
 

--- a/dt-parallelizer/src/lib.rs
+++ b/dt-parallelizer/src/lib.rs
@@ -15,8 +15,8 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use dt_common::meta::{
-    ddl_meta::ddl_data::DdlData, dt_data::DtItem, dt_queue::DtQueue, row_data::RowData,
-    struct_meta::struct_data::StructData,
+    dcl_meta::dcl_data::DclData, ddl_meta::ddl_data::DdlData, dt_data::DtItem, dt_queue::DtQueue,
+    row_data::RowData, struct_meta::struct_data::StructData,
 };
 use dt_connector::Sinker;
 use merge_parallelizer::TbMergedData;
@@ -40,6 +40,14 @@ pub trait Parallelizer {
     async fn sink_dml(
         &mut self,
         _data: Vec<RowData>,
+        _sinkers: &[Arc<async_mutex::Mutex<Box<dyn Sinker + Send>>>],
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn sink_dcl(
+        &mut self,
+        _data: Vec<DclData>,
         _sinkers: &[Arc<async_mutex::Mutex<Box<dyn Sinker + Send>>>],
     ) -> anyhow::Result<()> {
         Ok(())

--- a/dt-parallelizer/src/merge_parallelizer.rs
+++ b/dt-parallelizer/src/merge_parallelizer.rs
@@ -2,6 +2,7 @@ use std::{cmp, sync::Arc};
 
 use async_trait::async_trait;
 use dt_common::config::sinker_config::BasicSinkerConfig;
+use dt_common::meta::dcl_meta::dcl_data::DclData;
 use dt_common::meta::ddl_meta::ddl_data::DdlData;
 use dt_common::meta::dt_queue::DtQueue;
 use dt_common::meta::{
@@ -74,6 +75,16 @@ impl Parallelizer for MergeParallelizer {
         // ddl should always be excuted serially
         self.base_parallelizer
             .sink_ddl(vec![data], sinkers, 1, false)
+            .await
+    }
+
+    async fn sink_dcl(
+        &mut self,
+        data: Vec<DclData>,
+        sinkers: &[Arc<async_mutex::Mutex<Box<dyn Sinker + Send>>>],
+    ) -> anyhow::Result<()> {
+        self.base_parallelizer
+            .sink_dcl(vec![data], sinkers, 1, false)
             .await
     }
 }

--- a/dt-parallelizer/src/serial_parallelizer.rs
+++ b/dt-parallelizer/src/serial_parallelizer.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use dt_common::meta::{
-    ddl_meta::ddl_data::DdlData, dt_data::DtItem, dt_queue::DtQueue, row_data::RowData,
-    struct_meta::struct_data::StructData,
+    dcl_meta::dcl_data::DclData, ddl_meta::ddl_data::DdlData, dt_data::DtItem, dt_queue::DtQueue,
+    row_data::RowData, struct_meta::struct_data::StructData,
 };
 use dt_connector::Sinker;
 
@@ -42,6 +42,16 @@ impl Parallelizer for SerialParallelizer {
     ) -> anyhow::Result<()> {
         self.base_parallelizer
             .sink_ddl(vec![data], sinkers, 1, false)
+            .await
+    }
+
+    async fn sink_dcl(
+        &mut self,
+        data: Vec<DclData>,
+        sinkers: &[Arc<async_mutex::Mutex<Box<dyn Sinker + Send>>>],
+    ) -> anyhow::Result<()> {
+        self.base_parallelizer
+            .sink_dcl(vec![data], sinkers, 1, false)
             .await
     }
 

--- a/dt-tests/tests/mysql_to_mysql/cdc/dcl_test/check_with_failed.txt
+++ b/dt-tests/tests/mysql_to_mysql/cdc/dcl_test/check_with_failed.txt
@@ -1,0 +1,13 @@
+-- test_drop/123456
+select version()
+
+-- test_revoke/123456
+select * from dcl_test_1.tb2
+
+-- test_role1/123456
+select * from dcl_test_1.tb2
+
+-- test_role2/123456
+select * from dcl_test_1.tb1
+select * from dcl_test_1.tb2
+

--- a/dt-tests/tests/mysql_to_mysql/cdc/dcl_test/check_with_succeed.txt
+++ b/dt-tests/tests/mysql_to_mysql/cdc/dcl_test/check_with_succeed.txt
@@ -1,0 +1,11 @@
+-- test_create/123456
+select version()
+
+-- test_grant/123456
+select * from dcl_test_1.tb1
+
+-- test_role1/123456
+select * from dcl_test_1.tb1
+
+-- test_revoke/123456
+select * from dcl_test_1.tb1

--- a/dt-tests/tests/mysql_to_mysql/cdc/dcl_test/dst_prepare.sql
+++ b/dt-tests/tests/mysql_to_mysql/cdc/dcl_test/dst_prepare.sql
@@ -1,0 +1,16 @@
+DROP USER IF EXISTS 'test_create'@'%';
+DROP USER IF EXISTS 'test_drop'@'%';
+DROP USER IF EXISTS 'test_grant'@'%';
+DROP USER IF EXISTS 'test_revoke'@'%';
+DROP USER IF EXISTS 'test_role1'@'%';
+DROP USER IF EXISTS 'test_role2'@'%';
+DROP ROLE IF EXISTS 'role1';
+DROP ROLE IF EXISTS 'role2';
+DROP ROLE IF EXISTS 'role3';
+
+DROP DATABASE IF EXISTS dcl_test_1;
+CREATE DATABASE dcl_test_1;
+
+CREATE TABLE dcl_test_1.tb1 ( f_0 tinyint, f_1 smallint DEFAULT NULL, PRIMARY KEY (f_0) ); 
+CREATE TABLE dcl_test_1.tb2 ( f_0 tinyint, f_1 smallint DEFAULT NULL, PRIMARY KEY (f_0) ); 
+

--- a/dt-tests/tests/mysql_to_mysql/cdc/dcl_test/src_prepare.sql
+++ b/dt-tests/tests/mysql_to_mysql/cdc/dcl_test/src_prepare.sql
@@ -1,0 +1,16 @@
+DROP USER IF EXISTS 'test_create'@'%';
+DROP USER IF EXISTS 'test_drop'@'%';
+DROP USER IF EXISTS 'test_grant'@'%';
+DROP USER IF EXISTS 'test_revoke'@'%';
+DROP USER IF EXISTS 'test_role1'@'%';
+DROP USER IF EXISTS 'test_role2'@'%';
+DROP ROLE IF EXISTS 'role1';
+DROP ROLE IF EXISTS 'role2';
+DROP ROLE IF EXISTS 'role3';
+
+DROP DATABASE IF EXISTS dcl_test_1;
+CREATE DATABASE dcl_test_1;
+
+CREATE TABLE dcl_test_1.tb1 ( f_0 tinyint, f_1 smallint DEFAULT NULL, PRIMARY KEY (f_0) ); 
+CREATE TABLE dcl_test_1.tb2 ( f_0 tinyint, f_1 smallint DEFAULT NULL, PRIMARY KEY (f_0) ); 
+

--- a/dt-tests/tests/mysql_to_mysql/cdc/dcl_test/src_test.sql
+++ b/dt-tests/tests/mysql_to_mysql/cdc/dcl_test/src_test.sql
@@ -1,0 +1,27 @@
+CREATE USER 'test_create'@'%' IDENTIFIED BY '123456_old';
+ALTER USER 'test_create'@'%' IDENTIFIED BY '123456';
+
+CREATE USER 'test_drop'@'%' IDENTIFIED BY '123456';
+DROP USER 'test_drop'@'%';
+
+CREATE USER 'test_grant'@'%' IDENTIFIED BY '123456';
+GRANT SELECT ON dcl_test_1.tb1 TO 'test_grant'@'%';
+
+CREATE USER 'test_revoke'@'%' IDENTIFIED BY '123456';
+GRANT SELECT ON dcl_test_1.tb1 TO 'test_revoke'@'%';
+GRANT SELECT ON dcl_test_1.tb2 TO 'test_revoke'@'%';
+REVOKE SELECT ON dcl_test_1.tb2 FROM 'test_revoke'@'%';
+
+CREATE USER 'test_role1'@'%' IDENTIFIED BY '123456';
+CREATE ROLE 'role1';
+GRANT SELECT ON dcl_test_1.tb1 to 'role1';
+CREATE ROLE 'role2';
+GRANT SELECT ON dcl_test_1.tb2 to 'role2';
+GRANT 'role1','role2' TO 'test_role1'@'%';
+SET DEFAULT ROLE 'role1' TO 'test_role1'@'%';
+
+CREATE ROLE 'role3';
+GRANT SELECT ON dcl_test_1.* to 'role3';
+CREATE USER 'test_role2'@'%' IDENTIFIED BY '123456';
+GRANT 'role3' TO 'test_role2'@'%';
+DROP ROLE 'role3';

--- a/dt-tests/tests/mysql_to_mysql/cdc/dcl_test/task_config.ini
+++ b/dt-tests/tests/mysql_to_mysql/cdc/dcl_test/task_config.ini
@@ -11,16 +11,16 @@ heartbeat_tb=heartbeat_db.ape_dts_heartbeat
 [filter]
 ignore_dbs=
 do_dbs=
-do_tbs=test_db_1.*,upper_case_db.*
+do_tbs=*.*
 ignore_tbs=
 do_events=insert,update,delete
-ignore_cols=json:[{"db":"test_db_1","tb":"ignore_cols_1","ignore_cols":["f_2","f_3"]},{"db":"test_db_1","tb":"ignore_cols_2","ignore_cols":["f_3"]}]
 do_ddls=*
+do_dcls=*
 
 [sinker]
 db_type=mysql
 sink_type=write
-batch_size=2
+batch_size=4
 url={mysql_sinker_url}
 
 [router]
@@ -28,13 +28,13 @@ tb_map=
 col_map=
 db_map=
 
+[pipeline]
+buffer_size=4
+checkpoint_interval_secs=10
+
 [parallelizer]
 parallel_type=rdb_merge
 parallel_size=2
-
-[pipeline]
-buffer_size=4
-checkpoint_interval_secs=1
 
 [runtime]
 log_dir=./logs

--- a/dt-tests/tests/mysql_to_mysql/cdc_tests.rs
+++ b/dt-tests/tests/mysql_to_mysql/cdc_tests.rs
@@ -166,4 +166,10 @@ mod test {
     async fn cdc_gtid_test() {
         TestBase::run_cdc_test("mysql_to_mysql/cdc/gtid_test", 3000, 2000).await;
     }
+
+    #[tokio::test]
+    #[serial]
+    async fn cdc_dcl_test() {
+        TestBase::run_dcl_test("mysql_to_mysql/cdc/dcl_test", 3000, 5000).await;
+    }
 }

--- a/dt-tests/tests/test_runner/test_base.rs
+++ b/dt-tests/tests/test_runner/test_base.rs
@@ -318,4 +318,13 @@ impl TestBase {
             .unwrap();
         runner.close().await.unwrap();
     }
+
+    pub async fn run_dcl_test(test_dir: &str, start_millis: u64, parse_millis: u64) {
+        let runner = RdbTestRunner::new(test_dir).await.unwrap();
+        runner
+            .run_dcl_test(start_millis, parse_millis)
+            .await
+            .unwrap();
+        runner.close().await.unwrap();
+    }
 }


### PR DESCRIPTION
MySQL cdc simply support DCLs, such as:
```
CREATE USER 
ALTER USER 
DROP USER 
GRANT 
REVOKE
CREATE ROLE
DROP ROLE
SET DEFAULT ROLE
```
- supported:
  - select which types of DCL statements to synchronize(dt-common/src/meta/dcl_meta/dcl_type.rs). DCL is not synchronized by default.
- not supported:
  - database name and table name filtering and routing

*Note that syncing DCL often requires the sinker user to have high permissions.*