### PR TITLE
improve: filter supports raw regex string

### DIFF
--- a/dt-common/src/config/config_token_parser.rs
+++ b/dt-common/src/config/config_token_parser.rs
@@ -4,7 +4,81 @@ use crate::{error::Error, utils::sql_util::SqlUtil};
 
 use super::config_enums::DbType;
 
-const REGEX_ESCAPE_PAIR: (&str, char) = ("r#", '#');
+pub enum TokenEscapePair {
+    Char((char, char)),
+    String((String, String)),
+}
+
+impl Clone for TokenEscapePair {
+    fn clone(&self) -> Self {
+        match self {
+            TokenEscapePair::Char((escape_left, escape_right)) => {
+                TokenEscapePair::Char((escape_left.clone(), escape_right.clone()))
+            }
+            TokenEscapePair::String((escape_left, escape_right)) => {
+                TokenEscapePair::String((escape_left.clone(), escape_right.clone()))
+            }
+        }
+    }
+}
+
+impl TokenEscapePair {
+    pub fn char_to_token_escape_pairs(e: &[(char, char)]) -> Vec<TokenEscapePair> {
+        e.into_iter()
+            .map(|(escape_left, escape_right)| Self::Char((*escape_left, *escape_right)))
+            .collect()
+    }
+
+    pub fn match_escape_left(&self, chars: &[char], start_index: usize) -> bool {
+        match self {
+            TokenEscapePair::Char((escape_left, _)) => {
+                if start_index >= chars.len() {
+                    return false;
+                }
+                if chars[start_index] != *escape_left {
+                    return false;
+                }
+                true
+            }
+            TokenEscapePair::String((escape_left, _)) => {
+                if start_index + escape_left.len() > chars.len() {
+                    return false;
+                }
+                for (i, char_to_match) in escape_left.chars().enumerate() {
+                    if chars[start_index + i] != char_to_match {
+                        return false;
+                    }
+                }
+                true
+            }
+        }
+    }
+
+    pub fn match_escape_right(&self, chars: &[char], start_index: usize) -> bool {
+        match self {
+            TokenEscapePair::Char((_, escape_right)) => {
+                if start_index >= chars.len() {
+                    return false;
+                }
+                if chars[start_index] != *escape_right {
+                    return false;
+                }
+                true
+            }
+            TokenEscapePair::String((_, escape_right)) => {
+                if start_index + escape_right.len() > chars.len() {
+                    return false;
+                }
+                for (i, char_to_match) in escape_right.chars().enumerate() {
+                    if chars[start_index + i] != char_to_match {
+                        return false;
+                    }
+                }
+                true
+            }
+        }
+    }
+}
 
 pub struct ConfigTokenParser {}
 
