### PR TITLE
feature: prometheus style metrics api in http

### DIFF
--- a/.github/workflows/build_and_push_images.yml
+++ b/.github/workflows/build_and_push_images.yml
@@ -36,13 +36,13 @@ jobs:
       - name: Build for x86_64
         if: contains(inputs.platforms, 'linux/amd64')
         run: |
-          cross build --target x86_64-unknown-linux-gnu --release
+          cross build --target x86_64-unknown-linux-gnu --release --features metrics
           cp target/x86_64-unknown-linux-gnu/release/dt-main amd64-unknown-linux-gnu-dt-main
 
       - name: Build for aarch64
         if: contains(inputs.platforms, 'linux/arm64')
         run: |
-          cross build --target aarch64-unknown-linux-gnu --release
+          cross build --target aarch64-unknown-linux-gnu --release --features metrics
           cp target/aarch64-unknown-linux-gnu/release/dt-main arm64-unknown-linux-gnu-dt-main
 
       - name: Set up docker buildx

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -56,7 +56,7 @@ jobs:
         if: matrix.target == 'x86_64-apple-darwin'
         run: |
           rustup target add ${{ matrix.target }}
-          cargo build --release --target=${{ matrix.target }}
+          cargo build --release --features metrics --target=${{ matrix.target }}
 
       - name: Create release artifact
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,7 +303,7 @@ dependencies = [
  "serde_json",
  "strum",
  "strum_macros",
- "thiserror",
+ "thiserror 1.0.69",
  "typed-builder 0.16.2",
  "uuid",
 ]
