### PR TITLE
fix: decode username and password fields in Redis client authentication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1415,6 +1415,7 @@ dependencies = [
  "mongodb",
  "mysql-binlog-connector-rust",
  "orc-format",
+ "percent-encoding",
  "postgres-protocol",
  "postgres-types",
  "rdkafka",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ actix-web = "4.9.0"
 hex = "0.4.3"
 clickhouse = "0.13.1"
 dashmap = "6.1.0"
+percent-encoding = "2.3.1"
 
 [profile.release]
 panic = 'unwind'

--- a/dt-connector/Cargo.toml
+++ b/dt-connector/Cargo.toml
@@ -48,3 +48,4 @@ orc-format = { workspace = true }
 rust_decimal = { workspace = true }
 hex = { workspace = true }
 clickhouse = { workspace = true }
+percent-encoding = { workspace = true }

--- a/dt-connector/src/extractor/redis/redis_client.rs
+++ b/dt-connector/src/extractor/redis/redis_client.rs
@@ -4,6 +4,7 @@ use async_std::net::TcpStream;
 use async_std::prelude::*;
 use async_trait::async_trait;
 use futures::executor::block_on;
+use percent_encoding::percent_decode;
 use url::Url;
 
 use super::redis_resp_reader::RedisRespReader;
@@ -43,9 +44,12 @@ impl RedisClient {
             let mut cmd = RedisCmd::new();
             cmd.add_str_arg("AUTH");
             if !username.is_empty() {
-                cmd.add_str_arg(username);
+                let decoded_username = percent_decode(username.as_bytes()).decode_utf8()?;
+                cmd.add_str_arg(&decoded_username);
             }
-            cmd.add_str_arg(password);
+
+            let decoded_password = percent_decode(password.as_bytes()).decode_utf8()?;
+            cmd.add_str_arg(&decoded_password);
 
             me.send(&cmd).await?;
             if let Ok(Value::Okay) = me.read().await {
@@ -134,3 +138,4 @@ impl RedisClient {
         Ok(results)
     }
 }
+


### PR DESCRIPTION
This PR addresses a bug where the `RedisClient` fails to authenticate with a Redis server if the connection URL contains a username or password with special, percent-encoded characters (e.g., `@` encoded as `%40`). 

The root cause is that the `username` and `password` fields retrieved from `url::Url::parse()` are the raw, encoded strings from the URL. The client was then attempting to use these encoded credentials directly in the `AUTH` command, which caused the Redis server to reject the authentication attempt due to an incorrect password. 