@@ -13,13 +87,18 @@ impl ConfigTokenParser {
         config_str: &str,
         db_type: &DbType,
         delimiters: &[char],
+        custom_escape_pairs: Option<&[TokenEscapePair]>,
     ) -> anyhow::Result<Vec<String>> {
         if config_str.is_empty() {
             return Ok(Vec::new());
         }
 
         let escape_pairs = SqlUtil::get_escape_pairs(db_type);
-        let tokens = Self::parse(config_str, delimiters, &escape_pairs);
+        let mut token_escape_pairs = TokenEscapePair::char_to_token_escape_pairs(&escape_pairs);
+        if let Some(e) = custom_escape_pairs {
+            token_escape_pairs.extend_from_slice(e);
+        }
+        let tokens = Self::parse(config_str, delimiters, &token_escape_pairs);
         for token in tokens.iter() {
             if !SqlUtil::is_valid_token(token, db_type, &escape_pairs) {
                 bail! {Error::ConfigError(format!(
@@ -31,7 +110,11 @@ impl ConfigTokenParser {
         Ok(tokens)
     }
 
-    pub fn parse(config: &str, delimiters: &[char], escape_pairs: &[(char, char)]) -> Vec<String> {
+    pub fn parse(
+        config: &str,
+        delimiters: &[char],
+        escape_pairs: &[TokenEscapePair],
+    ) -> Vec<String> {
         let chars: Vec<char> = config.chars().collect();
         let mut start_index = 0;
         let mut tokens = Vec::new();
@@ -60,33 +143,15 @@ impl ConfigTokenParser {
         chars: &[char],
         start_index: usize,
         delimiters: &[char],
-        escape_pairs: &[(char, char)],
+        escape_pairs: &[TokenEscapePair],
     ) -> (String, usize) {
         // read token surrounded by escapes: `db.2`
-        for (escape_left, escape_right) in escape_pairs.iter() {
-            if chars[start_index] == *escape_left {
-                return Self::read_token_with_escape(
-                    chars,
-                    start_index,
-                    (*escape_left, *escape_right),
-                );
-            } else if Self::match_prefix(chars, start_index, REGEX_ESCAPE_PAIR.0) {
-                return Self::read_token_with_regex_escape(chars, start_index);
+        for e in escape_pairs.iter() {
+            if e.match_escape_left(chars, start_index) {
+                return Self::read_token_with_escape(chars, start_index, e);
             }
         }
         Self::read_token_to_delimiter(chars, start_index, delimiters)
-    }
-
-    fn match_prefix(chars: &[char], start_index: usize, prefix: &str) -> bool {
-        for (i, c) in prefix.chars().enumerate() {
-            if start_index + i >= chars.len() {
-                return false;
-            }
-            if chars[start_index + i] != c {
-                return false;
-            }
-        }
-        true
     }
 
     fn read_token_to_delimiter(
@@ -112,45 +177,45 @@ impl ConfigTokenParser {
     fn read_token_with_escape(
         chars: &[char],
         start_index: usize,
-        escape_pair: (char, char),
+        escape_pair: &TokenEscapePair,
     ) -> (String, usize) {
-        let mut start = false;
         let mut token = String::new();
         let mut read_count = 0;
-        for c in chars.iter().skip(start_index) {
-            if start && *c == escape_pair.1 {
-                token.push(*c);
-                read_count += 1;
-                break;
+        match escape_pair {
+            TokenEscapePair::Char((escape_left, escape_right)) => {
+                let mut start = false;
+                for c in chars.iter().skip(start_index) {
+                    if start && *c == *escape_right {
+                        token.push(*c);
+                        read_count += 1;
+                        break;
+                    }
+                    if *c == *escape_left {
+                        start = true;
+                    }
+                    if start {
+                        token.push(*c);
+                        read_count += 1;
+                    }
+                }
             }
-            if *c == escape_pair.0 {
-                start = true;
-            }
-            if start {
-                token.push(*c);
-                read_count += 1;
+            TokenEscapePair::String((escape_left, _)) => {
+                let prefix_len = escape_left.len();
+                for c in chars.iter().skip(start_index) {
+                    token.push(*c);
+                    read_count += 1;
+                    if read_count > prefix_len
+                        && escape_pair.match_escape_right(&chars, start_index + read_count - 1)
+                    {
+                        break;
+                    }
+                }
             }
         }
 
         // when there are emojs in the token, the read_count may be less than token.len(), for example:
         // in chars, 😀 only takes 1 slot, which is '\u{1f600}'
         // in token, 😀 takes 4 slots, which are: 240, 159, 152, 128
-        let next_index = start_index + read_count;
-        (token, next_index)
-    }
-
-    fn read_token_with_regex_escape(chars: &[char], start_index: usize) -> (String, usize) {
-        let mut token = String::new();
-        let prefix_len = REGEX_ESCAPE_PAIR.0.len();
-        let mut read_count = 0;
-        for c in chars.iter().skip(start_index) {
-            token.push(*c);
-            read_count += 1;
-            if read_count > prefix_len && *c == REGEX_ESCAPE_PAIR.1 {
-                break;
-            }
-        }
-
         let next_index = start_index + read_count;
         (token, next_index)
     }
@@ -165,7 +230,10 @@ mod tests {
     fn test_parse_mysql_filter_config_tokens() {
         let config = r#"db_1.tb_1,`db.2`.`tb.2`,`db"3`.tb_3,db_4.`tb"4`,db_5.*,`db.6`.*,db_7*.*,`db.8*`.*,*.*,`*`.`*`,r#.*#.r#.?#,`r#.*#`.`r#.?#`"#;
         let delimiters = vec!['.', ','];
-        let escape_pairs = vec![('`', '`')];
+        let escape_pairs = vec![
+            TokenEscapePair::Char(('`', '`')),
+            TokenEscapePair::String(("r#".to_string(), '#'.to_string())),
+        ];
 
         let tokens = ConfigTokenParser::parse(config, &delimiters, &escape_pairs);
         assert_eq!(tokens.len(), 24);
@@ -199,7 +267,7 @@ mod tests {
     fn test_parse_mysql_router_config_tokens() {
         let config = r#"db_1.tb_1:`db.2`.`tb.2`,`db"3`.tb_3:db_4.`tb"4`"#;
         let delimiters = vec!['.', ',', ':'];
-        let escape_pairs = vec![('`', '`')];
+        let escape_pairs = vec![TokenEscapePair::Char(('`', '`'))];
 
         let tokens = ConfigTokenParser::parse(config, &delimiters, &escape_pairs);
         assert_eq!(tokens.len(), 8);
@@ -215,12 +283,15 @@ mod tests {
 
     #[test]
     fn test_parse_pg_filter_config_tokens() {
-        let config = r#"db_1.tb_1,"db.2"."tb.2","db`3".tb_3,db_4."tb`4",db_5.*,"db.6".*,db_7*.*,"db.8*".*,*.*,"*"."*""#;
+        let config = r#"db_1.tb_1,"db.2"."tb.2","db`3".tb_3,db_4."tb`4",db_5.*,"db.6".*,db_7*.*,"db.8*".*,*.*,"*"."*",r#.*#.r#.?#,"r#.*#"."r#.?#""#;
         let delimiters = vec!['.', ','];
-        let escape_pairs = vec![('"', '"')];
+        let escape_pairs = vec![
+            TokenEscapePair::Char(('"', '"')),
+            TokenEscapePair::String(("r#".to_string(), '#'.to_string())),
+        ];
 
         let tokens = ConfigTokenParser::parse(config, &delimiters, &escape_pairs);
-        assert_eq!(tokens.len(), 20);
+        assert_eq!(tokens.len(), 24);
         assert_eq!(tokens[0], "db_1");
         assert_eq!(tokens[1], "tb_1");
         assert_eq!(tokens[2], r#""db.2""#);
@@ -241,13 +312,17 @@ mod tests {
         assert_eq!(tokens[17], "*");
         assert_eq!(tokens[18], r#""*""#);
         assert_eq!(tokens[19], r#""*""#);
+        assert_eq!(tokens[20], "r#.*#");
+        assert_eq!(tokens[21], "r#.?#");
+        assert_eq!(tokens[22], r#""r#.*#""#);
+        assert_eq!(tokens[23], r#""r#.?#""#);
     }
 
     #[test]
     fn test_parse_pg_router_config_tokens() {
         let config = r#"db_1.tb_1:"db.2"."tb.2","db`3".tb_3:db_4."tb`4""#;
         let delimiters = vec!['.', ',', ':'];
-        let escape_pairs = vec![('"', '"')];
+        let escape_pairs = vec![TokenEscapePair::Char(('"', '"'))];
 
         let tokens = ConfigTokenParser::parse(config, &delimiters, &escape_pairs);
         assert_eq!(tokens.len(), 8);
@@ -265,7 +340,7 @@ mod tests {
     fn test_parse_emoj_config_tokens() {
         let config = r#"SET "set_key_3_  😀" "val_2_  😀""#;
         let delimiters = vec![' '];
-        let escape_pairs = vec![('"', '"')];
+        let escape_pairs = vec![TokenEscapePair::Char(('"', '"'))];
         let tokens = ConfigTokenParser::parse(config, &delimiters, &escape_pairs);
         assert_eq!(tokens.len(), 3);
         assert_eq!(tokens[0], "SET");

--- a/dt-common/src/config/config_token_parser.rs
+++ b/dt-common/src/config/config_token_parser.rs
@@ -4,22 +4,10 @@ use crate::{error::Error, utils::sql_util::SqlUtil};
 
 use super::config_enums::DbType;
 
+#[derive(Debug, Clone)]
 pub enum TokenEscapePair {
     Char((char, char)),
     String((String, String)),
-}
-
-impl Clone for TokenEscapePair {
-    fn clone(&self) -> Self {
-        match self {
-            TokenEscapePair::Char((escape_left, escape_right)) => {
-                TokenEscapePair::Char((escape_left.clone(), escape_right.clone()))
-            }
-            TokenEscapePair::String((escape_left, escape_right)) => {
-                TokenEscapePair::String((escape_left.clone(), escape_right.clone()))
-            }
-        }
-    }
 }
 
 impl TokenEscapePair {

--- a/dt-common/src/config/config_token_parser.rs
+++ b/dt-common/src/config/config_token_parser.rs
@@ -10,11 +10,21 @@ pub enum TokenEscapePair {
     String((String, String)),
 }
 
+impl From<(char, char)> for TokenEscapePair {
+    fn from(value: (char, char)) -> Self {
+        Self::Char(value)
+    }
+}
+
+impl From<(String, String)> for TokenEscapePair {
+    fn from(value: (String, String)) -> Self {
+        Self::String(value)
+    }
+}
+
 impl TokenEscapePair {
-    pub fn char_to_token_escape_pairs(e: &[(char, char)]) -> Vec<TokenEscapePair> {
-        e.into_iter()
-            .map(|(escape_left, escape_right)| Self::Char((*escape_left, *escape_right)))
-            .collect()
+    pub fn from_char_pairs(char_pairs: Vec<(char, char)>) -> Vec<Self> {
+        char_pairs.into_iter().map(|e| Self::from(e)).collect()
     }
 
     pub fn match_escape_left(&self, chars: &[char], start_index: usize) -> bool {
@@ -67,9 +77,9 @@ impl ConfigTokenParser {
         }
 
         let escape_pairs = SqlUtil::get_escape_pairs(db_type);
-        let mut token_escape_pairs = TokenEscapePair::char_to_token_escape_pairs(&escape_pairs);
-        if let Some(e) = custom_escape_pairs {
-            token_escape_pairs.extend_from_slice(e);
+        let mut token_escape_pairs = TokenEscapePair::from_char_pairs(escape_pairs.clone());
+        if let Some(pairs) = custom_escape_pairs {
+            token_escape_pairs.extend_from_slice(pairs);
         }
         let tokens = Self::parse(config_str, delimiters, &token_escape_pairs);
         for token in tokens.iter() {

--- a/dt-common/src/config/config_token_parser.rs
+++ b/dt-common/src/config/config_token_parser.rs
@@ -18,46 +18,31 @@ impl TokenEscapePair {
     }
 
     pub fn match_escape_left(&self, chars: &[char], start_index: usize) -> bool {
-        match self {
-            TokenEscapePair::Char((escape_left, _)) => {
-                if start_index >= chars.len() {
-                    return false;
-                }
-                if chars[start_index] != *escape_left {
-                    return false;
-                }
-                true
-            }
-            TokenEscapePair::String((escape_left, _)) => {
-                if start_index + escape_left.len() > chars.len() {
-                    return false;
-                }
-                for (i, char_to_match) in escape_left.chars().enumerate() {
-                    if chars[start_index + i] != char_to_match {
-                        return false;
-                    }
-                }
-                true
-            }
-        }
+        self.match_escape_side(chars, start_index, true)
     }
 
     pub fn match_escape_right(&self, chars: &[char], start_index: usize) -> bool {
+        self.match_escape_side(chars, start_index, false)
+    }
+
+    fn match_escape_side(&self, chars: &[char], start_index: usize, is_left: bool) -> bool {
         match self {
-            TokenEscapePair::Char((_, escape_right)) => {
+            TokenEscapePair::Char((escape_left, escape_right)) => {
+                let escape = if is_left { escape_left } else { escape_right };
                 if start_index >= chars.len() {
                     return false;
                 }
-                if chars[start_index] != *escape_right {
+                if chars[start_index] != *escape {
                     return false;
                 }
                 true
             }
-            TokenEscapePair::String((_, escape_right)) => {
-                if start_index + escape_right.len() > chars.len() {
+            TokenEscapePair::String((escape_left, escape_right)) => {
+                let escape = if is_left { escape_left } else { escape_right };
+                if start_index + escape.len() > chars.len() {
                     return false;
                 }
-                for (i, char_to_match) in escape_right.chars().enumerate() {
+                for (i, char_to_match) in escape.chars().enumerate() {
                     if chars[start_index + i] != char_to_match {
                         return false;
                     }

--- a/dt-common/src/rdb_filter.rs
+++ b/dt-common/src/rdb_filter.rs
@@ -159,7 +159,7 @@ impl RdbFilter {
                 return false;
             }
         }
-        pattern.contains("*") || pattern.contains("?") || pattern.starts_with("r#")
+        pattern.contains("*") || pattern.contains("?") || pattern.starts_with(REGEX_ESCAPE_PAIR.0)
     }
 
     fn match_all(set: &HashSet<String>) -> bool {

--- a/dt-common/src/rdb_filter.rs
+++ b/dt-common/src/rdb_filter.rs
@@ -246,7 +246,7 @@ impl RdbFilter {
 
     fn parse_config(config_str: &str, db_type: &DbType) -> anyhow::Result<Vec<String>> {
         let delimiters = vec![',', '.'];
-        let custom_escape_pairs = vec![TokenEscapePair::String((
+        let custom_escape_pairs = vec![TokenEscapePair::from((
             REGEX_ESCAPE_PAIR.0.to_string(),
             REGEX_ESCAPE_PAIR.1.to_string(),
         ))];

--- a/dt-common/src/rdb_filter.rs
+++ b/dt-common/src/rdb_filter.rs
@@ -155,7 +155,7 @@ impl RdbFilter {
                 return false;
             }
         }
-        pattern.contains("*") || pattern.contains("?")
+        pattern.contains("*") || pattern.contains("?") || pattern.starts_with("r#")
     }
 
     fn match_all(set: &HashSet<String>) -> bool {
@@ -195,13 +195,20 @@ impl RdbFilter {
                 return pattern == SqlUtil::escape(item, escape_pair);
             }
         }
-        // only support 2 wildchars : '*' and '?', '.' is NOT supported
-        // * : matching multiple chars
-        // ? : for matching 0-1 chars
-        let mut pattern = pattern
+        
+        let mut pattern = pattern.to_string();
+        if pattern.starts_with("r#") {
+            // support raw regex strings starting with `r#`.
+            pattern = pattern.trim_start_matches("r#").to_string();
+        } else {
+            // only support 2 wildchars : '*' and '?', '.' is NOT supported
+            // * : matching multiple chars
+            // ? : for matching 0-1 chars
+            pattern = pattern
             .replace('.', "\\.")
             .replace('*', ".*")
             .replace('?', ".?");
+        }
         pattern = format!(r"^{}$", pattern);
 
         Regex::new(&pattern)
@@ -325,6 +332,15 @@ mod tests {
         assert!(!RdbFilter::match_token("h.llo", "he.llo", &escape_pairs));
         assert!(!RdbFilter::match_token("h.llo", "h.lo", &escape_pairs));
         assert!(!RdbFilter::match_token("h.llo", "hello", &escape_pairs));
+
+        // match with raw regex strings starting with `r#`
+        assert!(RdbFilter::match_token("r#hello", "hello", &escape_pairs));
+        assert!(RdbFilter::match_token("r#he?llo", "hllo", &escape_pairs));
+        assert!(RdbFilter::match_token("r#he?llo", "hello", &escape_pairs));
+        assert!(RdbFilter::match_token("r#he*llo", "hllo", &escape_pairs));
+        assert!(RdbFilter::match_token("r#he*llo", "heeeeeeeello", &escape_pairs));
+        assert!(RdbFilter::match_token("r#h.?llo", "htllo", &escape_pairs));
+        assert!(RdbFilter::match_token("r#h.*llo", "htestllo", &escape_pairs));
     }
 
     #[test]
@@ -376,6 +392,24 @@ mod tests {
         ));
         assert!(!RdbFilter::match_token("`h.llo`", "`h.lo`", &escape_pairs));
         assert!(!RdbFilter::match_token("`h.llo`", "`hello`", &escape_pairs));
+
+        // match with strings starting with `r#`, should also be exactly match
+        assert!(RdbFilter::match_token("`r#hello`", "r#hello", &escape_pairs));
+        assert!(!RdbFilter::match_token("`r#hello`", "hello", &escape_pairs));
+
+        assert!(RdbFilter::match_token("`r#he?llo`", "r#he?llo", &escape_pairs));
+        assert!(!RdbFilter::match_token("`r#he?llo`", "hllo", &escape_pairs));
+        assert!(!RdbFilter::match_token("`r#he?llo`", "hello", &escape_pairs));
+
+        assert!(RdbFilter::match_token("`r#he*llo`", "r#he*llo", &escape_pairs));
+        assert!(!RdbFilter::match_token("`r#he*llo`", "hllo", &escape_pairs));
+        assert!(!RdbFilter::match_token("`r#he*llo`", "heeeeeeeello", &escape_pairs));
+
+        assert!(RdbFilter::match_token("`r#h.?llo`", "r#h.?llo", &escape_pairs));
+        assert!(!RdbFilter::match_token("`r#h.?llo`", "htllo", &escape_pairs));
+
+        assert!(RdbFilter::match_token("`r#h.*llo`", "r#h.*llo", &escape_pairs));
+        assert!(!RdbFilter::match_token("`r#h.*llo`", "htestllo", &escape_pairs));
     }
 
     #[test]
@@ -463,6 +497,24 @@ mod tests {
             r#""hello""#,
             &escape_pairs
         ));
+
+        // match with raw regex strings starting with `r#`, should also be exactly match
+        assert!(RdbFilter::match_token(r#""r#hello""#, r#""r#hello""#, &escape_pairs));
+        assert!(!RdbFilter::match_token(r#""r#hello""#, "hello", &escape_pairs));
+
+        assert!(RdbFilter::match_token(r#""r#he?llo""#, r#""r#he?llo""#, &escape_pairs));
+        assert!(!RdbFilter::match_token(r#""r#he?llo""#, "hllo", &escape_pairs));
+        assert!(!RdbFilter::match_token(r#""r#he?llo""#, "hello", &escape_pairs));
+
+        assert!(RdbFilter::match_token(r#""r#he*llo""#, r#""r#he*llo""#, &escape_pairs));
+        assert!(!RdbFilter::match_token(r#""r#he*llo""#, "hllo", &escape_pairs));
+        assert!(!RdbFilter::match_token(r#""r#he*llo""#, "heeeeeello", &escape_pairs));
+
+        assert!(RdbFilter::match_token(r#""r#h.?llo""#, r#""r#h.?llo""#, &escape_pairs));
+        assert!(!RdbFilter::match_token(r#""r#h.?llo""#, "htllo", &escape_pairs));
+
+        assert!(RdbFilter::match_token(r#""r#h.*llo""#, r#""r#h.*llo""#, &escape_pairs));
+        assert!(!RdbFilter::match_token(r#""r#h.*llo""#, "htestllo", &escape_pairs));
     }
 
     #[test]

--- a/dt-common/src/rdb_filter.rs
+++ b/dt-common/src/rdb_filter.rs
@@ -197,10 +197,7 @@ impl RdbFilter {
         }
 
         let mut pattern = pattern.to_string();
-        if pattern.starts_with("r#") {
-            // support raw regex strings starting with `r#`.
-            pattern = pattern.trim_start_matches("r#").to_string();
-        } else {
+        if !pattern.starts_with("r#") {
             // only support 2 wildchars : '*' and '?', '.' is NOT supported
             // * : matching multiple chars
             // ? : for matching 0-1 chars
@@ -208,6 +205,9 @@ impl RdbFilter {
                 .replace('.', "\\.")
                 .replace('*', ".*")
                 .replace('?', ".?");
+        } else {
+            // support raw regex strings starting with `r#`.
+            pattern.drain(..2);
         }
         pattern = format!(r"^{}$", pattern);
 

--- a/dt-common/src/rdb_filter.rs
+++ b/dt-common/src/rdb_filter.rs
@@ -195,7 +195,7 @@ impl RdbFilter {
                 return pattern == SqlUtil::escape(item, escape_pair);
             }
         }
-        
+
         let mut pattern = pattern.to_string();
         if pattern.starts_with("r#") {
             // support raw regex strings starting with `r#`.
@@ -205,9 +205,9 @@ impl RdbFilter {
             // * : matching multiple chars
             // ? : for matching 0-1 chars
             pattern = pattern
-            .replace('.', "\\.")
-            .replace('*', ".*")
-            .replace('?', ".?");
+                .replace('.', "\\.")
+                .replace('*', ".*")
+                .replace('?', ".?");
         }
         pattern = format!(r"^{}$", pattern);
 
@@ -338,9 +338,17 @@ mod tests {
         assert!(RdbFilter::match_token("r#he?llo", "hllo", &escape_pairs));
         assert!(RdbFilter::match_token("r#he?llo", "hello", &escape_pairs));
         assert!(RdbFilter::match_token("r#he*llo", "hllo", &escape_pairs));
-        assert!(RdbFilter::match_token("r#he*llo", "heeeeeeeello", &escape_pairs));
+        assert!(RdbFilter::match_token(
+            "r#he*llo",
+            "heeeeeeeello",
+            &escape_pairs
+        ));
         assert!(RdbFilter::match_token("r#h.?llo", "htllo", &escape_pairs));
-        assert!(RdbFilter::match_token("r#h.*llo", "htestllo", &escape_pairs));
+        assert!(RdbFilter::match_token(
+            "r#h.*llo",
+            "htestllo",
+            &escape_pairs
+        ));
     }
 
     #[test]
@@ -394,22 +402,58 @@ mod tests {
         assert!(!RdbFilter::match_token("`h.llo`", "`hello`", &escape_pairs));
 
         // match with strings starting with `r#`, should also be exactly match
-        assert!(RdbFilter::match_token("`r#hello`", "r#hello", &escape_pairs));
+        assert!(RdbFilter::match_token(
+            "`r#hello`",
+            "r#hello",
+            &escape_pairs
+        ));
         assert!(!RdbFilter::match_token("`r#hello`", "hello", &escape_pairs));
 
-        assert!(RdbFilter::match_token("`r#he?llo`", "r#he?llo", &escape_pairs));
+        assert!(RdbFilter::match_token(
+            "`r#he?llo`",
+            "r#he?llo",
+            &escape_pairs
+        ));
         assert!(!RdbFilter::match_token("`r#he?llo`", "hllo", &escape_pairs));
-        assert!(!RdbFilter::match_token("`r#he?llo`", "hello", &escape_pairs));
+        assert!(!RdbFilter::match_token(
+            "`r#he?llo`",
+            "hello",
+            &escape_pairs
+        ));
 
-        assert!(RdbFilter::match_token("`r#he*llo`", "r#he*llo", &escape_pairs));
+        assert!(RdbFilter::match_token(
+            "`r#he*llo`",
+            "r#he*llo",
+            &escape_pairs
+        ));
         assert!(!RdbFilter::match_token("`r#he*llo`", "hllo", &escape_pairs));
-        assert!(!RdbFilter::match_token("`r#he*llo`", "heeeeeeeello", &escape_pairs));
+        assert!(!RdbFilter::match_token(
+            "`r#he*llo`",
+            "heeeeeeeello",
+            &escape_pairs
+        ));
 
-        assert!(RdbFilter::match_token("`r#h.?llo`", "r#h.?llo", &escape_pairs));
-        assert!(!RdbFilter::match_token("`r#h.?llo`", "htllo", &escape_pairs));
+        assert!(RdbFilter::match_token(
+            "`r#h.?llo`",
+            "r#h.?llo",
+            &escape_pairs
+        ));
+        assert!(!RdbFilter::match_token(
+            "`r#h.?llo`",
+            "htllo",
+            &escape_pairs
+        ));
 
-        assert!(RdbFilter::match_token("`r#h.*llo`", "r#h.*llo", &escape_pairs));
-        assert!(!RdbFilter::match_token("`r#h.*llo`", "htestllo", &escape_pairs));
+        assert!(RdbFilter::match_token(
+            "`r#h.*llo`",
+            "r#h.*llo",
+            &escape_pairs
+        ));
+        assert!(!RdbFilter::match_token(
+            "`r#h.*llo`",
+            "htestllo",
+            &escape_pairs
+        ));
     }
 
     #[test]
@@ -499,22 +543,70 @@ mod tests {
         ));
 
         // match with raw regex strings starting with `r#`, should also be exactly match
-        assert!(RdbFilter::match_token(r#""r#hello""#, r#""r#hello""#, &escape_pairs));
-        assert!(!RdbFilter::match_token(r#""r#hello""#, "hello", &escape_pairs));
+        assert!(RdbFilter::match_token(
+            r#""r#hello""#,
+            r#""r#hello""#,
+            &escape_pairs
+        ));
+        assert!(!RdbFilter::match_token(
+            r#""r#hello""#,
+            "hello",
+            &escape_pairs
+        ));
 
-        assert!(RdbFilter::match_token(r#""r#he?llo""#, r#""r#he?llo""#, &escape_pairs));
-        assert!(!RdbFilter::match_token(r#""r#he?llo""#, "hllo", &escape_pairs));
-        assert!(!RdbFilter::match_token(r#""r#he?llo""#, "hello", &escape_pairs));
+        assert!(RdbFilter::match_token(
+            r#""r#he?llo""#,
+            r#""r#he?llo""#,
+            &escape_pairs
+        ));
+        assert!(!RdbFilter::match_token(
+            r#""r#he?llo""#,
+            "hllo",
+            &escape_pairs
+        ));
+        assert!(!RdbFilter::match_token(
+            r#""r#he?llo""#,
+            "hello",
+            &escape_pairs
+        ));
 
-        assert!(RdbFilter::match_token(r#""r#he*llo""#, r#""r#he*llo""#, &escape_pairs));
-        assert!(!RdbFilter::match_token(r#""r#he*llo""#, "hllo", &escape_pairs));
-        assert!(!RdbFilter::match_token(r#""r#he*llo""#, "heeeeeello", &escape_pairs));
+        assert!(RdbFilter::match_token(
+            r#""r#he*llo""#,
+            r#""r#he*llo""#,
+            &escape_pairs
+        ));
+        assert!(!RdbFilter::match_token(
+            r#""r#he*llo""#,
+            "hllo",
+            &escape_pairs
+        ));
+        assert!(!RdbFilter::match_token(
+            r#""r#he*llo""#,
+            "heeeeeello",
+            &escape_pairs
+        ));
 
-        assert!(RdbFilter::match_token(r#""r#h.?llo""#, r#""r#h.?llo""#, &escape_pairs));
-        assert!(!RdbFilter::match_token(r#""r#h.?llo""#, "htllo", &escape_pairs));
+        assert!(RdbFilter::match_token(
+            r#""r#h.?llo""#,
+            r#""r#h.?llo""#,
+            &escape_pairs
+        ));
+        assert!(!RdbFilter::match_token(
+            r#""r#h.?llo""#,
+            "htllo",
+            &escape_pairs
+        ));
 
-        assert!(RdbFilter::match_token(r#""r#h.*llo""#, r#""r#h.*llo""#, &escape_pairs));
-        assert!(!RdbFilter::match_token(r#""r#h.*llo""#, "htestllo", &escape_pairs));
+        assert!(RdbFilter::match_token(
+            r#""r#h.*llo""#,
+            r#""r#h.*llo""#,
+            &escape_pairs
+        ));
+        assert!(!RdbFilter::match_token(
+            r#""r#h.*llo""#,
+            "htestllo",
+            &escape_pairs
+        ));
     }
 
     #[test]

--- a/dt-connector/src/extractor/base_extractor.rs
+++ b/dt-connector/src/extractor/base_extractor.rs
@@ -231,7 +231,7 @@ impl BaseExtractor {
         let schema_tb = ConfigTokenParser::parse(
             heartbeat_tb,
             &['.'],
-            &TokenEscapePair::char_to_token_escape_pairs(&SqlUtil::get_escape_pairs(&db_type)),
+            &TokenEscapePair::from_char_pairs(SqlUtil::get_escape_pairs(&db_type)),
         );
 
         if schema_tb.len() < 2 {

--- a/dt-connector/src/extractor/base_extractor.rs
+++ b/dt-connector/src/extractor/base_extractor.rs
@@ -6,7 +6,10 @@ use std::sync::{
 use anyhow::bail;
 
 use dt_common::{
-    config::{config_enums::DbType, config_token_parser::ConfigTokenParser},
+    config::{
+        config_enums::DbType,
+        config_token_parser::{ConfigTokenParser, TokenEscapePair},
+    },
     error::Error,
     log_debug, log_error, log_info, log_warn,
     meta::{
@@ -225,8 +228,11 @@ impl BaseExtractor {
             return vec![];
         }
 
-        let schema_tb =
-            ConfigTokenParser::parse(heartbeat_tb, &['.'], &SqlUtil::get_escape_pairs(&db_type));
+        let schema_tb = ConfigTokenParser::parse(
+            heartbeat_tb,
+            &['.'],
+            &TokenEscapePair::char_to_token_escape_pairs(&SqlUtil::get_escape_pairs(&db_type)),
+        );
 
         if schema_tb.len() < 2 {
             log_warn!("heartbeat disabled, heartbeat_tb should be like schema.tb");

--- a/dt-connector/src/extractor/pg/pg_cdc_extractor.rs
+++ b/dt-connector/src/extractor/pg/pg_cdc_extractor.rs
@@ -116,7 +116,8 @@ impl PgCdcExtractor {
         tokio::pin!(stream);
 
         // setup ddl capture
-        let ddl_meta = ConfigTokenParser::parse_config(&self.ddl_meta_tb, &DbType::Pg, &['.'])?;
+        let ddl_meta =
+            ConfigTokenParser::parse_config(&self.ddl_meta_tb, &DbType::Pg, &['.'], None)?;
         if ddl_meta.len() == 2 {
             self.filter.add_do_tb(&ddl_meta[0], &ddl_meta[1]);
         }

--- a/dt-connector/src/extractor/redis/redis_psync_extractor.rs
+++ b/dt-connector/src/extractor/redis/redis_psync_extractor.rs
@@ -221,9 +221,7 @@ impl RedisPsyncExtractor {
         let heartbeat_db_key = ConfigTokenParser::parse(
             &self.heartbeat_key,
             &['.'],
-            &TokenEscapePair::char_to_token_escape_pairs(&SqlUtil::get_escape_pairs(
-                &DbType::Redis,
-            )),
+            &TokenEscapePair::from_char_pairs(SqlUtil::get_escape_pairs(&DbType::Redis)),
         );
         let heartbeat_db_id = if heartbeat_db_key.len() == 2 {
             heartbeat_db_key[0].parse()?

--- a/dt-connector/src/extractor/redis/redis_psync_extractor.rs
+++ b/dt-connector/src/extractor/redis/redis_psync_extractor.rs
@@ -15,7 +15,7 @@ use crate::extractor::redis::StreamReader;
 use crate::extractor::resumer::cdc_resumer::CdcResumer;
 use crate::Extractor;
 use dt_common::config::config_enums::{DbType, ExtractType};
-use dt_common::config::config_token_parser::ConfigTokenParser;
+use dt_common::config::config_token_parser::{ConfigTokenParser, TokenEscapePair};
 use dt_common::meta::dt_data::DtData;
 use dt_common::meta::position::Position;
 use dt_common::meta::redis::redis_entry::RedisEntry;
@@ -221,7 +221,9 @@ impl RedisPsyncExtractor {
         let heartbeat_db_key = ConfigTokenParser::parse(
             &self.heartbeat_key,
             &['.'],
-            &SqlUtil::get_escape_pairs(&DbType::Redis),
+            &TokenEscapePair::char_to_token_escape_pairs(&SqlUtil::get_escape_pairs(
+                &DbType::Redis,
+            )),
         );
         let heartbeat_db_id = if heartbeat_db_key.len() == 2 {
             heartbeat_db_key[0].parse()?

--- a/dt-connector/src/meta_fetcher/pg/pg_struct_fetcher.rs
+++ b/dt-connector/src/meta_fetcher/pg/pg_struct_fetcher.rs
@@ -1039,7 +1039,7 @@ impl PgStructFetcher {
             .trim_end_matches('\'');
 
         let escape_pair = SqlUtil::get_escape_pairs(&DbType::Pg)[0];
-        if let Ok(tokens) = ConfigTokenParser::parse_config(value, &DbType::Pg, &['.']) {
+        if let Ok(tokens) = ConfigTokenParser::parse_config(value, &DbType::Pg, &['.'], None) {
             if tokens.len() == 1 {
                 return (String::new(), SqlUtil::unescape(&tokens[0], &escape_pair));
             } else if tokens.len() == 2 {

--- a/dt-connector/src/rdb_router.rs
+++ b/dt-connector/src/rdb_router.rs
@@ -285,7 +285,7 @@ impl RdbRouter {
 
     fn parse_config(config_str: &str, db_type: &DbType) -> anyhow::Result<Vec<String>> {
         let delimiters = vec![',', '.', ':'];
-        let tokens = ConfigTokenParser::parse_config(config_str, db_type, &delimiters)?;
+        let tokens = ConfigTokenParser::parse_config(config_str, db_type, &delimiters, None)?;
         let escape_pairs = SqlUtil::get_escape_pairs(db_type);
         let mut results = Vec::new();
         for t in tokens {

--- a/dt-task/src/task_runner.rs
+++ b/dt-task/src/task_runner.rs
@@ -767,7 +767,7 @@ impl TaskRunner {
             | ExtractorConfig::PgCdc { heartbeat_tb, .. } => ConfigTokenParser::parse(
                 heartbeat_tb,
                 &['.'],
-                &TokenEscapePair::char_to_token_escape_pairs(&SqlUtil::get_escape_pairs(
+                &TokenEscapePair::from_char_pairs(SqlUtil::get_escape_pairs(
                     &self.config.extractor_basic.db_type,
                 )),
             ),

--- a/dt-task/src/task_runner.rs
+++ b/dt-task/src/task_runner.rs
@@ -22,7 +22,7 @@ use crate::task_util::TaskUtil;
 use dt_common::{
     config::{
         config_enums::{build_task_type, DbType, PipelineType},
-        config_token_parser::ConfigTokenParser,
+        config_token_parser::{ConfigTokenParser, TokenEscapePair},
         extractor_config::ExtractorConfig,
         sinker_config::SinkerConfig,
         task_config::TaskConfig,
@@ -767,7 +767,9 @@ impl TaskRunner {
             | ExtractorConfig::PgCdc { heartbeat_tb, .. } => ConfigTokenParser::parse(
                 heartbeat_tb,
                 &['.'],
-                &SqlUtil::get_escape_pairs(&self.config.extractor_basic.db_type),
+                &TokenEscapePair::char_to_token_escape_pairs(&SqlUtil::get_escape_pairs(
+                    &self.config.extractor_basic.db_type,
+                )),
             ),
             _ => vec![],
         };

--- a/dt-tests/tests/test_runner/rdb_test_runner.rs
+++ b/dt-tests/tests/test_runner/rdb_test_runner.rs
@@ -404,7 +404,7 @@ impl RdbTestRunner {
         let tokens = ConfigTokenParser::parse(
             &heartbeat_tb,
             &['.'],
-            &TokenEscapePair::char_to_token_escape_pairs(&SqlUtil::get_escape_pairs(&db_type)),
+            &TokenEscapePair::from_char_pairs(SqlUtil::get_escape_pairs(&db_type)),
         );
         let db_tb = (tokens[0].clone(), tokens[1].clone());
 
@@ -811,7 +811,7 @@ impl RdbTestRunner {
         let tokens = ConfigTokenParser::parse(
             full_tb_name,
             &['.'],
-            &TokenEscapePair::char_to_token_escape_pairs(&escape_pairs),
+            &TokenEscapePair::from_char_pairs(escape_pairs.clone()),
         );
         let (db, tb) = if tokens.len() > 1 {
             (tokens[0].to_string(), tokens[1].to_string())

--- a/dt-tests/tests/test_runner/rdb_test_runner.rs
+++ b/dt-tests/tests/test_runner/rdb_test_runner.rs
@@ -3,9 +3,12 @@ use std::{collections::HashSet, str::FromStr};
 use chrono::{Duration, Utc};
 use dt_common::{
     config::{
-        config_enums::DbType, config_token_parser::ConfigTokenParser,
-        extractor_config::ExtractorConfig, meta_center_config::MetaCenterConfig,
-        sinker_config::SinkerConfig, task_config::TaskConfig,
+        config_enums::DbType,
+        config_token_parser::{ConfigTokenParser, TokenEscapePair},
+        extractor_config::ExtractorConfig,
+        meta_center_config::MetaCenterConfig,
+        sinker_config::SinkerConfig,
+        task_config::TaskConfig,
     },
     meta::{ddl_meta::ddl_type::DdlType, time::dt_utc_time::DtNaiveTime},
     rdb_filter::RdbFilter,
@@ -398,8 +401,11 @@ impl RdbTestRunner {
             _ => (String::new(), DbType::Mysql),
         };
 
-        let tokens =
-            ConfigTokenParser::parse(&heartbeat_tb, &['.'], &SqlUtil::get_escape_pairs(&db_type));
+        let tokens = ConfigTokenParser::parse(
+            &heartbeat_tb,
+            &['.'],
+            &TokenEscapePair::char_to_token_escape_pairs(&SqlUtil::get_escape_pairs(&db_type)),
+        );
         let db_tb = (tokens[0].clone(), tokens[1].clone());
 
         self.execute_prepare_sqls().await?;
@@ -802,7 +808,11 @@ impl RdbTestRunner {
 
     pub fn parse_full_tb_name(full_tb_name: &str, db_type: &DbType) -> (String, String) {
         let escape_pairs = SqlUtil::get_escape_pairs(db_type);
-        let tokens = ConfigTokenParser::parse(full_tb_name, &['.'], &escape_pairs);
+        let tokens = ConfigTokenParser::parse(
+            full_tb_name,
+            &['.'],
+            &TokenEscapePair::char_to_token_escape_pairs(&escape_pairs),
+        );
         let (db, tb) = if tokens.len() > 1 {
             (tokens[0].to_string(), tokens[1].to_string())
         } else {
@@ -878,7 +888,8 @@ impl RdbTestRunner {
         if BaseTestRunner::check_path_exists(&filtered_tbs_file) {
             let lines = BaseTestRunner::load_file(&filtered_tbs_file);
             for line in lines.iter() {
-                let db_tb = ConfigTokenParser::parse_config(line, db_type, &delimiters).unwrap();
+                let db_tb =
+                    ConfigTokenParser::parse_config(line, db_type, &delimiters, None).unwrap();
                 if db_tb.len() == 2 {
                     let db = SqlUtil::unescape(&db_tb[0], &escape_pairs[0]);
                     let tb = SqlUtil::unescape(&db_tb[1], &escape_pairs[0]);

--- a/dt-tests/tests/test_runner/redis_test_runner.rs
+++ b/dt-tests/tests/test_runner/redis_test_runner.rs
@@ -4,8 +4,11 @@ use super::{base_test_runner::BaseTestRunner, redis_cluster_connection::RedisClu
 use anyhow::bail;
 use dt_common::{
     config::{
-        config_enums::DbType, config_token_parser::ConfigTokenParser,
-        extractor_config::ExtractorConfig, sinker_config::SinkerConfig, task_config::TaskConfig,
+        config_enums::DbType,
+        config_token_parser::{ConfigTokenParser, TokenEscapePair},
+        extractor_config::ExtractorConfig,
+        sinker_config::SinkerConfig,
+        task_config::TaskConfig,
     },
     error::Error,
     rdb_filter::RdbFilter,
@@ -108,7 +111,9 @@ impl RedisTestRunner {
         let heartbeat_db_key = ConfigTokenParser::parse(
             &heartbeat_key,
             &['.'],
-            &SqlUtil::get_escape_pairs(&DbType::Redis),
+            &TokenEscapePair::char_to_token_escape_pairs(&SqlUtil::get_escape_pairs(
+                &DbType::Redis,
+            )),
         );
         let db_id: i64 = heartbeat_db_key[0].parse().unwrap();
         let key = &heartbeat_db_key[1];

--- a/dt-tests/tests/test_runner/redis_test_runner.rs
+++ b/dt-tests/tests/test_runner/redis_test_runner.rs
@@ -111,9 +111,7 @@ impl RedisTestRunner {
         let heartbeat_db_key = ConfigTokenParser::parse(
             &heartbeat_key,
             &['.'],
-            &TokenEscapePair::char_to_token_escape_pairs(&SqlUtil::get_escape_pairs(
-                &DbType::Redis,
-            )),
+            &TokenEscapePair::from_char_pairs(SqlUtil::get_escape_pairs(&DbType::Redis)),
         );
         let db_id: i64 = heartbeat_db_key[0].parse().unwrap();
         let key = &heartbeat_db_key[1];

--- a/dt-tests/tests/test_runner/redis_test_util.rs
+++ b/dt-tests/tests/test_runner/redis_test_util.rs
@@ -157,7 +157,7 @@ impl RedisTestUtil {
         for arg in ConfigTokenParser::parse(
             cmd,
             &DELIMITERS,
-            &TokenEscapePair::char_to_token_escape_pairs(&self.escape_pairs),
+            &TokenEscapePair::from_char_pairs(self.escape_pairs.clone()),
         ) {
             let mut arg = arg.clone();
             for (left, right) in &self.escape_pairs {
@@ -175,7 +175,7 @@ impl RedisTestUtil {
         let tokens = ConfigTokenParser::parse(
             cmd,
             &DELIMITERS,
-            &TokenEscapePair::char_to_token_escape_pairs(&self.escape_pairs),
+            &TokenEscapePair::from_char_pairs(self.escape_pairs.clone()),
         );
         let mut args = Vec::new();
         for token in tokens.iter() {

--- a/dt-tests/tests/test_runner/redis_test_util.rs
+++ b/dt-tests/tests/test_runner/redis_test_util.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use dt_common::config::config_token_parser::TokenEscapePair;
 use dt_common::meta::redis::command::cmd_encoder::CmdEncoder;
 use dt_common::meta::redis::redis_object::RedisCmd;
 use dt_common::{config::config_token_parser::ConfigTokenParser, utils::sql_util::SqlUtil};
@@ -153,7 +154,11 @@ impl RedisTestUtil {
     fn pack_cmd(&self, cmd: &str) -> Vec<u8> {
         // parse cmd args
         let mut redis_cmd = RedisCmd::new();
-        for arg in ConfigTokenParser::parse(cmd, &DELIMITERS, &self.escape_pairs) {
+        for arg in ConfigTokenParser::parse(
+            cmd,
+            &DELIMITERS,
+            &TokenEscapePair::char_to_token_escape_pairs(&self.escape_pairs),
+        ) {
             let mut arg = arg.clone();
             for (left, right) in &self.escape_pairs {
                 arg = arg
@@ -167,7 +172,11 @@ impl RedisTestUtil {
     }
 
     fn get_cmd_args(&self, cmd: &str) -> Vec<String> {
-        let tokens = ConfigTokenParser::parse(cmd, &DELIMITERS, &self.escape_pairs);
+        let tokens = ConfigTokenParser::parse(
+            cmd,
+            &DELIMITERS,
+            &TokenEscapePair::char_to_token_escape_pairs(&self.escape_pairs),
+        );
         let mut args = Vec::new();
         for token in tokens.iter() {
             let arg = SqlUtil::unescape(token, &self.escape_pairs[0]);


### PR DESCRIPTION
filter module support raw regex strings enclosed by `r#` and `#` escape pair.