@@ -898,7 +898,7 @@ dependencies = [
  "sealed",
  "serde",
  "static_assertions",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
  "tokio",
  "url",
@@ -1178,6 +1178,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04d2cd9c18b9f454ed67da600630b021a8a80bf33f8c95896ab33aaf1c26b728"
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core 0.9.11",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1342,6 +1356,7 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 name = "dt-common"
 version = "0.1.0"
 dependencies = [
+ "actix-web",
  "anyhow",
  "apache-avro",
  "async-trait",
@@ -1350,6 +1365,7 @@ dependencies = [
  "chrono",
  "concurrent-queue",
  "configparser",
+ "dashmap",
  "dotenv",
  "futures",
  "hex",
@@ -1362,6 +1378,7 @@ dependencies = [
  "openssl",
  "openssl-sys",
  "project-root",
+ "prometheus",
  "redis",
  "regex",
  "serde",
@@ -1369,7 +1386,7 @@ dependencies = [
  "serde_yaml",
  "sqlx",
  "strum",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "url",
 ]
@@ -1413,7 +1430,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "strum",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-postgres",
  "url",
@@ -1508,6 +1525,7 @@ dependencies = [
  "log4rs",
  "mongodb",
  "project-root",
+ "prometheus",
  "ratelimit",
  "rdkafka",
  "redis",
@@ -2491,7 +2509,7 @@ dependencies = [
  "openssl-sys",
  "ref_slice",
  "snap 1.1.1",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
  "twox-hash",
 ]
@@ -2677,7 +2695,7 @@ dependencies = [
  "serde-value",
  "serde_json",
  "serde_yaml",
- "thiserror",
+ "thiserror 1.0.69",
  "thread-id",
  "typemap-ors",
  "winapi",
@@ -2864,7 +2882,7 @@ dependencies = [
  "stringprep",
  "strsim 0.10.0",
  "take_mut",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-rustls 0.24.1",
  "tokio-util 0.7.15",
@@ -2896,7 +2914,7 @@ dependencies = [
  "serial_test",
  "sha1",
  "sha2 0.10.9",
- "thiserror",
+ "thiserror 1.0.69",
  "url",
  "zstd 0.13.3",
 ]
@@ -2916,7 +2934,7 @@ dependencies = [
  "quote",
  "syn 2.0.103",
  "termcolor",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2952,7 +2970,7 @@ dependencies = [
  "sha2 0.10.9",
  "smallvec",
  "subprocess",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
  "uuid",
  "zstd 0.13.3",
@@ -3163,7 +3181,7 @@ version = "0.1.0"
 source = "git+https://github.com/apecloud/orc-format#4fb40f9d94b00286d09396a1f3e520aa9cdcb7be"
 dependencies = [
  "byteorder",
- "protobuf",
+ "protobuf 2.28.0",
  "protoc-rust",
  "snap 0.2.5",
  "zstd 0.12.4",
@@ -3445,10 +3463,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bccbff07d5ed689c4087d20d7307a52ab6141edeedf487c3876a55b86cf63df"
 
 [[package]]
+name = "prometheus"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ca5326d8d0b950a9acd87e6a3f94745394f62e4dae1b1ee22b2bc0c394af43a"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot 0.12.4",
+ "protobuf 3.7.2",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "protobuf"
 version = "2.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+
+[[package]]
+name = "protobuf"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
+dependencies = [
+ "once_cell",
+ "protobuf-support",
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "protobuf-codegen"
@@ -3456,7 +3500,16 @@ version = "2.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "033460afb75cf755fcfc16dfaed20b86468082a2ea24e05ac35ab4a099a017d6"
 dependencies = [
- "protobuf",
+ "protobuf 2.28.0",
+]
+
+[[package]]
+name = "protobuf-support"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
+dependencies = [
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3475,7 +3528,7 @@ version = "2.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22f8a182bb17c485f20bdc4274a8c39000a61024cfe461c799b50fec77267838"
 dependencies = [
- "protobuf",
+ "protobuf 2.28.0",
  "protobuf-codegen",
  "protoc",
  "tempfile",
@@ -3595,7 +3648,7 @@ checksum = "36ea961700fd7260e7fa3701c8287d901b2172c51f9c1421fa0f21d7f7e184b7"
 dependencies = [
  "clocksource",
  "parking_lot 0.12.4",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3622,7 +3675,6 @@ version = "4.8.0+2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced38182dc436b3d9df0c77976f37a67134df26b050df1f0006688e46fc4c8be"
 dependencies = [
- "cmake",
  "libc",
  "libz-sys",
  "num_enum",
@@ -3679,7 +3731,7 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom 0.2.16",
  "libredox",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4574,7 +4626,7 @@ dependencies = [
  "sqlformat",
  "sqlx-rt",
  "stringprep",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
  "url",
  "uuid",
@@ -4777,7 +4829,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -4785,6 +4846,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.103",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5041,7 +5113,7 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
  "tinyvec",
  "tokio",
  "url",
@@ -5062,7 +5134,7 @@ dependencies = [
  "parking_lot 0.12.4",
  "resolv-conf",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "trust-dns-proto",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3675,6 +3675,7 @@ version = "4.8.0+2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced38182dc436b3d9df0c77976f37a67134df26b050df1f0006688e46fc4c8be"
 dependencies = [
+ "cmake",
  "libc",
  "libz-sys",
  "num_enum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ async-mutex = "1.4.0"
 project-root = "0.2.2"
 strum = { version = "0.25.0", features = ["derive"] }
 regex = "1.5.4"
-rdkafka = { version = "0.36.2", features = ["cmake-build", "libz-static"] }
+rdkafka = { version = "0.36.2", features = ["libz-static"] }
 kafka = "0.10.0"
 reqwest = {git = "https://github.com/apecloud/reqwest", features = ["redirect-with-sensitive-headers"] }
 rusoto_core = {version = "0.48.0", default-features = false, features = ["rustls"]}
@@ -66,6 +66,7 @@ openssl-sys = { version = "0.9", features = ["vendored"]}
 actix-web = "4.9.0"
 hex = "0.4.3"
 clickhouse = "0.13.1"
+dashmap = "6.1.0"
 
 [profile.release]
 panic = 'unwind'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ async-mutex = "1.4.0"
 project-root = "0.2.2"
 strum = { version = "0.25.0", features = ["derive"] }
 regex = "1.5.4"
-rdkafka = { version = "0.36.2", features = ["libz-static"] }
+rdkafka = { version = "0.36.2", features = ["cmake-build","libz-static"] }
 kafka = "0.10.0"
 reqwest = {git = "https://github.com/apecloud/reqwest", features = ["redirect-with-sensitive-headers"] }
 rusoto_core = {version = "0.48.0", default-features = false, features = ["rustls"]}

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ RUN --mount=type=cache,target=$CARGO_HOME/git,rw \
     if [ -n "${BUILD_TARGET}" ]; then \
         BUILD_ARGS="${BUILD_ARGS} --target ${BUILD_TARGET}" ; \
     fi ; \
-    cargo build --release ${BUILD_ARGS} && \
+    cargo build --release ${BUILD_ARGS} --features metrics && \
     mkdir -p bin/ && \
     cp /app/target/release/${MODULE_NAME} bin/
 

--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ test: CARGO_INCREMENTAL=0
 test: RUSTFLAGS='-Cinstrument-coverage'
 test: LLVM_PROFILE_FILE='cargo-test-%p-%m.profraw'
 test: ## Run tests.
-	cargo test
+	cargo test --workspace --lib
 
 .PHONY: test-cover
 test-cover: grcov test  ## Run tests with coverage report

--- a/README.md
+++ b/README.md
@@ -25,6 +25,29 @@
 | Data check/revise/review | &#10004;       | &#10004; | &#10004;       |                |                |             |                    |                     | &#10004;      |                 |                  |                |             |
 | Structure migration      | &#10004;       | &#10004; |                |                |                |             | &#10004;           | &#10004;            | &#10004;      | &#10004;        | &#10004;         | &#10004;       | &#10004;    |
 
+# Advanced
+
+## Crate features
+
+The dt-main crate provides several optional components which can be enabled via `Cargo [features]`:
+
+- `metrics`: Enable Prometheus format task metrics HTTP service interface.
+  After enabling this feature, you can customize the metrics service with the following configuration:
+
+  ```
+  [metrics]
+  # http service host
+  http_host=127.0.0.1
+  # http service port
+  http_port=9090
+  # http service worker count
+  workers=2
+  # prometheus metrics const labels
+  labels=your_label1:your_value1,your_label2:your_value2
+  ```
+
+- TBD
+
 # Quick starts
 
 ## Tutorial

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -28,6 +28,29 @@
 | 数据校验/订正/复查 | &#10004;       | &#10004; | &#10004;       |                |                |             |                    |                     | &#10004;      |                 |                  |                |             |
 | 库表结构迁移       | &#10004;       | &#10004; |                |                |                |             | &#10004;           | &#10004;            | &#10004;      | &#10004;        | &#10004;         | &#10004;       | &#10004;    |
 
+# 高级选项
+
+## Crate features
+
+dt-main crate 提供了几个可选组件，可以通过 `Cargo [features]` 启用：
+
+- `metrics`: 启用 Prometheus 格式的任务指标 HTTP 服务接口。
+  启用此功能后，您可以通过以下配置自定义指标服务：
+
+  ```
+  [metrics]
+  # http服务host
+  http_host=127.0.0.1
+  # http服务port
+  http_port=9090
+  # http服务工作节点数量
+  workers=2
+  # prometheus指标静态标签
+  labels=your_label1:your_value1,your_label2:your_value2
+  ```
+
+- TBD
+
 # 快速上手
 
 ## 教程

--- a/docs/en/build_images.md
+++ b/docs/en/build_images.md
@@ -7,25 +7,29 @@ You can get amd64 & arm64 images which uses gnu by running [github workflow](/.g
 # Local build
 
 - on arm64 machine
+
 ```
 docker buildx build \
 --platform linux/arm64 --tag ape-dts:0.1.0-test-arm64 \
---build-arg MODULE_NAME=dt-main --load . 
+--build-arg MODULE_NAME=dt-main --load .
 ```
 
 - on amd64 machine
+
 ```
 docker buildx build \
 --platform linux/amd64 --tag ape-dts:0.1.0-test-amd64 \
---build-arg MODULE_NAME=dt-main --load . 
+--build-arg MODULE_NAME=dt-main --load .
 ```
 
 # Cross build on Mac
+
 On Mac, you can use musl to produce a statically linked executable, then copy it into an alpine image.
 
 But note that musl may cause Rust code very slow, refer to: [blog](https://andygrove.io/2020/05/why-musl-extremely-slow/), [discussion](https://www.reddit.com/r/rust/comments/gdycv8/why_does_musl_make_my_code_so_slow/), it is **NOT** recommended for production.
 
 ## Download cross build tools
+
 ```
 mkdir ~/Downloads/macos-cross-toolchains
 cd ~/Downloads/macos-cross-toolchains
@@ -38,27 +42,30 @@ tar -xvzf x86_64-unknown-linux-musl-x86_64-darwin.tar.gz
 ```
 
 ## Add rust target
+
 ```
 rustup target add aarch64-unknown-linux-musl
 rustup target add x86_64-unknown-linux-musl
 ```
 
 ## Build
+
 ```
 # build x86_64-unknown-linux-musl
 export "PATH=$HOME/Downloads/macos-cross-toolchains/x86_64-unknown-linux-musl/bin:$PATH"
 export CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=x86_64-linux-musl-gcc
 export CC=x86_64-linux-musl-gcc
-sudo cargo build --release --target=x86_64-unknown-linux-musl
+sudo cargo build --release --features metrics --target=x86_64-unknown-linux-musl
 
 # build aarch64-unknown-linux-musl
 export "PATH=$HOME/Downloads/macos-cross-toolchains/aarch64-unknown-linux-musl/bin:$PATH"
 export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-gcc
 export CC=aarch64-linux-musl-gcc
-sudo cargo build --release --target=aarch64-unknown-linux-musl
+sudo cargo build --release --features metrics --target=aarch64-unknown-linux-musl
 ```
 
 ## Build images and push
+
 ```
 # copy targets to tmp dir
 rm -rf tmp

--- a/dt-common/Cargo.toml
+++ b/dt-common/Cargo.toml
@@ -8,6 +8,9 @@ edition = "2021"
 [lints]
 workspace = true
 
+[features]
+metrics = ["prometheus"]
+
 [dependencies]
 dotenv = { workspace = true }
 sqlx = { workspace = true }
@@ -41,3 +44,6 @@ openssl = { workspace = true }
 openssl-sys = { workspace = true }
 hex = { workspace = true }
 async-trait = { workspace = true }
+dashmap = {workspace = true}
+actix-web = {workspace = true}
+prometheus = {version = "0.14.0", optional = true}

--- a/dt-common/src/config/config_enums.rs
+++ b/dt-common/src/config/config_enums.rs
@@ -50,8 +50,9 @@ pub enum ExtractType {
     FoxlakeS3,
 }
 
-#[derive(Display, EnumString, IntoStaticStr)]
+#[derive(Display, EnumString, IntoStaticStr, Clone, Debug, Default)]
 pub enum SinkType {
+    #[default]
     #[strum(serialize = "dummy")]
     Dummy,
     #[strum(serialize = "write")]
@@ -115,4 +116,26 @@ pub enum MetaCenterType {
     Basic,
     #[strum(serialize = "dbengine")]
     DbEngine,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Display, EnumString, IntoStaticStr)]
+pub enum TaskType {
+    #[strum(serialize = "struct")]
+    Struct,
+    #[strum(serialize = "snapshot")]
+    Snapshot,
+    #[strum(serialize = "cdc")]
+    Cdc,
+    #[strum(serialize = "check")]
+    Check,
+}
+
+pub fn build_task_type(extract_type: &ExtractType, sink_type: &SinkType) -> Option<TaskType> {
+    match (extract_type, sink_type) {
+        (ExtractType::Struct, SinkType::Struct) => Some(TaskType::Struct),
+        (ExtractType::Snapshot, SinkType::Write) => Some(TaskType::Snapshot),
+        (ExtractType::Cdc, SinkType::Write) => Some(TaskType::Cdc),
+        (ExtractType::Snapshot, SinkType::Check) => Some(TaskType::Check),
+        _ => None,
+    }
 }

--- a/dt-common/src/config/metrics_config.rs
+++ b/dt-common/src/config/metrics_config.rs
@@ -1,0 +1,12 @@
+#[cfg(feature = "metrics")]
+use std::collections::HashMap;
+
+#[derive(Clone)]
+#[cfg(feature = "metrics")]
+pub struct MetricsConfig {
+    pub http_host: String,
+    pub http_port: u64,
+    pub workers: u64,
+    // come from task config such like: k1=v1,k2=v2
+    pub metrics_labels: HashMap<String, String>,
+}

--- a/dt-common/src/config/mod.rs
+++ b/dt-common/src/config/mod.rs
@@ -15,3 +15,6 @@ pub mod runtime_config;
 pub mod s3_config;
 pub mod sinker_config;
 pub mod task_config;
+
+#[cfg(feature = "metrics")]
+pub mod metrics_config;

--- a/dt-common/src/config/sinker_config.rs
+++ b/dt-common/src/config/sinker_config.rs
@@ -2,6 +2,7 @@ use super::{
     config_enums::{ConflictPolicyEnum, DbType},
     s3_config::S3Config,
 };
+use crate::config::config_enums::SinkType;
 
 #[derive(Clone, Debug)]
 pub enum SinkerConfig {
@@ -146,6 +147,7 @@ pub enum SinkerConfig {
 
 #[derive(Clone, Debug, Default)]
 pub struct BasicSinkerConfig {
+    pub sink_type: SinkType,
     pub db_type: DbType,
     pub url: String,
     pub batch_size: usize,

--- a/dt-common/src/logger.rs
+++ b/dt-common/src/logger.rs
@@ -57,3 +57,8 @@ macro_rules! log_warn {
 macro_rules! log_debug {
     ($($arg:tt)+) => (log::log!(target: "default_logger", log::Level::Debug, $($arg)+))
 }
+
+#[macro_export(local_inner_macros)]
+macro_rules! log_task {
+    ($($arg:tt)+) => (log::log!(target: "task_logger", log::Level::Info, $($arg)+));
+}

--- a/dt-common/src/meta/dcl_meta/dcl_data.rs
+++ b/dt-common/src/meta/dcl_meta/dcl_data.rs
@@ -23,4 +23,19 @@ impl DclData {
     pub fn to_sql(&self) -> String {
         self.statement.to_sql(&self.db_type)
     }
+
+    pub fn get_data_size(&self) -> u64 {
+        self.to_string().len() as u64
+    }
+
+    pub fn get_malloc_size(&self) -> u64 {
+        let mut size = 0;
+
+        size += self.default_schema.len() as u64;
+        size += std::mem::size_of::<DclType>() as u64;
+        size += std::mem::size_of::<DbType>() as u64;
+        size += self.statement.get_malloc_size();
+
+        size
+    }
 }

--- a/dt-common/src/meta/dcl_meta/dcl_statement.rs
+++ b/dt-common/src/meta/dcl_meta/dcl_statement.rs
@@ -41,6 +41,21 @@ impl DclStatement {
             DclStatement::Unknown => String::new(),
         }
     }
+
+    pub fn get_malloc_size(&self) -> u64 {
+        match self {
+            DclStatement::CreateUser(s)
+            | DclStatement::AlterUser(s)
+            | DclStatement::CreateRole(s)
+            | DclStatement::DropUser(s)
+            | DclStatement::DropRole(s)
+            | DclStatement::SetRole(s)
+            | DclStatement::Grant(s)
+            | DclStatement::Revoke(s) => s.origin.len() as u64,
+
+            DclStatement::Unknown => 0,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]

--- a/dt-common/src/meta/ddl_meta/ddl_data.rs
+++ b/dt-common/src/meta/ddl_meta/ddl_data.rs
@@ -54,4 +54,20 @@ impl DdlData {
         }
         res
     }
+
+    pub fn get_data_size(&self) -> u64 {
+        self.to_sql().len() as u64
+    }
+
+    pub fn get_malloc_size(&self) -> u64 {
+        let mut size: u64 = 0;
+
+        size += self.default_schema.len() as u64;
+        size += self.query.len() as u64;
+        size += std::mem::size_of::<DdlType>() as u64;
+        size += std::mem::size_of::<DbType>() as u64;
+        size += self.statement.get_malloc_size();
+
+        size
+    }
 }

--- a/dt-common/src/meta/ddl_meta/ddl_statement.rs
+++ b/dt-common/src/meta/ddl_meta/ddl_statement.rs
@@ -695,6 +695,193 @@ impl DdlStatement {
             _ => String::new(),
         }
     }
+
+    pub fn get_malloc_size(&self) -> u64 {
+        let mut size = 0;
+        match &self {
+            DdlStatement::CreateDatabase(create_database_statement) => {
+                size += create_database_statement.db.len() as u64;
+                size += create_database_statement.unparsed.len() as u64;
+                size += 1;
+            }
+            DdlStatement::DropDatabase(drop_database_statement) => {
+                size += drop_database_statement.db.len() as u64;
+                size += drop_database_statement.unparsed.len() as u64;
+                size += 1;
+            }
+            DdlStatement::AlterDatabase(alter_database_statement) => {
+                size += alter_database_statement.db.len() as u64;
+                size += alter_database_statement.unparsed.len() as u64;
+            }
+            DdlStatement::CreateSchema(create_schema_statement) => {
+                size += create_schema_statement.schema.len() as u64;
+                size += create_schema_statement.unparsed.len() as u64;
+                size += 1;
+            }
+            DdlStatement::DropSchema(drop_schema_statement) => {
+                size += drop_schema_statement.schema.len() as u64;
+                size += drop_schema_statement.unparsed.len() as u64;
+                size += 1;
+            }
+            DdlStatement::AlterSchema(alter_schema_statement) => {
+                size += alter_schema_statement.schema.len() as u64;
+                size += alter_schema_statement.unparsed.len() as u64;
+            }
+            DdlStatement::MysqlCreateTable(mysql_create_table_statement) => {
+                size += mysql_create_table_statement.db.len() as u64;
+                size += mysql_create_table_statement.tb.len() as u64;
+                size += mysql_create_table_statement.unparsed.len() as u64;
+                size += 1;
+            }
+            DdlStatement::MysqlAlterTable(mysql_alter_table_statement) => {
+                size += mysql_alter_table_statement.db.len() as u64;
+                size += mysql_alter_table_statement.tb.len() as u64;
+                size += mysql_alter_table_statement.unparsed.len() as u64;
+            }
+            DdlStatement::MysqlAlterTableRename(mysql_alter_table_rename_statement) => {
+                size += mysql_alter_table_rename_statement.db.len() as u64;
+                size += mysql_alter_table_rename_statement.tb.len() as u64;
+                size += mysql_alter_table_rename_statement.new_db.len() as u64;
+                size += mysql_alter_table_rename_statement.new_tb.len() as u64;
+                size += mysql_alter_table_rename_statement.unparsed.len() as u64;
+            }
+            DdlStatement::MysqlTruncateTable(mysql_truncate_table_statement) => {
+                size += mysql_truncate_table_statement.db.len() as u64;
+                size += mysql_truncate_table_statement.tb.len() as u64;
+                size += mysql_truncate_table_statement.unparsed.len() as u64;
+            }
+            DdlStatement::PgCreateTable(pg_create_table_statement) => {
+                size += pg_create_table_statement.schema.len() as u64;
+                size += pg_create_table_statement.tb.len() as u64;
+                size += pg_create_table_statement.unparsed.len() as u64;
+                size += std::mem::size_of::<Option<String>>() as u64 * 2;
+                size += pg_create_table_statement
+                    .temporary
+                    .as_ref()
+                    .map_or(0, |s| s.len() as u64);
+                size += pg_create_table_statement
+                    .unlogged
+                    .as_ref()
+                    .map_or(0, |s| s.len() as u64);
+                size += 1;
+            }
+            DdlStatement::PgAlterTable(pg_alter_table_statement) => {
+                size += pg_alter_table_statement.schema.len() as u64;
+                size += pg_alter_table_statement.tb.len() as u64;
+                size += pg_alter_table_statement.unparsed.len() as u64;
+                size += 2;
+            }
+            DdlStatement::PgAlterTableRename(pg_alter_table_rename_statement) => {
+                size += pg_alter_table_rename_statement.schema.len() as u64;
+                size += pg_alter_table_rename_statement.tb.len() as u64;
+                size += pg_alter_table_rename_statement.new_schema.len() as u64;
+                size += pg_alter_table_rename_statement.new_tb.len() as u64;
+                size += pg_alter_table_rename_statement.unparsed.len() as u64;
+                size += 2;
+            }
+            DdlStatement::PgAlterTableSetSchema(pg_alter_table_set_schema_statement) => {
+                size += pg_alter_table_set_schema_statement.schema.len() as u64;
+                size += pg_alter_table_set_schema_statement.tb.len() as u64;
+                size += pg_alter_table_set_schema_statement.new_schema.len() as u64;
+                size += pg_alter_table_set_schema_statement.new_tb.len() as u64;
+                size += pg_alter_table_set_schema_statement.unparsed.len() as u64;
+                size += 2;
+            }
+            DdlStatement::PgTruncateTable(pg_truncate_table_statement) => {
+                size += pg_truncate_table_statement.schema.len() as u64;
+                size += pg_truncate_table_statement.tb.len() as u64;
+                size += pg_truncate_table_statement.unparsed.len() as u64;
+                size += 1;
+            }
+            DdlStatement::PgCreateIndex(pg_create_index_statement) => {
+                size += pg_create_index_statement.schema.len() as u64;
+                size += pg_create_index_statement.tb.len() as u64;
+                size += pg_create_index_statement.unparsed.len() as u64;
+                size += std::mem::size_of::<Option<String>>() as u64;
+                size += pg_create_index_statement
+                    .index_name
+                    .as_ref()
+                    .map_or(0, |s| s.len() as u64);
+                size += 4;
+            }
+            DdlStatement::PgDropIndex(pg_drop_index_statement) => {
+                size += pg_drop_index_statement.index_name.len() as u64;
+                size += pg_drop_index_statement.unparsed.len() as u64;
+                size += 2;
+            }
+            DdlStatement::PgDropMultiIndex(pg_drop_multi_index_statement) => {
+                size += std::mem::size_of::<Vec<String>>() as u64;
+                size += pg_drop_multi_index_statement
+                    .index_names
+                    .iter()
+                    .map(|s| s.len() as u64)
+                    .sum::<u64>();
+                size += pg_drop_multi_index_statement.unparsed.len() as u64;
+                size += 1;
+            }
+            DdlStatement::DropMultiTable(drop_multi_table_statement) => {
+                size += std::mem::size_of::<Vec<(String, String)>>() as u64;
+                size += drop_multi_table_statement
+                    .schema_tbs
+                    .iter()
+                    .map(|(s, t)| s.len() as u64 + t.len() as u64)
+                    .sum::<u64>();
+                size += drop_multi_table_statement.unparsed.len() as u64;
+                size += 1;
+            }
+            DdlStatement::RenameMultiTable(rename_multi_table_statement) => {
+                size += std::mem::size_of::<Vec<(String, String)>>() as u64 * 2;
+                size += rename_multi_table_statement
+                    .schema_tbs
+                    .iter()
+                    .map(|(s1, s2)| s1.len() as u64 + s2.len() as u64)
+                    .sum::<u64>();
+                size += rename_multi_table_statement
+                    .new_schema_tbs
+                    .iter()
+                    .map(|(s1, s2)| s1.len() as u64 + s2.len() as u64)
+                    .sum::<u64>();
+                size += rename_multi_table_statement.unparsed.len() as u64;
+                size += 1;
+            }
+            DdlStatement::DropTable(drop_table_statement) => {
+                size += drop_table_statement.schema.len() as u64;
+                size += drop_table_statement.tb.len() as u64;
+                size += drop_table_statement.unparsed.len() as u64;
+                size += 1;
+            }
+            DdlStatement::RenameTable(rename_table_statement) => {
+                size += rename_table_statement.schema.len() as u64;
+                size += rename_table_statement.tb.len() as u64;
+                size += rename_table_statement.new_schema.len() as u64;
+                size += rename_table_statement.new_tb.len() as u64;
+                size += rename_table_statement.unparsed.len() as u64;
+            }
+            DdlStatement::MysqlCreateIndex(mysql_create_index_statement) => {
+                size += mysql_create_index_statement.db.len() as u64;
+                size += mysql_create_index_statement.tb.len() as u64;
+                size += mysql_create_index_statement.index_name.len() as u64;
+                size += mysql_create_index_statement.unparsed.len() as u64;
+                size += std::mem::size_of::<Option<String>>() as u64 * 2;
+                size += mysql_create_index_statement
+                    .index_kind
+                    .as_ref()
+                    .map_or(0, |s| s.len() as u64);
+                size += mysql_create_index_statement
+                    .index_type
+                    .as_ref()
+                    .map_or(0, |s| s.len() as u64);
+            }
+            DdlStatement::MysqlDropIndex(mysql_drop_index_statement) => {
+                size += mysql_drop_index_statement.db.len() as u64;
+                size += mysql_drop_index_statement.tb.len() as u64;
+                size += mysql_drop_index_statement.index_name.len() as u64;
+                size += mysql_drop_index_statement.unparsed.len() as u64;
+            }
+            DdlStatement::Unknown => {}
+        }
+        size
+    }
 }
 
 impl DropMultiTableStatement {

--- a/dt-common/src/meta/dt_data.rs
+++ b/dt-common/src/meta/dt_data.rs
@@ -19,6 +19,14 @@ impl DtItem {
     pub fn is_ddl(&self) -> bool {
         self.dt_data.is_ddl()
     }
+
+    pub fn is_dcl(&self) -> bool {
+        self.dt_data.is_dcl()
+    }
+
+    pub fn get_data_size(&self) -> u64 {
+        self.dt_data.get_data_size()
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -62,11 +70,17 @@ impl DtData {
         matches!(self, DtData::Ddl { .. })
     }
 
-    pub fn get_data_size(&self) -> usize {
+    pub fn is_dcl(&self) -> bool {
+        matches!(self, DtData::Dcl { .. })
+    }
+
+    pub fn get_data_size(&self) -> u64 {
         match &self {
-            DtData::Dml { row_data } => row_data.data_size,
-            DtData::Redis { entry } => entry.data_size,
-            DtData::Foxlake { file_meta } => file_meta.data_size,
+            DtData::Dml { row_data } => row_data.data_size as u64,
+            DtData::Dcl { dcl_data } => dcl_data.get_malloc_size(),
+            DtData::Ddl { ddl_data } => ddl_data.get_malloc_size(),
+            DtData::Redis { entry } => entry.get_data_malloc_size() as u64,
+            DtData::Foxlake { file_meta } => file_meta.data_size as u64,
             // ignore other item types
             _ => 0,
         }

--- a/dt-common/src/meta/dt_queue.rs
+++ b/dt-common/src/meta/dt_queue.rs
@@ -1,4 +1,4 @@
-use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use concurrent_queue::{ConcurrentQueue, PopError};
 
@@ -9,17 +9,17 @@ use super::dt_data::DtItem;
 pub struct DtQueue {
     queue: ConcurrentQueue<DtItem>,
     check_memory: bool,
-    max_bytes: i64,
-    cur_bytes: AtomicI64,
+    max_bytes: u64,
+    cur_bytes: AtomicU64,
 }
 
 impl DtQueue {
-    pub fn new(capacity: usize, max_bytes: i64) -> Self {
+    pub fn new(capacity: usize, max_bytes: u64) -> Self {
         Self {
             queue: ConcurrentQueue::bounded(capacity),
             max_bytes,
             check_memory: max_bytes > 0,
-            cur_bytes: AtomicI64::new(0),
+            cur_bytes: AtomicU64::new(0),
         }
     }
 
@@ -39,6 +39,11 @@ impl DtQueue {
     }
 
     #[inline(always)]
+    pub fn get_curr_size(&self) -> u64 {
+        self.cur_bytes.load(Ordering::Relaxed)
+    }
+
+    #[inline(always)]
     pub async fn push(&self, item: DtItem) -> anyhow::Result<()> {
         while self.queue.is_full() {
             TimeUtil::sleep_millis(1).await;
@@ -48,10 +53,9 @@ impl DtQueue {
             while self.cur_bytes.load(Ordering::Acquire) > self.max_bytes {
                 TimeUtil::sleep_millis(1).await;
             }
-
-            self.cur_bytes
-                .fetch_add(item.dt_data.get_data_size() as i64, Ordering::Release);
         }
+        self.cur_bytes
+            .fetch_add(item.dt_data.get_data_size(), Ordering::Release);
 
         self.queue.push(item)?;
         Ok(())
@@ -61,13 +65,11 @@ impl DtQueue {
     pub fn pop(&self) -> anyhow::Result<DtItem, PopError> {
         let item = self.queue.pop()?;
 
-        if self.check_memory {
-            if self.queue.is_empty() {
-                self.cur_bytes.store(0, Ordering::Release);
-            } else {
-                self.cur_bytes
-                    .fetch_sub(item.dt_data.get_data_size() as i64, Ordering::Release);
-            }
+        if self.queue.is_empty() {
+            self.cur_bytes.store(0, Ordering::Release);
+        } else {
+            self.cur_bytes
+                .fetch_sub(item.dt_data.get_data_size(), Ordering::Release);
         }
 
         Ok(item)

--- a/dt-common/src/meta/mod.rs
+++ b/dt-common/src/meta/mod.rs
@@ -3,6 +3,7 @@
 pub mod adaptor;
 pub mod avro;
 pub mod col_value;
+pub mod dcl_meta;
 pub mod ddl_meta;
 pub mod dt_data;
 pub mod dt_queue;
@@ -21,4 +22,3 @@ pub mod row_type;
 pub mod struct_meta;
 pub mod syncer;
 pub mod time;
-pub mod dcl_meta;

--- a/dt-common/src/meta/row_data.rs
+++ b/dt-common/src/meta/row_data.rs
@@ -203,6 +203,10 @@ impl RowData {
         self.data_size = self.get_data_malloc_size();
     }
 
+    pub fn get_data_size(&self) -> u64 {
+        self.data_size as u64
+    }
+
     fn get_data_malloc_size(&self) -> usize {
         let mut size = 0;
         // do not use mem::size_of_val() since:

--- a/dt-common/src/meta/struct_meta/statement/pg_create_rbac_statement.rs
+++ b/dt-common/src/meta/struct_meta/statement/pg_create_rbac_statement.rs
@@ -110,6 +110,8 @@ impl PgCreateRbacStatement {
 
 #[cfg(test)]
 mod tests {
+    use dashmap::DashMap;
+
     use super::*;
     use crate::config::config_enums::DbType;
     use crate::meta::struct_meta::structure::rbac::{PgPrivilege, PgRole, PgRoleMember};
@@ -120,7 +122,7 @@ mod tests {
         let mut filter = RdbFilter {
             db_type: DbType::Pg,
             do_structures: HashSet::new(),
-            cache: HashMap::new(),
+            cache: DashMap::new(),
             do_schemas: HashSet::new(),
             ignore_schemas: HashSet::new(),
             do_tbs: HashSet::new(),

--- a/dt-common/src/meta/struct_meta/statement/pg_create_table_statement.rs
+++ b/dt-common/src/meta/struct_meta/statement/pg_create_table_statement.rs
@@ -181,7 +181,7 @@ impl PgCreateTableStatement {
 
     fn index_to_sql(index: &Index) -> anyhow::Result<String> {
         let parser = DdlParser::new(DbType::Pg);
-        if let Ok(mut ddl_data) = parser.parse(&index.definition) {
+        if let Ok(Some(mut ddl_data)) = parser.parse(&index.definition) {
             if let DdlStatement::PgCreateIndex(s) = &mut ddl_data.statement {
                 s.schema = index.schema_name.clone();
                 s.tb = index.table_name.clone();

--- a/dt-common/src/monitor/counter.rs
+++ b/dt-common/src/monitor/counter.rs
@@ -1,15 +1,17 @@
 use std::time::Instant;
 
+use crate::utils::limit_queue::LimitedQueue;
+
 #[derive(Clone)]
 pub struct Counter {
     pub timestamp: Instant,
-    pub value: usize,
-    pub count: usize,
+    pub value: u64,
+    pub count: u64,
     pub description: String,
 }
 
 impl Counter {
-    pub fn new(value: usize, count: usize) -> Self {
+    pub fn new(value: u64, count: u64) -> Self {
         Self {
             timestamp: Instant::now(),
             value,
@@ -19,13 +21,29 @@ impl Counter {
     }
 
     #[inline(always)]
-    pub fn add(&mut self, value: usize, count: usize) {
+    pub fn adds(&mut self, values: &LimitedQueue<(u64, u64)>) {
+        for (value, count) in values.iter() {
+            if *count == 0 {
+                continue;
+            }
+            self.add(*value, *count);
+        }
+    }
+
+    #[inline(always)]
+    pub fn set(&mut self, value: u64, count: u64) {
+        self.value = value;
+        self.count = count;
+    }
+
+    #[inline(always)]
+    pub fn add(&mut self, value: u64, count: u64) {
         self.value += value;
         self.count += count;
     }
 
     #[inline(always)]
-    pub fn avg_by_count(&self) -> usize {
+    pub fn avg_by_count(&self) -> u64 {
         if self.count > 0 {
             self.value / self.count
         } else {

--- a/dt-common/src/monitor/group_monitor.rs
+++ b/dt-common/src/monitor/group_monitor.rs
@@ -1,8 +1,7 @@
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use tokio::{sync::Mutex, sync::MutexGuard};
+use dashmap::DashMap;
 
 use super::counter_type::CounterType;
 use super::monitor::Monitor;
@@ -15,13 +14,13 @@ use crate::monitor::counter_type::AggregateType;
 pub struct GroupMonitor {
     name: String,
     description: String,
-    monitors: HashMap<String, Arc<Mutex<Monitor>>>,
-    no_window_counter_statistics_map: HashMap<CounterType, HashMap<AggregateType, usize>>,
+    monitors: DashMap<String, Arc<Monitor>>,
+    no_window_counter_statistics_map: DashMap<CounterType, DashMap<AggregateType, u64>>,
 }
 
 #[async_trait]
 impl FlushableMonitor for GroupMonitor {
-    async fn flush(&mut self) {
+    async fn flush(&self) {
         self.flush().await;
     }
 }
@@ -31,58 +30,35 @@ impl GroupMonitor {
         Self {
             name: name.into(),
             description: description.into(),
-            monitors: HashMap::new(),
-            no_window_counter_statistics_map: HashMap::new(),
+            monitors: DashMap::new(),
+            no_window_counter_statistics_map: DashMap::new(),
         }
     }
 
-    pub fn add_monitor(&mut self, id: &str, monitor: Arc<Mutex<Monitor>>) {
+    pub fn add_monitor(&self, id: &str, monitor: Arc<Monitor>) {
         self.monitors.insert(id.to_string(), monitor);
     }
 
-    pub async fn remove_monitor(&mut self, id: &str) {
+    pub fn remove_monitor(&self, id: &str) {
         // keep statistics of no_window counters before removing:
         // eg. 2025-02-18 05:43:37.028889 | pipeline | global | sinked_count | latest=4199364
-        if let Some(monitor) = self.monitors.remove(id) {
-            let guard = monitor.lock().await;
+        if let Some((_, monitor)) = self.monitors.remove(id) {
             Self::refresh_no_window_counter_statistics_map(
-                &mut self.no_window_counter_statistics_map,
-                &guard,
+                &self.no_window_counter_statistics_map,
+                &monitor,
             );
         }
     }
 
-    fn refresh_no_window_counter_statistics_map(
-        no_window_counter_statistics_map: &mut HashMap<CounterType, HashMap<AggregateType, usize>>,
-        guard: &MutexGuard<'_, Monitor>,
-    ) {
-        for (counter_type, counter) in guard.no_window_counters.iter() {
-            // let mut aggregate_value_map = HashMap::new();
-            for aggregate_type in counter_type.get_aggregate_types().iter() {
-                let aggregate_value = match aggregate_type {
-                    AggregateType::Latest => counter.value,
-                    AggregateType::AvgByCount => counter.avg_by_count(),
-                    _ => continue,
-                };
+    pub async fn flush(&self) {
+        let window_counter_statistics_map: DashMap<CounterType, Vec<WindowCounterStatistics>> =
+            DashMap::new();
+        let no_window_counter_statistics_map = self.no_window_counter_statistics_map.clone();
 
-                no_window_counter_statistics_map
-                    .entry(counter_type.to_owned())
-                    .or_default()
-                    .entry(aggregate_type.to_owned())
-                    .and_modify(|v| *v += aggregate_value)
-                    .or_insert(aggregate_value);
-            }
-        }
-    }
-
-    pub async fn flush(&mut self) {
-        let mut window_counter_statistics_map: HashMap<CounterType, Vec<WindowCounterStatistics>> =
-            HashMap::new();
-        let mut no_window_counter_statistics_map = self.no_window_counter_statistics_map.clone();
-
-        for (_, monitor) in self.monitors.iter() {
-            let mut guard = monitor.lock().await;
-            for (counter_type, counter) in guard.time_window_counters.iter_mut() {
+        for entry in self.monitors.iter() {
+            let (_, monitor) = entry.pair();
+            for mut sub_entry in monitor.time_window_counters.iter_mut() {
+                let (counter_type, counter) = sub_entry.pair_mut();
                 let statistics = counter.statistics();
                 window_counter_statistics_map
                     .entry(counter_type.to_owned())
@@ -90,8 +66,8 @@ impl GroupMonitor {
                     .push(statistics);
             }
             Self::refresh_no_window_counter_statistics_map(
-                &mut no_window_counter_statistics_map,
-                &guard,
+                &no_window_counter_statistics_map,
+                monitor,
             );
         }
 
@@ -115,13 +91,41 @@ impl GroupMonitor {
             log_monitor!("{}", log);
         }
 
-        for (counter_type, aggregate_value_map) in no_window_counter_statistics_map.iter_mut() {
+        for entry in no_window_counter_statistics_map.iter() {
+            let (counter_type, aggregate_value_map) = entry.pair();
             let mut log = format!("{} | {} | {}", self.name, self.description, counter_type);
             for aggregate_type in counter_type.get_aggregate_types().iter() {
-                let aggregate_value = aggregate_value_map.get(aggregate_type).unwrap_or(&0);
-                log = format!("{} | {}={}", log, aggregate_type, aggregate_value);
+                if let Some(aggregate_value) = aggregate_value_map.get(aggregate_type).map(|v| *v) {
+                    log = format!("{} | {}={}", log, aggregate_type, aggregate_value);
+                } else {
+                    log = format!("{} | {}={}", log, aggregate_type, 0);
+                }
             }
             log_monitor!("{}", log);
+        }
+    }
+
+    fn refresh_no_window_counter_statistics_map(
+        no_window_counter_statistics_map: &DashMap<CounterType, DashMap<AggregateType, u64>>,
+        monitor: &Arc<Monitor>,
+    ) {
+        for entry in monitor.no_window_counters.iter() {
+            let (counter_type, counter) = entry.pair();
+            // let mut aggregate_value_map = HashMap::new();
+            for aggregate_type in counter_type.get_aggregate_types().iter() {
+                let aggregate_value = match aggregate_type {
+                    AggregateType::Latest => counter.value,
+                    AggregateType::AvgByCount => counter.avg_by_count(),
+                    _ => continue,
+                };
+
+                no_window_counter_statistics_map
+                    .entry(counter_type.to_owned())
+                    .or_default()
+                    .entry(aggregate_type.to_owned())
+                    .and_modify(|v| *v += aggregate_value)
+                    .or_insert(aggregate_value);
+            }
         }
     }
 }

--- a/dt-common/src/monitor/mod.rs
+++ b/dt-common/src/monitor/mod.rs
@@ -3,12 +3,17 @@ use async_trait::async_trait;
 pub mod counter;
 pub mod counter_type;
 pub mod group_monitor;
+pub mod task_metrics;
+pub mod task_monitor;
 
 #[allow(clippy::module_inception)]
 pub mod monitor;
 pub mod time_window_counter;
 
+#[cfg(feature = "metrics")]
+pub mod prometheus_metrics;
+
 #[async_trait]
 pub trait FlushableMonitor {
-    async fn flush(&mut self);
+    async fn flush(&self);
 }

--- a/dt-common/src/monitor/monitor.rs
+++ b/dt-common/src/monitor/monitor.rs
@@ -1,6 +1,5 @@
-use std::collections::HashMap;
-
 use async_trait::async_trait;
+use dashmap::DashMap;
 
 use super::counter::Counter;
 use super::counter_type::{CounterType, WindowType};
@@ -8,21 +7,22 @@ use super::time_window_counter::TimeWindowCounter;
 use super::FlushableMonitor;
 use crate::log_monitor;
 use crate::monitor::counter_type::AggregateType;
+use crate::utils::limit_queue::LimitedQueue;
 
 #[derive(Clone, Default)]
 pub struct Monitor {
     pub name: String,
     pub description: String,
-    pub no_window_counters: HashMap<CounterType, Counter>,
-    pub time_window_counters: HashMap<CounterType, TimeWindowCounter>,
-    pub time_window_secs: usize,
-    pub max_sub_count: usize,
-    pub count_window: usize,
+    pub no_window_counters: DashMap<CounterType, Counter>,
+    pub time_window_counters: DashMap<CounterType, TimeWindowCounter>,
+    pub time_window_secs: u64,
+    pub max_sub_count: u64,
+    pub count_window: u64,
 }
 
 #[async_trait]
 impl FlushableMonitor for Monitor {
-    async fn flush(&mut self) {
+    async fn flush(&self) {
         self.flush().await;
     }
 }
@@ -31,23 +31,24 @@ impl Monitor {
     pub fn new(
         name: &str,
         description: &str,
-        time_window_secs: usize,
-        max_sub_count: usize,
-        count_window: usize,
+        time_window_secs: u64,
+        max_sub_count: u64,
+        count_window: u64,
     ) -> Self {
         Self {
             name: name.into(),
             description: description.into(),
-            no_window_counters: HashMap::new(),
-            time_window_counters: HashMap::new(),
+            no_window_counters: DashMap::new(),
+            time_window_counters: DashMap::new(),
             time_window_secs,
             max_sub_count,
             count_window,
         }
     }
 
-    pub async fn flush(&mut self) {
-        for (counter_type, counter) in self.time_window_counters.iter_mut() {
+    pub async fn flush(&self) {
+        for mut entry_mut in self.time_window_counters.iter_mut() {
+            let (counter_type, counter) = entry_mut.pair_mut();
             let statistics = counter.statistics();
             let mut log = format!("{} | {} | {}", self.name, self.description, counter_type);
             for aggregate_type in counter_type.get_aggregate_types() {
@@ -65,7 +66,8 @@ impl Monitor {
             log_monitor!("{}", log);
         }
 
-        for (counter_type, counter) in self.no_window_counters.iter() {
+        for entry in self.no_window_counters.iter() {
+            let (counter_type, counter) = entry.pair();
             let mut log = format!("{} | {} | {}", self.name, self.description, counter_type);
             for aggregate_type in counter_type.get_aggregate_types() {
                 let aggregate_value = match aggregate_type {
@@ -79,47 +81,76 @@ impl Monitor {
         }
     }
 
-    pub fn add_batch_counter(
-        &mut self,
-        counter_type: CounterType,
-        value: usize,
-        count: usize,
-    ) -> &mut Self {
+    pub fn add_batch_counter(&self, counter_type: CounterType, value: u64, count: u64) -> &Self {
         if count == 0 {
             return self;
         }
         self.add_counter_internal(counter_type, value, count)
     }
 
-    pub fn add_counter(&mut self, counter_type: CounterType, value: usize) -> &mut Self {
+    pub fn add_counter(&self, counter_type: CounterType, value: u64) -> &Self {
         self.add_counter_internal(counter_type, value, 1)
     }
 
-    fn add_counter_internal(
-        &mut self,
+    pub fn set_counter(&self, counter_type: CounterType, value: u64) -> &Self {
+        if let WindowType::NoWindow = counter_type.get_window_type() {
+            self.no_window_counters
+                .entry(counter_type)
+                .and_modify(|counter| counter.set(value, 1))
+                .or_insert_with(|| Counter::new(value, 1));
+        }
+        self
+    }
+
+    pub fn add_multi_counter(
+        &self,
         counter_type: CounterType,
-        value: usize,
-        count: usize,
-    ) -> &mut Self {
+        entry: &LimitedQueue<(u64, u64)>,
+    ) -> &Self {
+        self.add_muilti_counter_internal(counter_type, entry)
+    }
+
+    fn add_counter_internal(&self, counter_type: CounterType, value: u64, count: u64) -> &Self {
         match counter_type.get_window_type() {
             WindowType::NoWindow => {
-                if let Some(counter) = self.no_window_counters.get_mut(&counter_type) {
-                    counter.add(value, count);
-                } else {
-                    self.no_window_counters
-                        .insert(counter_type, Counter::new(value, count));
-                }
+                self.no_window_counters
+                    .entry(counter_type)
+                    .or_insert_with(|| Counter::new(0, 0))
+                    .add(value, count);
             }
 
             WindowType::TimeWindow => {
-                if let Some(counter) = self.time_window_counters.get_mut(&counter_type) {
-                    counter.add(value, count)
-                } else {
-                    let mut counter =
-                        TimeWindowCounter::new(self.time_window_secs, self.max_sub_count);
-                    counter.add(value, count);
-                    self.time_window_counters.insert(counter_type, counter);
-                }
+                self.time_window_counters
+                    .entry(counter_type)
+                    .or_insert_with(|| {
+                        TimeWindowCounter::new(self.time_window_secs, self.max_sub_count)
+                    })
+                    .add(value, count);
+            }
+        }
+        self
+    }
+
+    fn add_muilti_counter_internal(
+        &self,
+        counter_type: CounterType,
+        entry: &LimitedQueue<(u64, u64)>,
+    ) -> &Self {
+        match counter_type.get_window_type() {
+            WindowType::NoWindow => {
+                self.no_window_counters
+                    .entry(counter_type)
+                    .or_insert_with(|| Counter::new(0, 0))
+                    .adds(entry);
+            }
+
+            WindowType::TimeWindow => {
+                self.time_window_counters
+                    .entry(counter_type)
+                    .or_insert_with(|| {
+                        TimeWindowCounter::new(self.time_window_secs, self.max_sub_count)
+                    })
+                    .adds(entry);
             }
         }
         self

--- a/dt-common/src/monitor/prometheus_metrics.rs
+++ b/dt-common/src/monitor/prometheus_metrics.rs
@@ -1,0 +1,255 @@
+#[cfg(feature = "metrics")]
+use std::{collections::BTreeMap, sync::Arc};
+
+use actix_web::{middleware::Logger, web, App, HttpResponse, HttpServer, Responder, Result};
+use dashmap::DashMap;
+use prometheus::{Gauge, Opts, Registry, TextEncoder};
+
+use crate::config::config_enums::TaskType;
+use crate::config::metrics_config::MetricsConfig;
+use crate::monitor::task_metrics::TaskMetricsType;
+
+pub struct PrometheusMetrics {
+    registry: Arc<Registry>,
+    metrics: DashMap<TaskMetricsType, Gauge>,
+    task_type: Option<TaskType>,
+    config: MetricsConfig,
+}
+
+impl PrometheusMetrics {
+    pub fn new(task_type: Option<TaskType>, config: MetricsConfig) -> Self {
+        Self {
+            registry: Arc::new(Registry::new()),
+            metrics: DashMap::new(),
+            task_type,
+            config,
+        }
+    }
+
+    pub fn initialization(&self) -> &Self {
+        let register_handler =
+            |metrics_name: &str, metrics_desc: &str, metrics_type: TaskMetricsType| {
+                let metrics = Gauge::with_opts(
+                    Opts::new(metrics_name, metrics_desc)
+                        .const_labels(self.config.metrics_labels.to_owned()),
+                )
+                .unwrap();
+
+                self.registry.register(Box::new(metrics.clone())).unwrap();
+                self.metrics.insert(metrics_type, metrics);
+            };
+
+        // TODO: support these metrics:
+        // register_handler(
+        //     "extractor_rps_max",
+        //     "the max records per second of extractor",
+        //     TaskMetricsType::ExtractorRpsMax,
+        // );
+        // register_handler(
+        //     "extractor_rps_min",
+        //     "the min records per second of extractor",
+        //     TaskMetricsType::ExtractorRpsMin,
+        // );
+        // register_handler(
+        //     "extractor_rps_avg",
+        //     "the average records per second of extractor",
+        //     TaskMetricsType::ExtractorRpsAvg,
+        // );
+        // register_handler(
+        //     "extractor_bps_max",
+        //     "the max bytes per second of extractor",
+        //     TaskMetricsType::ExtractorBpsMax,
+        // );
+        // register_handler(
+        //     "extractor_bps_min",
+        //     "the min bytes per second of extractor",
+        //     TaskMetricsType::ExtractorBpsMin,
+        // );
+        // register_handler(
+        //     "extractor_bps_avg",
+        //     "the average bytes per second of extractor",
+        //     TaskMetricsType::ExtractorBpsAvg,
+        // );
+
+        register_handler(
+            "extractor_pushed_rps_max",
+            "the max pushed records per second of extractor",
+            TaskMetricsType::ExtractorPushedRpsMax,
+        );
+        register_handler(
+            "extractor_pushed_rps_min",
+            "the min pushed records per second of extractor",
+            TaskMetricsType::ExtractorPushedRpsMin,
+        );
+        register_handler(
+            "extractor_pushed_rps_avg",
+            "the average pushed records per second of extractor",
+            TaskMetricsType::ExtractorPushedRpsAvg,
+        );
+        register_handler(
+            "extractor_pushed_bps_max",
+            "the max pushed bytes per second of extractor",
+            TaskMetricsType::ExtractorPushedBpsMax,
+        );
+        register_handler(
+            "extractor_pushed_bps_min",
+            "the min pushed bytes per second of extractor",
+            TaskMetricsType::ExtractorPushedBpsMin,
+        );
+        register_handler(
+            "extractor_pushed_bps_avg",
+            "the average pushed bytes per second of extractor",
+            TaskMetricsType::ExtractorPushedBpsAvg,
+        );
+
+        register_handler(
+            "pipeline_queue_size",
+            "the records size of pipeline queue",
+            TaskMetricsType::PipelineQueueSize,
+        );
+        register_handler(
+            "pipeline_queue_bytes",
+            "the bytes in pipeline queue",
+            TaskMetricsType::PipelineQueueBytes,
+        );
+
+        register_handler(
+            "sinker_rt_max",
+            "the max response time of sinker, the unit is millisecond",
+            TaskMetricsType::SinkerRtMax,
+        );
+        register_handler(
+            "sinker_rt_min",
+            "the min response time of sinker, the unit is millisecond",
+            TaskMetricsType::SinkerRtMin,
+        );
+        register_handler(
+            "sinker_rt_avg",
+            "the average response time of sinker, the unit is millisecond",
+            TaskMetricsType::SinkerRtAvg,
+        );
+
+        register_handler(
+            "sinker_rps_max",
+            "the max records per second of sinker",
+            TaskMetricsType::SinkerRpsMax,
+        );
+        register_handler(
+            "sinker_rps_min",
+            "the min records per second of sinker",
+            TaskMetricsType::SinkerRpsMin,
+        );
+        register_handler(
+            "sinker_rps_avg",
+            "the average records per second of sinker",
+            TaskMetricsType::SinkerRpsAvg,
+        );
+        register_handler(
+            "sinker_bps_max",
+            "the max bytes per second of sinker",
+            TaskMetricsType::SinkerBpsMax,
+        );
+        register_handler(
+            "sinker_bps_min",
+            "the min bytes per second of sinker",
+            TaskMetricsType::SinkerBpsMin,
+        );
+        register_handler(
+            "sinker_bps_avg",
+            "the average bytes per second of sinker",
+            TaskMetricsType::SinkerBpsAvg,
+        );
+
+        register_handler(
+            "sinker_sinked_records",
+            "the number of records sinked",
+            TaskMetricsType::SinkerSinkedRecords,
+        );
+        register_handler(
+            "sinker_sinked_bytes",
+            "the bytes of records sinked",
+            TaskMetricsType::SinkerSinkedBytes,
+        );
+
+        if let Some(task_type) = &self.task_type {
+            match task_type {
+                TaskType::Snapshot => {
+                    register_handler(
+                        "extractor_plan_records",
+                        "the records estimated by extractor plan",
+                        TaskMetricsType::ExtractorPlanRecords,
+                    );
+                }
+                TaskType::Cdc => {
+                    register_handler(
+                        "timestamp",
+                        "the timestamp of task",
+                        TaskMetricsType::Timestamp,
+                    );
+                    register_handler(
+                        "sinker_ddl_count",
+                        "the count of DDL operations",
+                        TaskMetricsType::SinkerDdlCount,
+                    );
+                }
+                TaskType::Struct | TaskType::Check => {}
+            }
+        }
+        self
+    }
+
+    pub fn set_metrics(&self, metrics: &BTreeMap<TaskMetricsType, u64>) {
+        for (metrics_type, value) in metrics.iter() {
+            if let Some(metrics) = self.metrics.get_mut(metrics_type) {
+                metrics.set(*value as f64);
+            }
+        }
+    }
+
+    pub async fn start_metrics(&self) -> tokio::task::JoinHandle<Result<(), std::io::Error>> {
+        let registry = self.registry.clone();
+        let addr = format!("{}:{}", self.config.http_host, self.config.http_port);
+        let server = HttpServer::new(move || {
+            App::new()
+                .wrap(Logger::default())
+                .app_data(web::Data::new(registry.clone()))
+                .service(web::resource("/metrics").route(web::get().to(metrics_hander)))
+                .service(web::resource("/healthz").route(web::get().to(healthz_handler)))
+                .default_service(web::route().to(not_found_handler))
+        })
+        .workers(self.config.workers as usize)
+        .shutdown_timeout(10)
+        .bind(&addr)
+        .unwrap()
+        .run();
+
+        tokio::spawn(server)
+    }
+}
+
+async fn metrics_hander(registry: web::Data<Arc<Registry>>) -> impl Responder {
+    let mut buffer = String::new();
+    let encoder = TextEncoder::new();
+
+    match encoder.encode_utf8(&registry.gather(), &mut buffer) {
+        Ok(_) => HttpResponse::Ok()
+            .content_type("text/plain; charset=utf-8; version=0.0.4")
+            .body(buffer),
+        Err(e) => {
+            log::error!("Failed to encode metrics: {}", e);
+            HttpResponse::InternalServerError().body("Failed to encode metrics")
+        }
+    }
+}
+
+async fn healthz_handler() -> Result<impl Responder> {
+    Ok(HttpResponse::Ok()
+        .content_type("application/json")
+        .body(r#"{"status":"ok","service":"ape-dts"}"#))
+}
+
+async fn not_found_handler() -> Result<impl Responder> {
+    Ok(HttpResponse::NotFound()
+        .content_type("application/json")
+        .body(r#"{"error":"Not Found","message":"The requested endpoint does not exist"}"#))
+}

--- a/dt-common/src/monitor/task_metrics.rs
+++ b/dt-common/src/monitor/task_metrics.rs
@@ -1,0 +1,61 @@
+use serde::Serialize;
+use strum::{Display, EnumString, IntoStaticStr};
+
+#[derive(
+    PartialOrd,
+    Ord,
+    EnumString,
+    IntoStaticStr,
+    Display,
+    PartialEq,
+    Eq,
+    Hash,
+    Clone,
+    Copy,
+    Debug,
+    Serialize,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskMetricsType {
+    // TODO:
+    Delay,
+    Timestamp,
+
+    // TODO: These metrics describe the records and bytes pulled by extractor, different from ExtractorPushed*, which describe the overall traffic before filtering
+    ExtractorRpsMax,
+    ExtractorRpsMin,
+    ExtractorRpsAvg,
+    ExtractorBpsMax,
+    ExtractorBpsMin,
+    ExtractorBpsAvg,
+
+    ExtractorPlanRecords,
+
+    ExtractorPushedRpsMax,
+    ExtractorPushedRpsMin,
+    ExtractorPushedRpsAvg,
+    ExtractorPushedBpsMax,
+    ExtractorPushedBpsMin,
+    ExtractorPushedBpsAvg,
+
+    PipelineQueueSize,
+    PipelineQueueBytes,
+
+    PipelineRecordSizeMax,
+
+    SinkerRtMax,
+    SinkerRtMin,
+    SinkerRtAvg,
+
+    SinkerRpsMax,
+    SinkerRpsMin,
+    SinkerRpsAvg,
+    SinkerBpsMax,
+    SinkerBpsMin,
+    SinkerBpsAvg,
+
+    SinkerSinkedRecords,
+    SinkerSinkedBytes,
+
+    SinkerDdlCount,
+}

--- a/dt-common/src/monitor/task_monitor.rs
+++ b/dt-common/src/monitor/task_monitor.rs
@@ -1,0 +1,445 @@
+use std::{collections::BTreeMap, sync::Arc};
+
+use async_trait::async_trait;
+use dashmap::DashMap;
+
+use super::monitor::Monitor;
+#[cfg(feature = "metrics")]
+use crate::monitor::prometheus_metrics::PrometheusMetrics;
+use crate::{
+    config::config_enums::TaskType,
+    log_task,
+    monitor::{counter_type::CounterType, task_metrics::TaskMetricsType, FlushableMonitor},
+};
+
+#[derive(Clone)]
+pub struct TaskMonitor {
+    task_type: Option<TaskType>,
+
+    extractors: DashMap<String, Arc<Monitor>>,
+    pipelines: DashMap<String, Arc<Monitor>>,
+    sinkers: DashMap<String, Arc<Monitor>>,
+
+    no_window_metrics_map: DashMap<TaskMetricsType, u64>,
+    #[cfg(feature = "metrics")]
+    pub prometheus_metrics: Arc<PrometheusMetrics>,
+}
+
+#[derive(PartialEq, Eq, Hash, Clone)]
+pub enum MonitorType {
+    Extractor,
+    Pipeline,
+    Sinker,
+}
+
+enum CalcType {
+    #[allow(dead_code)]
+    Add,
+    Max,
+    Avg,
+    Min,
+    Latest,
+}
+
+#[async_trait]
+impl FlushableMonitor for TaskMonitor {
+    async fn flush(&self) {
+        if self.task_type.is_none() {
+            return;
+        }
+
+        self.reset_before_calc();
+        if let Some(metrics) = self.calc() {
+            log_task!("{}", serde_json::to_string(&metrics).unwrap());
+            #[cfg(feature = "metrics")]
+            self.prometheus_metrics.set_metrics(&metrics);
+        }
+    }
+}
+
+impl TaskMonitor {
+    #[cfg(not(feature = "metrics"))]
+    pub fn new(task_type: Option<TaskType>) -> Self {
+        Self {
+            task_type,
+            extractors: DashMap::new(),
+            pipelines: DashMap::new(),
+            sinkers: DashMap::new(),
+            no_window_metrics_map: DashMap::new(),
+        }
+    }
+
+    #[cfg(feature = "metrics")]
+    pub fn new(task_type: Option<TaskType>, prometheus_metrics: Arc<PrometheusMetrics>) -> Self {
+        Self {
+            task_type,
+            extractors: DashMap::new(),
+            pipelines: DashMap::new(),
+            sinkers: DashMap::new(),
+            no_window_metrics_map: DashMap::new(),
+            prometheus_metrics,
+        }
+    }
+
+    pub fn get_task_type(&self) -> Option<&TaskType> {
+        self.task_type.as_ref()
+    }
+
+    pub fn register(&self, task_id: &str, monitors: Vec<(MonitorType, Arc<Monitor>)>) {
+        if self.task_type.is_none() {
+            return;
+        }
+
+        for (monitor_type, monitor) in monitors {
+            match monitor_type {
+                MonitorType::Extractor => {
+                    self.extractors.insert(task_id.to_string(), monitor);
+                }
+                MonitorType::Pipeline => {
+                    self.pipelines.insert(task_id.to_string(), monitor);
+                }
+                MonitorType::Sinker => {
+                    self.sinkers.insert(task_id.to_string(), monitor);
+                }
+            }
+        }
+    }
+
+    pub fn unregister(&self, task_id: &str, monitors: Vec<MonitorType>) {
+        if self.task_type.is_none() {
+            return;
+        }
+
+        let mut calc_monitors = Vec::new();
+        for monitor_type in monitors {
+            match monitor_type {
+                MonitorType::Extractor => {
+                    if let Some((_, monitor)) = self.extractors.remove(task_id) {
+                        calc_monitors.push((MonitorType::Extractor, monitor.clone()));
+                    };
+                }
+                MonitorType::Sinker => {
+                    if let Some((_, monitor)) = self.sinkers.remove(task_id) {
+                        calc_monitors.push((MonitorType::Sinker, monitor.clone()));
+                    };
+                }
+                _ => {}
+            }
+        }
+        calc_nowindow_metrics(&self.no_window_metrics_map, calc_monitors);
+    }
+
+    pub fn add_no_window_metrics(&self, metrics_type: TaskMetricsType, value: u64) {
+        self.no_window_metrics_map
+            .entry(metrics_type)
+            .and_modify(|v| *v += value)
+            .or_insert(value);
+    }
+
+    fn calc(&self) -> Option<BTreeMap<TaskMetricsType, u64>> {
+        self.task_type.as_ref()?;
+        let mut metrics: BTreeMap<TaskMetricsType, u64> = BTreeMap::new();
+        let mut calc_handler =
+            |calc_type: CalcType, task_metrics_type: TaskMetricsType, val: u64| match calc_type {
+                CalcType::Min => {
+                    metrics
+                        .entry(task_metrics_type)
+                        .and_modify(|v| *v = (*v).min(val))
+                        .or_insert(val);
+                }
+                CalcType::Max => {
+                    metrics
+                        .entry(task_metrics_type)
+                        .and_modify(|v| *v = (*v).max(val))
+                        .or_insert(val);
+                }
+                CalcType::Avg => {
+                    metrics
+                        .entry(task_metrics_type)
+                        .and_modify(|v| *v = ((*v) + val) / 2)
+                        .or_insert(val);
+                }
+                _ => {}
+            };
+
+        let mut calc_monitors = Vec::new();
+        for item in self.extractors.iter() {
+            calc_monitors.push((MonitorType::Extractor, item.value().clone()));
+            // extractor rps
+            if let Some(mut counter) = item
+                .value()
+                .time_window_counters
+                .get_mut(&CounterType::ExtractedRecords)
+            {
+                let statics = counter.statistics();
+                calc_handler(
+                    CalcType::Min,
+                    TaskMetricsType::ExtractorRpsMin,
+                    statics.min_by_sec,
+                );
+                calc_handler(
+                    CalcType::Max,
+                    TaskMetricsType::ExtractorRpsMax,
+                    statics.max_by_sec,
+                );
+                calc_handler(
+                    CalcType::Avg,
+                    TaskMetricsType::ExtractorRpsAvg,
+                    statics.avg_by_sec,
+                );
+            }
+            // extractor bps
+            if let Some(mut counter) = item
+                .value()
+                .time_window_counters
+                .get_mut(&CounterType::ExtractedBytes)
+            {
+                let statics = counter.statistics();
+                calc_handler(
+                    CalcType::Min,
+                    TaskMetricsType::ExtractorBpsMin,
+                    statics.min_by_sec,
+                );
+                calc_handler(
+                    CalcType::Max,
+                    TaskMetricsType::ExtractorBpsMax,
+                    statics.max_by_sec,
+                );
+                calc_handler(
+                    CalcType::Avg,
+                    TaskMetricsType::ExtractorBpsAvg,
+                    statics.avg_by_sec,
+                );
+            }
+            // extractor pushed records
+            if let Some(mut counter) = item
+                .value()
+                .time_window_counters
+                .get_mut(&CounterType::RecordCount)
+            {
+                let statics = counter.statistics();
+                calc_handler(
+                    CalcType::Min,
+                    TaskMetricsType::ExtractorPushedRpsMin,
+                    statics.min_by_sec,
+                );
+                calc_handler(
+                    CalcType::Max,
+                    TaskMetricsType::ExtractorPushedRpsMax,
+                    statics.max_by_sec,
+                );
+                calc_handler(
+                    CalcType::Avg,
+                    TaskMetricsType::ExtractorPushedRpsAvg,
+                    statics.avg_by_sec,
+                );
+            }
+            // extractor pushed bytes
+            if let Some(mut counter) = item
+                .value()
+                .time_window_counters
+                .get_mut(&CounterType::DataBytes)
+            {
+                let statics = counter.statistics();
+                calc_handler(
+                    CalcType::Min,
+                    TaskMetricsType::ExtractorPushedBpsMin,
+                    statics.min_by_sec,
+                );
+                calc_handler(
+                    CalcType::Max,
+                    TaskMetricsType::ExtractorPushedBpsMax,
+                    statics.max_by_sec,
+                );
+                calc_handler(
+                    CalcType::Avg,
+                    TaskMetricsType::ExtractorPushedBpsAvg,
+                    statics.avg_by_sec,
+                );
+            }
+        }
+        for item in self.pipelines.iter() {
+            calc_monitors.push((MonitorType::Pipeline, item.value().clone()));
+        }
+        for item in self.sinkers.iter() {
+            calc_monitors.push((MonitorType::Sinker, item.value().clone()));
+            // sinker rt
+            if let Some(mut counter) = item
+                .value()
+                .time_window_counters
+                .get_mut(&CounterType::RtPerQuery)
+            {
+                let statics = counter.statistics();
+                calc_handler(
+                    CalcType::Min,
+                    TaskMetricsType::SinkerRtMin,
+                    statics.min_by_sec,
+                );
+                calc_handler(
+                    CalcType::Max,
+                    TaskMetricsType::SinkerRtMax,
+                    statics.max_by_sec,
+                );
+                calc_handler(
+                    CalcType::Avg,
+                    TaskMetricsType::SinkerRtAvg,
+                    statics.avg_by_sec,
+                );
+            }
+            // sinker rps
+            if let Some(mut counter) = item
+                .value()
+                .time_window_counters
+                .get_mut(&CounterType::RecordsPerQuery)
+            {
+                let statics = counter.statistics();
+                calc_handler(
+                    CalcType::Min,
+                    TaskMetricsType::SinkerRpsMin,
+                    statics.min_by_sec,
+                );
+                calc_handler(
+                    CalcType::Max,
+                    TaskMetricsType::SinkerRpsMax,
+                    statics.max_by_sec,
+                );
+                calc_handler(
+                    CalcType::Avg,
+                    TaskMetricsType::SinkerRpsAvg,
+                    statics.avg_by_sec,
+                );
+            }
+            // sinker bps
+            if let Some(mut counter) = item
+                .value()
+                .time_window_counters
+                .get_mut(&CounterType::DataBytes)
+            {
+                let statics = counter.statistics();
+                calc_handler(
+                    CalcType::Min,
+                    TaskMetricsType::SinkerBpsMin,
+                    statics.min_by_sec,
+                );
+                calc_handler(
+                    CalcType::Max,
+                    TaskMetricsType::SinkerBpsMax,
+                    statics.max_by_sec,
+                );
+                calc_handler(
+                    CalcType::Avg,
+                    TaskMetricsType::SinkerBpsAvg,
+                    statics.avg_by_sec,
+                );
+            }
+        }
+        calc_nowindow_metrics(&self.no_window_metrics_map, calc_monitors);
+
+        for item in self.no_window_metrics_map.iter() {
+            metrics.insert(*item.key(), *item.value());
+            #[cfg(feature = "metrics")]
+            self.prometheus_metrics.set_metrics(&metrics);
+        }
+
+        Some(metrics)
+    }
+
+    fn reset_before_calc(&self) {
+        self.no_window_metrics_map
+            .remove(&TaskMetricsType::PipelineQueueSize);
+        self.no_window_metrics_map
+            .remove(&TaskMetricsType::PipelineQueueBytes);
+    }
+}
+
+fn calc_nowindow_metrics(
+    result_map: &DashMap<TaskMetricsType, u64>,
+    calc_monitors: Vec<(MonitorType, Arc<Monitor>)>,
+) {
+    let batch_metrics = DashMap::<TaskMetricsType, u64>::new();
+    let metric_handler = |monitor: &Arc<Monitor>,
+                          counter_type: CounterType,
+                          metrics_type: TaskMetricsType,
+                          calc_type: CalcType| {
+        if let Some(counter) = monitor.no_window_counters.get(&counter_type) {
+            match calc_type {
+                CalcType::Add => {
+                    result_map
+                        .entry(metrics_type)
+                        .and_modify(|v| *v += counter.value)
+                        .or_insert(counter.value);
+                }
+                CalcType::Max => {
+                    result_map
+                        .entry(metrics_type)
+                        .and_modify(|v| *v = (*v).max(counter.value))
+                        .or_insert(counter.value);
+                }
+                CalcType::Latest => {
+                    result_map
+                        .entry(metrics_type)
+                        .and_modify(|v| *v = counter.value)
+                        .or_insert(counter.value);
+                }
+                _ => {}
+            }
+        }
+    };
+    let batch_metrics_handler =
+        |monitor: &Arc<Monitor>, counter_type: CounterType, metrics_type: TaskMetricsType| {
+            if let Some(counter) = monitor.no_window_counters.get(&counter_type) {
+                batch_metrics
+                    .entry(metrics_type)
+                    .and_modify(|v| *v += counter.value)
+                    .or_insert(counter.value);
+            }
+        };
+
+    for (monitor_type, monitor) in calc_monitors {
+        match monitor_type {
+            MonitorType::Extractor => {}
+            MonitorType::Sinker => {}
+            MonitorType::Pipeline => {
+                metric_handler(
+                    &monitor,
+                    CounterType::Timestamp,
+                    TaskMetricsType::Timestamp,
+                    CalcType::Max,
+                );
+                metric_handler(
+                    &monitor,
+                    CounterType::QueuedRecordCurrent,
+                    TaskMetricsType::PipelineQueueSize,
+                    CalcType::Latest,
+                );
+                metric_handler(
+                    &monitor,
+                    CounterType::QueuedByteCurrent,
+                    TaskMetricsType::PipelineQueueBytes,
+                    CalcType::Latest,
+                );
+                batch_metrics_handler(
+                    &monitor,
+                    CounterType::DDLRecordTotal,
+                    TaskMetricsType::SinkerDdlCount,
+                );
+                batch_metrics_handler(
+                    &monitor,
+                    CounterType::SinkedRecordTotal,
+                    TaskMetricsType::SinkerSinkedRecords,
+                );
+                batch_metrics_handler(
+                    &monitor,
+                    CounterType::SinkedByteTotal,
+                    TaskMetricsType::SinkerSinkedBytes,
+                );
+            }
+        }
+    }
+    for (metrics_type, value) in batch_metrics {
+        result_map
+            .entry(metrics_type)
+            .and_modify(|v| *v = (*v).max(value))
+            .or_insert(value);
+    }
+}

--- a/dt-common/src/monitor/time_window_counter.rs
+++ b/dt-common/src/monitor/time_window_counter.rs
@@ -1,27 +1,44 @@
 use std::{cmp, collections::LinkedList};
 
 use super::counter::Counter;
+use crate::utils::limit_queue::LimitedQueue;
 
-#[derive(Default)]
 pub struct WindowCounterStatistics {
-    pub sum: usize,
-    pub max: usize,
-    pub max_by_sec: usize,
-    pub count: usize,
-    pub avg_by_count: usize,
-    pub avg_by_sec: usize,
+    pub sum: u64,
+    pub max: u64,
+    pub min: u64,
+    pub avg_by_count: u64,
+    pub max_by_sec: u64,
+    pub min_by_sec: u64,
+    pub avg_by_sec: u64,
+    pub count: u64,
+}
+
+impl Default for WindowCounterStatistics {
+    fn default() -> Self {
+        Self {
+            sum: 0,
+            max: 0,
+            min: u64::MAX,
+            avg_by_count: 0,
+            max_by_sec: 0,
+            min_by_sec: u64::MAX,
+            avg_by_sec: 0,
+            count: 0,
+        }
+    }
 }
 
 #[derive(Clone)]
 pub struct TimeWindowCounter {
-    pub time_window_secs: usize,
-    pub max_sub_count: usize,
+    pub time_window_secs: u64,
+    pub max_sub_count: u64,
     pub counters: LinkedList<Counter>,
     pub description: String,
 }
 
 impl TimeWindowCounter {
-    pub fn new(time_window_secs: usize, max_sub_count: usize) -> Self {
+    pub fn new(time_window_secs: u64, max_sub_count: u64) -> Self {
         Self {
             time_window_secs,
             max_sub_count,
@@ -31,45 +48,90 @@ impl TimeWindowCounter {
     }
 
     #[inline(always)]
-    pub fn add(&mut self, value: usize, count: usize) {
-        while self.counters.len() > self.max_sub_count {
+    pub fn adds(&mut self, values: &LimitedQueue<(u64, u64)>) -> &Self {
+        for (value, count) in values.iter() {
+            if *count == 0 {
+                continue;
+            }
+            self.add(*value, *count);
+        }
+        self
+    }
+
+    #[inline(always)]
+    pub fn add(&mut self, value: u64, count: u64) -> &Self {
+        while self.counters.len() as u64 > self.max_sub_count {
             self.counters.pop_front();
         }
         self.counters.push_back(Counter::new(value, count));
+        self
     }
 
     #[inline(always)]
     pub fn statistics(&mut self) -> WindowCounterStatistics {
         self.refresh_window();
 
-        let mut statistics = WindowCounterStatistics {
-            ..Default::default()
-        };
+        if self.counters.is_empty() {
+            return WindowCounterStatistics {
+                ..Default::default()
+            };
+        }
+
+        let mut statistics = WindowCounterStatistics::default();
 
         let mut sum_in_current_sec = 0;
-        let mut current_elapsed_secs = 0;
+        let mut current_elapsed_secs = None;
+        let mut sec_sums = LimitedQueue::new(1000);
 
         for counter in self.counters.iter() {
             statistics.sum += counter.value;
             statistics.count += counter.count;
             statistics.max = cmp::max(statistics.max, counter.value);
+            statistics.min = cmp::min(statistics.min, counter.value);
 
-            if current_elapsed_secs == counter.timestamp.elapsed().as_secs() {
-                sum_in_current_sec += counter.value;
-            } else {
-                current_elapsed_secs = counter.timestamp.elapsed().as_secs();
-                statistics.max_by_sec = cmp::max(statistics.max_by_sec, sum_in_current_sec);
-                sum_in_current_sec = counter.value;
+            let counter_elapsed_secs = counter.timestamp.elapsed().as_secs();
+
+            match current_elapsed_secs {
+                None => {
+                    // first counter
+                    current_elapsed_secs = Some(counter_elapsed_secs);
+                    sum_in_current_sec = counter.value;
+                }
+                Some(elapsed_secs) if elapsed_secs == counter_elapsed_secs => {
+                    // sum when in same second
+                    sum_in_current_sec += counter.value;
+                }
+                Some(_) => {
+                    // new second
+                    sec_sums.push(sum_in_current_sec);
+                    current_elapsed_secs = Some(counter_elapsed_secs);
+                    sum_in_current_sec = counter.value;
+                }
             }
         }
-        statistics.max_by_sec = cmp::max(statistics.max_by_sec, sum_in_current_sec);
+
+        // the last second
+        if current_elapsed_secs.is_some() {
+            sec_sums.push(sum_in_current_sec);
+        }
+        for &sec_sum in sec_sums.iter() {
+            statistics.max_by_sec = cmp::max(statistics.max_by_sec, sec_sum);
+            statistics.min_by_sec = cmp::min(statistics.min_by_sec, sec_sum);
+        }
 
         if statistics.count > 0 {
             statistics.avg_by_count = statistics.sum / statistics.count;
-            if let Some(first_counter) = self.counters.front() {
-                let time_span = cmp::max(first_counter.timestamp.elapsed().as_secs() as usize, 1);
-                statistics.avg_by_sec = statistics.sum / time_span;
+            if !sec_sums.is_empty() {
+                let sec_sum_total: u64 = sec_sums.iter().sum();
+                statistics.avg_by_sec = sec_sum_total / sec_sums.len() as u64;
             }
+        }
+
+        if statistics.min == u64::MAX {
+            statistics.min = 0;
+        }
+        if statistics.min_by_sec == u64::MAX {
+            statistics.min_by_sec = 0;
         }
 
         statistics
@@ -79,7 +141,7 @@ impl TimeWindowCounter {
     pub fn refresh_window(&mut self) {
         let mut outdate_count = 0;
         for counter in self.counters.iter() {
-            if counter.timestamp.elapsed().as_secs() >= self.time_window_secs as u64 {
+            if counter.timestamp.elapsed().as_secs() >= self.time_window_secs {
                 outdate_count += 1;
             } else {
                 break;

--- a/dt-common/src/utils/limit_queue.rs
+++ b/dt-common/src/utils/limit_queue.rs
@@ -1,0 +1,34 @@
+use std::collections::VecDeque;
+
+pub struct LimitedQueue<T> {
+    data: VecDeque<T>,
+    max_size: usize,
+}
+
+impl<T> LimitedQueue<T> {
+    pub fn new(max_size: usize) -> Self {
+        Self {
+            data: VecDeque::with_capacity(max_size),
+            max_size,
+        }
+    }
+
+    pub fn push(&mut self, item: T) {
+        if self.data.len() >= self.max_size {
+            self.data.pop_front();
+        }
+        self.data.push_back(item);
+    }
+
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+
+    pub fn iter(&self) -> std::collections::vec_deque::Iter<T> {
+        self.data.iter()
+    }
+}

--- a/dt-common/src/utils/mod.rs
+++ b/dt-common/src/utils/mod.rs
@@ -1,4 +1,5 @@
 pub mod file_util;
+pub mod limit_queue;
 pub mod redis_util;
 pub mod sql_util;
 pub mod time_util;

--- a/dt-connector/src/extractor/extractor_monitor.rs
+++ b/dt-connector/src/extractor/extractor_monitor.rs
@@ -1,37 +1,37 @@
 use std::sync::Arc;
 
-use tokio::{sync::Mutex, time::Instant};
+use tokio::time::Instant;
 
 use dt_common::monitor::{counter_type::CounterType, monitor::Monitor};
 
 #[derive(Clone, Default)]
 pub struct ExtractorCounters {
-    pub record_count: usize,
-    pub data_size: usize,
+    pub pushed_record_count: u64,
+    pub pushed_data_size: u64,
 }
 
 impl ExtractorCounters {
     pub fn new() -> Self {
         Self {
-            record_count: 0,
-            data_size: 0,
+            pushed_record_count: 0,
+            pushed_data_size: 0,
         }
     }
 }
 
 pub struct ExtractorMonitor {
-    pub monitor: Arc<Mutex<Monitor>>,
-    pub count_window: usize,
-    pub time_window_secs: usize,
+    pub monitor: Arc<Monitor>,
+    pub count_window: u64,
+    pub time_window_secs: u64,
     pub last_flush_time: Instant,
     pub flushed_counters: ExtractorCounters,
     pub counters: ExtractorCounters,
 }
 
 impl ExtractorMonitor {
-    pub async fn new(monitor: Arc<Mutex<Monitor>>) -> Self {
-        let count_window = monitor.lock().await.count_window;
-        let time_window_secs = monitor.lock().await.time_window_secs;
+    pub async fn new(monitor: Arc<Monitor>) -> Self {
+        let count_window = monitor.count_window;
+        let time_window_secs = monitor.time_window_secs;
         Self {
             monitor,
             last_flush_time: Instant::now(),
@@ -43,18 +43,19 @@ impl ExtractorMonitor {
     }
 
     pub async fn try_flush(&mut self, force: bool) {
-        let record_count = self.counters.record_count - self.flushed_counters.record_count;
-        let record_size = self.counters.data_size - self.flushed_counters.data_size;
+        let pushed_record_count =
+            self.counters.pushed_record_count - self.flushed_counters.pushed_record_count;
+        let pushed_record_size =
+            self.counters.pushed_data_size - self.flushed_counters.pushed_data_size;
         // to avoid too many sub counters, add counter by batch
         if force
-            || record_count >= self.count_window
-            || self.last_flush_time.elapsed().as_secs() >= self.time_window_secs as u64
+            || pushed_record_count >= self.count_window
+            || self.last_flush_time.elapsed().as_secs() >= self.time_window_secs
         {
             self.monitor
-                .lock()
-                .await
-                .add_counter(CounterType::RecordCount, record_count)
-                .add_counter(CounterType::DataBytes, record_size);
+                .add_counter(CounterType::RecordCount, pushed_record_count)
+                .add_counter(CounterType::DataBytes, pushed_record_size);
+
             self.last_flush_time = Instant::now();
             self.flushed_counters = self.counters.clone();
         }

--- a/dt-connector/src/extractor/mongo/mongo_snapshot_extractor.rs
+++ b/dt-connector/src/extractor/mongo/mongo_snapshot_extractor.rs
@@ -104,7 +104,7 @@ impl MongoSnapshotExtractor {
             "end extracting data from {}.{}, all count: {}",
             self.db,
             self.tb,
-            self.base_extractor.monitor.counters.record_count
+            self.base_extractor.monitor.counters.pushed_record_count
         );
         Ok(())
     }

--- a/dt-connector/src/extractor/mysql/mysql_cdc_extractor.rs
+++ b/dt-connector/src/extractor/mysql/mysql_cdc_extractor.rs
@@ -24,7 +24,7 @@ use crate::{
 use dt_common::{
     config::config_enums::DbType,
     error::Error,
-    log_debug, log_error, log_info, log_warn,
+    log_debug, log_error, log_info,
     meta::{
         adaptor::mysql_col_value_convertor::MysqlColValueConvertor, col_value::ColValue,
         dt_data::DtData, mysql::mysql_meta_manager::MysqlMetaManager, position::Position,
@@ -370,7 +370,7 @@ impl MysqlCdcExtractor {
         }
 
         if !self.filter.filter_all_dcl() {
-            if let Ok(dcl_data) = self
+            if let Ok(Some(dcl_data)) = self
                 .base_extractor
                 .parse_dcl(&DbType::Mysql, &query.schema, &query.query)
                 .await
@@ -385,7 +385,7 @@ impl MysqlCdcExtractor {
         }
 
         if !self.filter.filter_all_ddl() {
-            if let Ok(ddl_data) = self
+            if let Ok(Some(ddl_data)) = self
                 .base_extractor
                 .parse_ddl(&DbType::Mysql, &query.schema, &query.query)
                 .await
@@ -408,11 +408,6 @@ impl MysqlCdcExtractor {
                 return Ok(());
             }
         }
-
-        log_warn!(
-                "received query event, but not dcl or ddl, sql: {}, maybe should execute it manually in target",
-                query.query
-            );
 
         Ok(())
     }

--- a/dt-connector/src/extractor/pg/pg_cdc_extractor.rs
+++ b/dt-connector/src/extractor/pg/pg_cdc_extractor.rs
@@ -434,7 +434,7 @@ impl PgCdcExtractor {
         let _tag = get_string(row_data, "tag");
         let schema = get_string(row_data, "schema");
 
-        if let Ok(ddl_data) = self
+        if let Ok(Some(ddl_data)) = self
             .base_extractor
             .parse_ddl(&DbType::Pg, &schema, &ddl_text)
             .await

--- a/dt-connector/src/extractor/pg/pg_snapshot_extractor.rs
+++ b/dt-connector/src/extractor/pg/pg_snapshot_extractor.rs
@@ -100,7 +100,7 @@ impl PgSnapshotExtractor {
             r#"end extracting data from "{}"."{}", all count: {}"#,
             self.schema,
             self.tb,
-            self.base_extractor.monitor.counters.record_count
+            self.base_extractor.monitor.counters.pushed_record_count
         );
         Ok(())
     }

--- a/dt-connector/src/extractor/redis/redis_reshard_extractor.rs
+++ b/dt-connector/src/extractor/redis/redis_reshard_extractor.rs
@@ -9,7 +9,6 @@ use dt_common::{
     utils::redis_util::RedisUtil,
 };
 use redis::{Connection, ConnectionLike};
-use serde_json::json;
 use url::Url;
 
 use crate::{extractor::base_extractor::BaseExtractor, Extractor};
@@ -58,7 +57,7 @@ impl RedisReshardExtractor {
             let slots = move_out_slots[i..i + count].to_vec();
             i += count;
 
-            log_info!("will move slots to: [{}], slots: {}", node.id, json!(slots));
+            log_info!("will move slots to: [{}], slots: {:?}", node.id, slots);
             node_move_in_slots.insert(node.id.clone(), slots);
         }
 

--- a/dt-connector/src/extractor/redis/redis_snapshot_file_extractor.rs
+++ b/dt-connector/src/extractor/redis/redis_snapshot_file_extractor.rs
@@ -68,7 +68,7 @@ impl Extractor for RedisSnapshotFileExtractor {
             if parser.is_end {
                 log_info!(
                     "end extracting data from rdb, all count: {}",
-                    self.base_extractor.monitor.counters.record_count
+                    self.base_extractor.monitor.counters.pushed_record_count
                 );
                 break;
             }

--- a/dt-connector/src/sinker/mysql/mysql_sinker.rs
+++ b/dt-connector/src/sinker/mysql/mysql_sinker.rs
@@ -1,4 +1,4 @@
-use std::{str::FromStr, sync::Arc};
+use std::{cmp, str::FromStr, sync::Arc};
 
 use anyhow::Context;
 use async_trait::async_trait;
@@ -6,7 +6,7 @@ use sqlx::{
     mysql::{MySqlConnectOptions, MySqlPoolOptions},
     MySql, Pool,
 };
-use tokio::{sync::Mutex, sync::RwLock, time::Instant};
+use tokio::{sync::RwLock, time::Instant};
 
 use crate::{
     call_batch_fn, close_conn_pool, data_marker::DataMarker, rdb_query_builder::RdbQueryBuilder,
@@ -22,6 +22,7 @@ use dt_common::{
         row_type::RowType,
     },
     monitor::monitor::Monitor,
+    utils::limit_queue::LimitedQueue,
 };
 
 #[derive(Clone)]
@@ -31,7 +32,7 @@ pub struct MysqlSinker {
     pub meta_manager: MysqlMetaManager,
     pub router: RdbRouter,
     pub batch_size: usize,
-    pub monitor: Arc<Mutex<Monitor>>,
+    pub monitor: Arc<Monitor>,
     pub data_marker: Option<Arc<RwLock<DataMarker>>>,
     pub replace: bool,
 }
@@ -61,8 +62,12 @@ impl Sinker for MysqlSinker {
     }
 
     async fn sink_ddl(&mut self, data: Vec<DdlData>, _batch: bool) -> anyhow::Result<()> {
-        for ddl_data in data {
+        let mut rts = LimitedQueue::new(cmp::min(100, data.len()));
+        let mut data_size = 0;
+
+        for ddl_data in data.iter() {
             let sql = ddl_data.to_sql();
+            data_size += ddl_data.get_data_size();
             let query = sqlx::query(&sql);
             let (db, _tb) = ddl_data.get_schema_tb();
             log_info!("sink ddl, db: {}, sql: {}", db, sql);
@@ -82,20 +87,32 @@ impl Sinker for MysqlSinker {
                 .max_connections(1)
                 .connect_with(conn_options)
                 .await?;
+            let start_time = Instant::now();
             query.execute(&conn_pool).await?;
+            rts.push((start_time.elapsed().as_millis() as u64, 1));
             conn_pool.close().await;
         }
-        Ok(())
+
+        BaseSinker::update_serial_monitor(&self.monitor, data.len() as u64, data_size).await?;
+        BaseSinker::update_monitor_rt(&self.monitor, &rts).await
     }
 
     async fn sink_dcl(&mut self, data: Vec<DclData>, _batch: bool) -> anyhow::Result<()> {
-        for dcl_data in data {
+        let mut rts = LimitedQueue::new(cmp::min(100, data.len()));
+        let mut data_size = 0;
+
+        for dcl_data in data.iter() {
             let sql = dcl_data.to_sql();
+            data_size += dcl_data.get_data_size();
             log_info!("sink dcl: {}", &sql);
             let query = sqlx::query(&sql).persistent(false).disable_arguments();
+            let start_time = Instant::now();
             query.execute(&self.conn_pool).await?;
+            rts.push((start_time.elapsed().as_millis() as u64, 1));
         }
-        Ok(())
+
+        BaseSinker::update_serial_monitor(&self.monitor, data.len() as u64, data_size).await?;
+        BaseSinker::update_monitor_rt(&self.monitor, &rts).await
     }
 
     async fn close(&mut self) -> anyhow::Result<()> {
@@ -113,9 +130,6 @@ impl Sinker for MysqlSinker {
 
 impl MysqlSinker {
     async fn serial_sink(&mut self, data: &[RowData]) -> anyhow::Result<()> {
-        let start_time = Instant::now();
-        let mut data_size = 0;
-
         let mut tx = self.conn_pool.begin().await?;
         if let Some(sql) = self.get_data_marker_sql().await {
             sqlx::query(&sql)
@@ -123,22 +137,28 @@ impl MysqlSinker {
                 .await
                 .with_context(|| format!("failed to execute data marker sql: [{}]", sql))?;
         }
+
+        let mut data_size = 0;
+        let mut rts = LimitedQueue::new(cmp::min(100, data.len()));
         for row_data in data.iter() {
             data_size += row_data.data_size;
             let tb_meta = self.meta_manager.get_tb_meta_by_row_data(row_data).await?;
             let query_builder = RdbQueryBuilder::new_for_mysql(tb_meta, None);
-
             let query_info = query_builder.get_query_info(row_data, self.replace)?;
             let query = query_builder.create_mysql_query(&query_info);
+
+            let start_time = Instant::now();
             query
                 .execute(&mut tx)
                 .await
                 .with_context(|| format!("serial sink failed, row_data: [{}]", row_data))?;
+            rts.push((start_time.elapsed().as_millis() as u64, 1));
         }
         tx.commit().await?;
 
-        BaseSinker::update_serial_monitor(&mut self.monitor, data.len(), data_size, start_time)
-            .await
+        BaseSinker::update_serial_monitor(&self.monitor, data.len() as u64, data_size as u64)
+            .await?;
+        BaseSinker::update_monitor_rt(&self.monitor, &rts).await
     }
 
     async fn batch_delete(
@@ -147,8 +167,6 @@ impl MysqlSinker {
         start_index: usize,
         batch_size: usize,
     ) -> anyhow::Result<()> {
-        let start_time = Instant::now();
-
         let tb_meta = self
             .meta_manager
             .get_tb_meta_by_row_data(&data[0])
@@ -159,6 +177,8 @@ impl MysqlSinker {
             query_builder.get_batch_delete_query(data, start_index, batch_size)?;
         let query = query_builder.create_mysql_query(&query_info);
 
+        let start_time = Instant::now();
+        let mut rts = LimitedQueue::new(1);
         if let Some(sql) = self.get_data_marker_sql().await {
             let mut tx = self.conn_pool.begin().await?;
             sqlx::query(&sql).execute(&mut tx).await?;
@@ -167,8 +187,11 @@ impl MysqlSinker {
         } else {
             query.execute(&self.conn_pool).await?;
         }
+        rts.push((start_time.elapsed().as_millis() as u64, 1));
 
-        BaseSinker::update_batch_monitor(&mut self.monitor, batch_size, data_size, start_time).await
+        BaseSinker::update_batch_monitor(&self.monitor, batch_size as u64, data_size as u64)
+            .await?;
+        BaseSinker::update_monitor_rt(&self.monitor, &rts).await
     }
 
     async fn batch_insert(
@@ -177,8 +200,6 @@ impl MysqlSinker {
         start_index: usize,
         batch_size: usize,
     ) -> anyhow::Result<()> {
-        let start_time = Instant::now();
-
         let tb_meta = self
             .meta_manager
             .get_tb_meta_by_row_data(&data[0])
@@ -190,6 +211,8 @@ impl MysqlSinker {
             query_builder.get_batch_insert_query(data, start_index, batch_size, self.replace)?;
         let query = query_builder.create_mysql_query(&query_info);
 
+        let start_time = Instant::now();
+        let mut rts = LimitedQueue::new(1);
         let exec_error = if let Some(sql) = self.get_data_marker_sql().await {
             let mut tx = self.conn_pool.begin().await?;
             sqlx::query(&sql).execute(&mut tx).await?;
@@ -204,6 +227,7 @@ impl MysqlSinker {
                 _ => None,
             }
         };
+        rts.push((start_time.elapsed().as_millis() as u64, 1));
 
         if let Some(error) = exec_error {
             log_error!(
@@ -215,9 +239,11 @@ impl MysqlSinker {
             // insert one by one
             let sub_data = &data[start_index..start_index + batch_size];
             self.serial_sink(sub_data).await?;
+        } else {
+            BaseSinker::update_monitor_rt(&self.monitor, &rts).await?;
         }
 
-        BaseSinker::update_batch_monitor(&mut self.monitor, batch_size, data_size, start_time).await
+        BaseSinker::update_batch_monitor(&self.monitor, batch_size as u64, data_size as u64).await
     }
 
     async fn get_data_marker_sql(&self) -> Option<String> {

--- a/dt-connector/src/sinker/pg/pg_checker.rs
+++ b/dt-connector/src/sinker/pg/pg_checker.rs
@@ -1,9 +1,9 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{cmp, collections::HashMap, sync::Arc};
 
 use async_trait::async_trait;
 use futures::TryStreamExt;
 use sqlx::{Pool, Postgres};
-use tokio::{sync::Mutex, time::Instant};
+use tokio::time::Instant;
 
 use crate::{
     call_batch_fn, close_conn_pool,
@@ -14,12 +14,15 @@ use crate::{
     Sinker,
 };
 use dt_common::{
-    meta::pg::pg_meta_manager::PgMetaManager,
-    meta::rdb_meta_manager::RdbMetaManager,
-    meta::row_data::RowData,
-    meta::struct_meta::{statement::struct_statement::StructStatement, struct_data::StructData},
+    meta::{
+        pg::pg_meta_manager::PgMetaManager,
+        rdb_meta_manager::RdbMetaManager,
+        row_data::RowData,
+        struct_meta::{statement::struct_statement::StructStatement, struct_data::StructData},
+    },
     monitor::monitor::Monitor,
     rdb_filter::RdbFilter,
+    utils::limit_queue::LimitedQueue,
 };
 
 #[derive(Clone)]
@@ -29,7 +32,7 @@ pub struct PgChecker {
     pub extractor_meta_manager: RdbMetaManager,
     pub reverse_router: RdbRouter,
     pub batch_size: usize,
-    pub monitor: Arc<Mutex<Monitor>>,
+    pub monitor: Arc<Monitor>,
     pub filter: RdbFilter,
 }
 
@@ -66,8 +69,6 @@ impl Sinker for PgChecker {
 
 impl PgChecker {
     async fn serial_check(&mut self, data: Vec<RowData>) -> anyhow::Result<()> {
-        let start_time = Instant::now();
-
         if data.is_empty() {
             return Ok(());
         }
@@ -75,12 +76,16 @@ impl PgChecker {
 
         let mut miss = Vec::new();
         let mut diff = Vec::new();
+        let mut rts = LimitedQueue::new(cmp::min(100, data.len()));
         for src_row_data in data.iter() {
             let query_builder = RdbQueryBuilder::new_for_pg(tb_meta, None);
             let query_info = query_builder.get_select_query(src_row_data)?;
             let query = query_builder.create_pg_query(&query_info);
 
+            let start_time = Instant::now();
             let mut rows = query.fetch(&self.conn_pool);
+            rts.push((start_time.elapsed().as_millis() as u64, 1));
+
             if let Some(row) = rows.try_next().await.unwrap() {
                 let dst_row_data = RowData::from_pg_row(&row, tb_meta, &None);
                 let diff_col_values = BaseChecker::compare_row_data(src_row_data, &dst_row_data);
@@ -106,7 +111,8 @@ impl PgChecker {
         }
         BaseChecker::log_dml(miss, diff);
 
-        BaseSinker::update_serial_monitor(&mut self.monitor, data.len(), 0, start_time).await
+        BaseSinker::update_serial_monitor(&self.monitor, data.len() as u64, 0).await?;
+        BaseSinker::update_monitor_rt(&self.monitor, &rts).await
     }
 
     async fn batch_check(
@@ -115,8 +121,6 @@ impl PgChecker {
         start_index: usize,
         batch_size: usize,
     ) -> anyhow::Result<()> {
-        let start_time = Instant::now();
-
         let tb_meta = self.meta_manager.get_tb_meta_by_row_data(&data[0]).await?;
         let query_builder = RdbQueryBuilder::new_for_pg(tb_meta, None);
 
@@ -126,7 +130,11 @@ impl PgChecker {
 
         // fetch dst
         let mut dst_row_data_map = HashMap::new();
+        let start_time = Instant::now();
+        let mut rts = LimitedQueue::new(1);
         let mut rows = query.fetch(&self.conn_pool);
+        rts.push((start_time.elapsed().as_millis() as u64, 1));
+
         while let Some(row) = rows.try_next().await.unwrap() {
             let row_data = RowData::from_pg_row(&row, tb_meta, &None);
             let hash_code = row_data.get_hash_code(&tb_meta.basic);
@@ -145,7 +153,8 @@ impl PgChecker {
         .await?;
         BaseChecker::log_dml(miss, diff);
 
-        BaseSinker::update_batch_monitor(&mut self.monitor, batch_size, 0, start_time).await
+        BaseSinker::update_batch_monitor(&self.monitor, batch_size as u64, 0).await?;
+        BaseSinker::update_monitor_rt(&self.monitor, &rts).await
     }
 
     async fn serial_check_struct(&mut self, mut data: Vec<StructData>) -> anyhow::Result<()> {

--- a/dt-connector/src/sinker/pg/pg_sinker.rs
+++ b/dt-connector/src/sinker/pg/pg_sinker.rs
@@ -1,4 +1,4 @@
-use std::{str::FromStr, sync::Arc};
+use std::{cmp, str::FromStr, sync::Arc};
 
 use anyhow::Context;
 use async_trait::async_trait;
@@ -6,7 +6,7 @@ use sqlx::{
     postgres::{PgConnectOptions, PgPoolOptions},
     Executor, Pool, Postgres,
 };
-use tokio::{sync::Mutex, sync::RwLock, time::Instant};
+use tokio::{sync::RwLock, time::Instant};
 
 use crate::{
     call_batch_fn, close_conn_pool, data_marker::DataMarker, rdb_query_builder::RdbQueryBuilder,
@@ -15,10 +15,13 @@ use crate::{
 use dt_common::{
     log_error, log_info,
     meta::{
-        ddl_meta::ddl_data::DdlData, ddl_meta::ddl_type::DdlType,
-        pg::pg_meta_manager::PgMetaManager, row_data::RowData, row_type::RowType,
+        ddl_meta::{ddl_data::DdlData, ddl_type::DdlType},
+        pg::pg_meta_manager::PgMetaManager,
+        row_data::RowData,
+        row_type::RowType,
     },
     monitor::monitor::Monitor,
+    utils::limit_queue::LimitedQueue,
 };
 
 #[derive(Clone)]
@@ -28,7 +31,7 @@ pub struct PgSinker {
     pub meta_manager: PgMetaManager,
     pub router: RdbRouter,
     pub batch_size: usize,
-    pub monitor: Arc<Mutex<Monitor>>,
+    pub monitor: Arc<Monitor>,
     pub data_marker: Option<Arc<RwLock<DataMarker>>>,
     pub replace: bool,
 }
@@ -57,8 +60,12 @@ impl Sinker for PgSinker {
     }
 
     async fn sink_ddl(&mut self, data: Vec<DdlData>, _batch: bool) -> anyhow::Result<()> {
-        for ddl_data in data {
+        let mut rts = LimitedQueue::new(cmp::min(100, data.len()));
+        let mut data_size = 0;
+
+        for ddl_data in data.iter() {
             let (schema, _tb) = ddl_data.get_schema_tb();
+            data_size += ddl_data.get_data_size();
             let conn_options = PgConnectOptions::from_str(&self.url)?;
             let mut pool_options = PgPoolOptions::new().max_connections(1);
             let sql = format!("SET search_path = '{}';", schema);
@@ -83,10 +90,16 @@ impl Sinker for PgSinker {
 
             let conn_pool = pool_options.connect_with(conn_options).await?;
             let query = sqlx::query(&sql);
+
+            let start_time = Instant::now();
             query.execute(&conn_pool).await?;
+            rts.push((start_time.elapsed().as_millis() as u64, 1));
+
             conn_pool.close().await;
         }
-        Ok(())
+
+        BaseSinker::update_serial_monitor(&self.monitor, data.len() as u64, data_size).await?;
+        BaseSinker::update_monitor_rt(&self.monitor, &rts).await
     }
 
     async fn refresh_meta(&mut self, data: Vec<DdlData>) -> anyhow::Result<()> {
@@ -104,7 +117,6 @@ impl Sinker for PgSinker {
 
 impl PgSinker {
     async fn serial_sink(&mut self, data: &[RowData]) -> anyhow::Result<()> {
-        let start_time = Instant::now();
         let mut data_size = 0;
 
         let mut tx = self.conn_pool.begin().await?;
@@ -114,6 +126,7 @@ impl PgSinker {
                 .await
                 .with_context(|| format!("failed to execute data marker sql: [{}]", sql))?;
         }
+        let mut rts = LimitedQueue::new(cmp::min(100, data.len()));
         for row_data in data.iter() {
             data_size += row_data.data_size;
 
@@ -122,15 +135,19 @@ impl PgSinker {
 
             let query_info = query_builder.get_query_info(row_data, self.replace)?;
             let query = query_builder.create_pg_query(&query_info);
+
+            let start_time = Instant::now();
             query
                 .execute(&mut tx)
                 .await
                 .with_context(|| format!("serial sink failed, row_data: [{}]", row_data))?;
+            rts.push((start_time.elapsed().as_millis() as u64, 1));
         }
         tx.commit().await?;
 
-        BaseSinker::update_serial_monitor(&mut self.monitor, data.len(), data_size, start_time)
-            .await
+        BaseSinker::update_serial_monitor(&self.monitor, data.len() as u64, data_size as u64)
+            .await?;
+        BaseSinker::update_monitor_rt(&self.monitor, &rts).await
     }
 
     async fn batch_delete(
@@ -139,8 +156,6 @@ impl PgSinker {
         start_index: usize,
         batch_size: usize,
     ) -> anyhow::Result<()> {
-        let start_time = Instant::now();
-
         let tb_meta = self.meta_manager.get_tb_meta_by_row_data(&data[0]).await?;
         let query_builder = RdbQueryBuilder::new_for_pg(tb_meta, None);
 
@@ -148,6 +163,8 @@ impl PgSinker {
             query_builder.get_batch_delete_query(data, start_index, batch_size)?;
         let query = query_builder.create_pg_query(&query_info);
 
+        let start_time = Instant::now();
+        let mut rts = LimitedQueue::new(1);
         if let Some(sql) = self.get_data_marker_sql().await {
             let mut tx = self.conn_pool.begin().await?;
             sqlx::query(&sql).execute(&mut tx).await?;
@@ -156,8 +173,11 @@ impl PgSinker {
         } else {
             query.execute(&self.conn_pool).await?;
         }
+        rts.push((start_time.elapsed().as_millis() as u64, 1));
 
-        BaseSinker::update_batch_monitor(&mut self.monitor, batch_size, data_size, start_time).await
+        BaseSinker::update_batch_monitor(&self.monitor, batch_size as u64, data_size as u64)
+            .await?;
+        BaseSinker::update_monitor_rt(&self.monitor, &rts).await
     }
 
     async fn batch_insert(
@@ -166,8 +186,6 @@ impl PgSinker {
         start_index: usize,
         batch_size: usize,
     ) -> anyhow::Result<()> {
-        let start_time = Instant::now();
-
         let tb_meta = self
             .meta_manager
             .get_tb_meta_by_row_data(&data[0])
@@ -179,6 +197,8 @@ impl PgSinker {
             query_builder.get_batch_insert_query(data, start_index, batch_size, self.replace)?;
         let query = query_builder.create_pg_query(&query_info);
 
+        let start_time = Instant::now();
+        let mut rts = LimitedQueue::new(1);
         let exec_error = if let Some(sql) = self.get_data_marker_sql().await {
             let mut tx = self.conn_pool.begin().await?;
             sqlx::query(&sql).execute(&mut tx).await?;
@@ -200,9 +220,13 @@ impl PgSinker {
             );
             let sub_data = &data[start_index..start_index + batch_size];
             self.serial_sink(sub_data).await?;
+        } else {
+            rts.push((start_time.elapsed().as_millis() as u64, 1));
         }
 
-        BaseSinker::update_batch_monitor(&mut self.monitor, batch_size, data_size, start_time).await
+        BaseSinker::update_batch_monitor(&self.monitor, batch_size as u64, data_size as u64)
+            .await?;
+        BaseSinker::update_monitor_rt(&self.monitor, &rts).await
     }
 
     async fn get_data_marker_sql(&self) -> Option<String> {

--- a/dt-connector/src/sinker/redis/redis_statistic_sinker.rs
+++ b/dt-connector/src/sinker/redis/redis_statistic_sinker.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use serde::Serialize;
 use serde_json::json;
-use tokio::sync::Mutex;
 
 use dt_common::log_statistic;
 use dt_common::meta::dt_data::DtData;
@@ -15,7 +14,7 @@ use crate::Sinker;
 
 pub struct RedisStatisticSinker {
     pub statistic_type: RedisStatisticType,
-    pub monitor: Arc<Mutex<Monitor>>,
+    pub monitor: Arc<Monitor>,
     pub data_size_threshold: usize,
     pub freq_threshold: i64,
 }

--- a/dt-connector/src/sinker/sql_sinker.rs
+++ b/dt-connector/src/sinker/sql_sinker.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use tokio::sync::Mutex;
 
 use crate::{rdb_query_builder::RdbQueryBuilder, rdb_router::RdbRouter, Sinker};
 use dt_common::{
@@ -15,7 +14,7 @@ pub struct SqlSinker {
     pub meta_manager: RdbMetaManager,
     pub router: RdbRouter,
     pub reverse: bool,
-    pub monitor: Arc<Mutex<Monitor>>,
+    pub monitor: Arc<Monitor>,
 }
 
 #[async_trait]

--- a/dt-main/Cargo.toml
+++ b/dt-main/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2021"
 [lints]
 workspace = true
 
+[features]
+metrics = ["dt-task/metrics"]
+
 [dependencies]
 dt-task = {path = "../dt-task", version = "0.1.0"}
 dt-precheck = {path = "../dt-precheck", version = "0.1.0"}

--- a/dt-main/src/main.rs
+++ b/dt-main/src/main.rs
@@ -3,9 +3,23 @@ use std::env;
 use dt_precheck::{config::task_config::PrecheckTaskConfig, do_precheck};
 use dt_task::task_runner::TaskRunner;
 
+const ENV_SHUTDOWN_TIMEOUT_SECS: &str = "SHUTDOWN_TIMEOUT_SECS";
+
 #[tokio::main]
 async fn main() {
     env::set_var("RUST_BACKTRACE", "1");
+
+    tokio::spawn(async {
+        tokio::signal::ctrl_c().await.unwrap();
+        tokio::time::sleep(std::time::Duration::from_secs(
+            std::env::var(ENV_SHUTDOWN_TIMEOUT_SECS)
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(3),
+        ))
+        .await;
+        std::process::exit(0);
+    });
 
     let task_config = env::args().nth(1).expect("no task_config provided in args");
     if PrecheckTaskConfig::new(&task_config).is_ok() {

--- a/dt-parallelizer/src/check_parallelizer.rs
+++ b/dt-parallelizer/src/check_parallelizer.rs
@@ -1,14 +1,13 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+
+use super::{base_parallelizer::BaseParallelizer, snapshot_parallelizer::SnapshotParallelizer};
+use crate::{DataSize, Merger, Parallelizer};
 use dt_common::meta::{
     dt_data::DtItem, dt_queue::DtQueue, row_data::RowData, struct_meta::struct_data::StructData,
 };
 use dt_connector::Sinker;
-
-use crate::{Merger, Parallelizer};
-
-use super::{base_parallelizer::BaseParallelizer, snapshot_parallelizer::SnapshotParallelizer};
 
 pub struct CheckParallelizer {
     pub base_parallelizer: BaseParallelizer,
@@ -34,30 +33,44 @@ impl Parallelizer for CheckParallelizer {
         &mut self,
         data: Vec<RowData>,
         sinkers: &[Arc<async_mutex::Mutex<Box<dyn Sinker + Send>>>],
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<DataSize> {
+        let mut data_size = DataSize::default();
+
         let mut merged_datas = self.merger.merge(data).await?;
         for tb_merged_data in merged_datas.drain(..) {
             let batch_data = tb_merged_data.insert_rows;
+            data_size
+                .add_count(batch_data.len() as u64)
+                .add_bytes(batch_data.iter().map(|v| v.get_data_size()).sum());
             let batch_sub_datas = SnapshotParallelizer::partition(batch_data, self.parallel_size)?;
             self.base_parallelizer
                 .sink_dml(batch_sub_datas, sinkers, self.parallel_size, true)
                 .await?;
 
             let serial_data = tb_merged_data.unmerged_rows;
+            data_size
+                .add_count(serial_data.len() as u64)
+                .add_bytes(serial_data.iter().map(|v| v.get_data_size()).sum());
             let serial_sub_datas =
                 SnapshotParallelizer::partition(serial_data, self.parallel_size)?;
             self.base_parallelizer
                 .sink_dml(serial_sub_datas, sinkers, self.parallel_size, false)
                 .await?;
         }
-        Ok(())
+
+        Ok(data_size)
     }
 
     async fn sink_struct(
         &mut self,
         data: Vec<StructData>,
         sinkers: &[Arc<async_mutex::Mutex<Box<dyn Sinker + Send>>>],
-    ) -> anyhow::Result<()> {
-        sinkers[0].lock().await.sink_struct(data).await
+    ) -> anyhow::Result<DataSize> {
+        let data_size = DataSize {
+            count: data.len() as u64,
+            bytes: 0,
+        };
+        sinkers[0].lock().await.sink_struct(data).await?;
+        Ok(data_size)
     }
 }

--- a/dt-parallelizer/src/lib.rs
+++ b/dt-parallelizer/src/lib.rs
@@ -33,40 +33,40 @@ pub trait Parallelizer {
         &mut self,
         _data: Vec<DdlData>,
         _sinkers: &[Arc<async_mutex::Mutex<Box<dyn Sinker + Send>>>],
-    ) -> anyhow::Result<()> {
-        Ok(())
+    ) -> anyhow::Result<DataSize> {
+        Ok(DataSize::default())
     }
 
     async fn sink_dml(
         &mut self,
         _data: Vec<RowData>,
         _sinkers: &[Arc<async_mutex::Mutex<Box<dyn Sinker + Send>>>],
-    ) -> anyhow::Result<()> {
-        Ok(())
+    ) -> anyhow::Result<DataSize> {
+        Ok(DataSize::default())
     }
 
     async fn sink_dcl(
         &mut self,
         _data: Vec<DclData>,
         _sinkers: &[Arc<async_mutex::Mutex<Box<dyn Sinker + Send>>>],
-    ) -> anyhow::Result<()> {
-        Ok(())
+    ) -> anyhow::Result<DataSize> {
+        Ok(DataSize::default())
     }
 
     async fn sink_raw(
         &mut self,
         _data: Vec<DtItem>,
         _sinkers: &[Arc<async_mutex::Mutex<Box<dyn Sinker + Send>>>],
-    ) -> anyhow::Result<()> {
-        Ok(())
+    ) -> anyhow::Result<DataSize> {
+        Ok(DataSize::default())
     }
 
     async fn sink_struct(
         &mut self,
         _data: Vec<StructData>,
         _sinkers: &[Arc<async_mutex::Mutex<Box<dyn Sinker + Send>>>],
-    ) -> anyhow::Result<()> {
-        Ok(())
+    ) -> anyhow::Result<DataSize> {
+        Ok(DataSize::default())
     }
 
     async fn close(&mut self) -> anyhow::Result<()> {
@@ -80,5 +80,28 @@ pub trait Merger {
 
     async fn close(&mut self) -> anyhow::Result<()> {
         Ok(())
+    }
+}
+
+#[derive(Default)]
+pub struct DataSize {
+    pub count: u64,
+    pub bytes: u64,
+}
+
+impl DataSize {
+    pub fn add(&mut self, other: DataSize) {
+        self.count += other.count;
+        self.bytes += other.bytes;
+    }
+
+    pub fn add_count(&mut self, count: u64) -> &mut Self {
+        self.count += count;
+        self
+    }
+
+    pub fn add_bytes(&mut self, bytes: u64) -> &mut Self {
+        self.bytes += bytes;
+        self
     }
 }

--- a/dt-parallelizer/src/serial_parallelizer.rs
+++ b/dt-parallelizer/src/serial_parallelizer.rs
@@ -1,15 +1,14 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+
+use super::base_parallelizer::BaseParallelizer;
+use crate::{DataSize, Parallelizer};
 use dt_common::meta::{
     dcl_meta::dcl_data::DclData, ddl_meta::ddl_data::DdlData, dt_data::DtItem, dt_queue::DtQueue,
     row_data::RowData, struct_meta::struct_data::StructData,
 };
 use dt_connector::Sinker;
-
-use crate::Parallelizer;
-
-use super::base_parallelizer::BaseParallelizer;
 
 pub struct SerialParallelizer {
     pub base_parallelizer: BaseParallelizer,
@@ -29,47 +28,82 @@ impl Parallelizer for SerialParallelizer {
         &mut self,
         data: Vec<RowData>,
         sinkers: &[Arc<async_mutex::Mutex<Box<dyn Sinker + Send>>>],
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<DataSize> {
+        let data_size = DataSize {
+            count: data.len() as u64,
+            bytes: data.iter().map(|v| v.data_size as u64).sum(),
+        };
+
         self.base_parallelizer
             .sink_dml(vec![data], sinkers, 1, false)
-            .await
+            .await?;
+
+        Ok(data_size)
     }
 
     async fn sink_ddl(
         &mut self,
         data: Vec<DdlData>,
         sinkers: &[Arc<async_mutex::Mutex<Box<dyn Sinker + Send>>>],
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<DataSize> {
+        let data_size = DataSize {
+            count: data.len() as u64,
+            bytes: data.iter().map(|v| v.get_data_size()).sum(),
+        };
+
         self.base_parallelizer
             .sink_ddl(vec![data], sinkers, 1, false)
-            .await
+            .await?;
+
+        Ok(data_size)
     }
 
     async fn sink_dcl(
         &mut self,
         data: Vec<DclData>,
         sinkers: &[Arc<async_mutex::Mutex<Box<dyn Sinker + Send>>>],
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<DataSize> {
+        let data_size = DataSize {
+            count: data.len() as u64,
+            bytes: data.iter().map(|v| v.get_data_size()).sum(),
+        };
+
         self.base_parallelizer
             .sink_dcl(vec![data], sinkers, 1, false)
-            .await
+            .await?;
+
+        Ok(data_size)
     }
 
     async fn sink_raw(
         &mut self,
         data: Vec<DtItem>,
         sinkers: &[Arc<async_mutex::Mutex<Box<dyn Sinker + Send>>>],
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<DataSize> {
+        let data_size = DataSize {
+            count: data.len() as u64,
+            bytes: data.iter().map(|v| v.get_data_size()).sum(),
+        };
+
         self.base_parallelizer
             .sink_raw(vec![data], sinkers, 1, false)
-            .await
+            .await?;
+
+        Ok(data_size)
     }
 
     async fn sink_struct(
         &mut self,
         data: Vec<StructData>,
         sinkers: &[Arc<async_mutex::Mutex<Box<dyn Sinker + Send>>>],
-    ) -> anyhow::Result<()> {
-        sinkers[0].lock().await.sink_struct(data).await
+    ) -> anyhow::Result<DataSize> {
+        let data_size = DataSize {
+            count: data.len() as u64,
+            bytes: 0,
+        };
+
+        sinkers[0].lock().await.sink_struct(data).await?;
+
+        Ok(data_size)
     }
 }

--- a/dt-parallelizer/src/table_parallelizer.rs
+++ b/dt-parallelizer/src/table_parallelizer.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, sync::Arc};
 
-use crate::Parallelizer;
+use crate::{DataSize, Parallelizer};
 use async_trait::async_trait;
 use dt_common::meta::{
     ddl_meta::ddl_data::DdlData,
@@ -31,32 +31,53 @@ impl Parallelizer for TableParallelizer {
         &mut self,
         data: Vec<RowData>,
         sinkers: &[Arc<async_mutex::Mutex<Box<dyn Sinker + Send>>>],
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<DataSize> {
+        let data_size = DataSize {
+            count: data.len() as u64,
+            bytes: data.iter().map(|v| v.data_size as u64).sum(),
+        };
+
         let sub_datas = Self::partition_dml(data)?;
         self.base_parallelizer
             .sink_dml(sub_datas, sinkers, self.parallel_size, false)
-            .await
+            .await?;
+
+        Ok(data_size)
     }
 
     async fn sink_raw(
         &mut self,
         data: Vec<DtItem>,
         sinkers: &[Arc<async_mutex::Mutex<Box<dyn Sinker + Send>>>],
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<DataSize> {
+        let data_size = DataSize {
+            count: data.len() as u64,
+            bytes: data.iter().map(|v| v.get_data_size()).sum(),
+        };
+
         let sub_datas = Self::partition_raw(data)?;
         self.base_parallelizer
             .sink_raw(sub_datas, sinkers, self.parallel_size, false)
-            .await
+            .await?;
+
+        Ok(data_size)
     }
 
     async fn sink_ddl(
         &mut self,
         data: Vec<DdlData>,
         sinkers: &[Arc<async_mutex::Mutex<Box<dyn Sinker + Send>>>],
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<DataSize> {
+        let data_size = DataSize {
+            count: data.len() as u64,
+            bytes: data.iter().map(|v| v.get_data_size()).sum(),
+        };
+
         self.base_parallelizer
             .sink_ddl(vec![data], sinkers, 1, false)
-            .await
+            .await?;
+
+        Ok(data_size)
     }
 }
 

--- a/dt-precheck/src/prechecker/redis_prechecker.rs
+++ b/dt-precheck/src/prechecker/redis_prechecker.rs
@@ -83,7 +83,7 @@ impl Prechecker for RedisPrechecker {
         let buffer = Arc::new(DtQueue::new(1, 0));
 
         let filter = RdbFilter::from_config(&self.task_config.filter, &DbType::Redis)?;
-        let monitor = Arc::new(Mutex::new(Monitor::new("extractor", "", 1, 100, 1)));
+        let monitor = Arc::new(Monitor::new("extractor", "", 1, 100, 1));
         let base_extractor = BaseExtractor {
             buffer,
             router: RdbRouter::from_config(&self.task_config.router, &DbType::Redis)?,

--- a/dt-task/Cargo.toml
+++ b/dt-task/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2021"
 [lints]
 workspace = true
 
+[features]
+metrics = ["dt-common/metrics", "prometheus"]
+
 [dependencies]
 dt-common = {path = "../dt-common", version = "0.1.0"}
 dt-connector = {path = "../dt-connector", version = "0.1.0"}
@@ -39,3 +42,4 @@ redis = { workspace = true }
 ratelimit = { workspace = true }
 anyhow = { workspace = true }
 clickhouse = { workspace = true }
+prometheus = { version = "0.14.0", optional = true }

--- a/dt-task/src/extractor_util.rs
+++ b/dt-task/src/extractor_util.rs
@@ -69,7 +69,7 @@ impl ExtractorUtil {
         buffer: Arc<DtQueue>,
         shut_down: Arc<AtomicBool>,
         syncer: Arc<Mutex<Syncer>>,
-        monitor: Arc<Mutex<Monitor>>,
+        monitor: Arc<Monitor>,
         data_marker: Option<DataMarker>,
         router: RdbRouter,
         snapshot_resumer: SnapshotResumer,

--- a/dt-task/src/parallelizer_util.rs
+++ b/dt-task/src/parallelizer_util.rs
@@ -4,7 +4,6 @@ use std::{
 };
 
 use ratelimit::Ratelimiter;
-use tokio::sync::Mutex;
 
 use super::task_util::TaskUtil;
 use dt_common::{
@@ -31,14 +30,14 @@ pub struct ParallelizerUtil {}
 impl ParallelizerUtil {
     pub async fn create_parallelizer(
         config: &TaskConfig,
-        monitor: Arc<Mutex<Monitor>>,
+        monitor: Arc<Monitor>,
         rps_limiter: Option<Ratelimiter>,
     ) -> anyhow::Result<Box<dyn Parallelizer + Send + Sync>> {
         let parallel_size = config.parallelizer.parallel_size;
         let parallel_type = &config.parallelizer.parallel_type;
         let base_parallelizer = BaseParallelizer {
             poped_data: VecDeque::new(),
-            monitor: monitor.clone(),
+            monitor,
             rps_limiter,
         };
 
@@ -124,7 +123,7 @@ impl ParallelizerUtil {
                 };
                 Box::new(FoxlakeParallelizer {
                     task_config: config.clone(),
-                    base_parallelizer: snapshot_parallelizer,
+                    snapshot_parallelizer,
                 })
             }
         };

--- a/dt-task/src/sinker_util.rs
+++ b/dt-task/src/sinker_util.rs
@@ -77,7 +77,7 @@ impl SinkerUtil {
     pub async fn create_sinkers(
         task_config: &TaskConfig,
         extractor_config: &ExtractorConfig,
-        monitor: Arc<Mutex<Monitor>>,
+        monitor: Arc<Monitor>,
         data_marker: Option<Arc<RwLock<DataMarker>>>,
     ) -> anyhow::Result<Sinkers> {
         let log_level = &task_config.runtime.log_level;

--- a/dt-task/src/task_util.rs
+++ b/dt-task/src/task_util.rs
@@ -1,5 +1,6 @@
 use std::{str::FromStr, time::Duration};
 
+use dt_common::config::config_enums::TaskType;
 use dt_common::config::extractor_config::ExtractorConfig;
 use dt_common::config::s3_config::S3Config;
 use dt_common::config::{
@@ -12,6 +13,7 @@ use dt_common::meta::{
     mysql::mysql_meta_manager::MysqlMetaManager, pg::pg_meta_manager::PgMetaManager,
     rdb_meta_manager::RdbMetaManager,
 };
+use dt_common::rdb_filter::RdbFilter;
 use futures::TryStreamExt;
 use mongodb::bson::doc;
 use mongodb::options::ClientOptions;
@@ -209,6 +211,113 @@ impl TaskUtil {
         };
         tbs.sort();
         Ok(tbs)
+    }
+
+    pub async fn estimate_record_count(
+        task_type: &TaskType,
+        url: &str,
+        db_type: &DbType,
+        schemas: &[String],
+        filter: &RdbFilter,
+    ) -> anyhow::Result<u64> {
+        match task_type {
+            TaskType::Snapshot => match db_type {
+                DbType::Mysql => Self::estimate_mysql_snapshot(url, schemas, filter).await,
+                DbType::Pg => Self::estimate_pg_snapshot(url, schemas, filter).await,
+                _ => Ok(0),
+            },
+            _ => Ok(0),
+        }
+    }
+
+    async fn estimate_mysql_snapshot(
+        url: &str,
+        schemas: &[String],
+        filter: &RdbFilter,
+    ) -> anyhow::Result<u64> {
+        let conn_pool = Self::create_mysql_conn_pool(url, 1, false, false).await?;
+
+        let mut sql = String::from("select table_schema, table_name, TABLE_ROWS from information_schema.TABLES where table_type = 'BASE TABLE'");
+        if schemas.len() <= 100 {
+            let sql_with_filter = format!(
+                "{} and table_schema in ({})",
+                sql,
+                schemas
+                    .iter()
+                    .filter(|s| !MYSQL_SYS_DBS.contains(&s.as_str()))
+                    .map(|s| format!("'{}'", s))
+                    .collect::<Vec<_>>()
+                    .join(",")
+            );
+            sql = sql_with_filter;
+        }
+
+        let mut total_records = 0;
+        let mut rows = sqlx::query(&sql).fetch(&conn_pool);
+        while let Some(row) = rows.try_next().await.unwrap() {
+            let schema: String = row.try_get(0)?;
+            let tb: String = row.try_get(1)?;
+            let records: i64 = row.try_get(2)?;
+            if filter.filter_tb(&schema, &tb) {
+                continue;
+            }
+            total_records += if records < 0 { 0 } else { records as u64 };
+        }
+        conn_pool.close().await;
+
+        Ok(total_records)
+    }
+
+    async fn estimate_pg_snapshot(
+        url: &str,
+        schemas: &[String],
+        filter: &RdbFilter,
+    ) -> anyhow::Result<u64> {
+        let conn_pool = TaskUtil::create_pg_conn_pool(url, 1, false, false).await?;
+
+        let mut sql = String::from(
+            "SELECT
+    n.nspname AS schemaname,
+    c.relname AS tablename,
+    c.reltuples::bigint AS row_count
+FROM
+    pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE
+    c.relkind = 'r'
+    AND n.nspname NOT IN ('information_schema', 'pg_catalog')",
+        );
+
+        if schemas.len() <= 100 {
+            let sql_with_filter = format!(
+                "{} AND n.nspname IN ({})",
+                sql,
+                schemas
+                    .iter()
+                    .filter(|s| !PG_SYS_SCHEMAS.contains(&s.as_str()))
+                    .map(|s| format!("'{}'", s))
+                    .collect::<Vec<_>>()
+                    .join(",")
+            );
+            sql = sql_with_filter;
+        }
+
+        let mut total_length = 0;
+        let mut rows = sqlx::query(&sql).fetch(&conn_pool);
+        while let Some(row) = rows.try_next().await.unwrap() {
+            let schema: String = row.try_get(0)?;
+            let table_name: String = row.try_get(1)?;
+            let row_count: i64 = row.try_get(2)?;
+            if filter.filter_tb(&schema, &table_name) {
+                continue;
+            }
+            // Convert to u64, handling negative values (which shouldn't happen but just in case)
+            let row_count_u64 = if row_count < 0 { 0 } else { row_count as u64 };
+            total_length += row_count_u64;
+        }
+        conn_pool.close().await;
+
+        Ok(total_length)
     }
 
     pub async fn check_tb_exist(

--- a/dt-tests/tests/test_runner/rdb_struct_test_runner.rs
+++ b/dt-tests/tests/test_runner/rdb_struct_test_runner.rs
@@ -161,8 +161,8 @@ impl RdbStructTestRunner {
 
                 let src_indexdef = src_indexdef.unwrap();
                 let dst_indexdef = dst_index.get(PG_GET_INDEXDEF).unwrap();
-                let src_ddl_data = parser.parse(src_indexdef).unwrap();
-                let dst_ddl_data = parser.parse(dst_indexdef).unwrap();
+                let src_ddl_data = parser.parse(src_indexdef).unwrap().unwrap();
+                let dst_ddl_data = parser.parse(dst_indexdef).unwrap().unwrap();
 
                 if let DdlStatement::PgCreateIndex(src) = src_ddl_data.statement {
                     assert_eq!(src.schema, src_db_tb.0);

--- a/dt-tests/tests/test_runner/rdb_test_runner.rs
+++ b/dt-tests/tests/test_runner/rdb_test_runner.rs
@@ -855,7 +855,7 @@ impl RdbTestRunner {
                 continue;
             }
 
-            let ddl = parser.parse(&sql).unwrap();
+            let ddl = parser.parse(&sql).unwrap().unwrap();
             if ddl.ddl_type == DdlType::CreateTable {
                 let (mut db, tb) = ddl.get_schema_tb();
                 if db.is_empty() {

--- a/log4rs.yaml
+++ b/log4rs.yaml
@@ -172,6 +172,36 @@ appenders:
         count: 10
         pattern: "LOG_DIR_PLACEHODLER/sql{}.log"
 
+  task_appender:
+    kind: rolling_file
+    path: "LOG_DIR_PLACEHODLER/task.log"
+    encoder:
+      pattern: "{m}{n}"   
+    policy:
+      kind: compound
+      trigger:
+        kind: size
+        limit: 100kb
+      roller:
+        kind: delete    
+
+  http_appender:
+    kind: rolling_file
+    append: true
+    path: "LOG_DIR_PLACEHODLER/http.log"
+    encoder:
+      pattern: "{d(%Y-%m-%d %H:%M:%S.%6f)(utc)} - {level} - [{i}] - {m}{n}"
+    policy:
+      kind: compound
+      trigger:
+        kind: size
+        limit: 100mb
+      roller:
+        kind: fixed_window
+        base: 1
+        count: 10
+        pattern: "LOG_DIR_PLACEHODLER/http{}.log"
+
 loggers:
   mysql_binlog_connector_rust:  # crate: mysql-binlog-connector-rust
     level: LOG_LEVEL_PLACEHODLER
@@ -232,6 +262,32 @@ loggers:
     level: LOG_LEVEL_PLACEHODLER
     appenders: 
       - sql_appender
+
+  task_logger: 
+    level: LOG_LEVEL_PLACEHODLER
+    appenders: 
+      - task_appender
+    additive: false  
+
+  http_logger:
+    level: info
+    appenders:
+      - http_appender
+    additive: false
+
+  actix_web:
+    level: info
+    appenders:
+      - http_appender
+      - stdout
+    additive: false
+      
+  actix_server:
+    level: info  
+    appenders:
+      - http_appender
+      - stdout
+    additive: false  
 
 root:
   level: LOG_LEVEL_PLACEHODLER


### PR DESCRIPTION
provide an optional feature in `dt-main` crate to open a prometheus style metrics api.

can open this feature by:
```
cd dt-main
cargo build --release --features=metrics
```

when enable metrics feature, can set configs by:
  ```
  [metrics]
  # http service host
  http_host=127.0.0.1
  # http service port
  http_port=9090
  # http service worker count
  workers=2
  # prometheus metrics const labels
  labels=your_label1:your_value1,your_label2:your_value2
  ```

and with `curl 127.0.0.1:9090/metrics`, you can get the task metrics