### PR TITLE
feat: add transaction isolation setting for mysql sinker

### DIFF
--- a/dt-common/src/config/config_enums.rs
+++ b/dt-common/src/config/config_enums.rs
@@ -153,6 +153,21 @@ pub enum ResumeType {
     Dummy,
 }
 
+#[derive(Display, EnumString, IntoStaticStr, PartialEq, Default, Clone, Debug)]
+pub enum RdbTransactionIsolation {
+    #[strum(serialize = "read_uncommitted")]
+    ReadUncommitted,
+    #[strum(serialize = "read_committed")]
+    ReadCommitted,
+    #[strum(serialize = "repeatable_read")]
+    RepeatableRead,
+    #[strum(serialize = "serializable")]
+    Serializable,
+    #[default]
+    #[strum(serialize = "default")]
+    Default,
+}
+
 pub fn build_task_type(extract_type: &ExtractType, sink_type: &SinkType) -> Option<TaskType> {
     match (extract_type, sink_type) {
         (ExtractType::Struct, SinkType::Struct) => Some(TaskType::Struct),

--- a/dt-common/src/config/sinker_config.rs
+++ b/dt-common/src/config/sinker_config.rs
@@ -2,7 +2,7 @@ use super::{
     config_enums::{ConflictPolicyEnum, DbType},
     s3_config::S3Config,
 };
-use crate::config::config_enums::SinkType;
+use crate::config::config_enums::{RdbTransactionIsolation, SinkType};
 
 #[derive(Clone, Debug)]
 pub enum SinkerConfig {
@@ -13,6 +13,7 @@ pub enum SinkerConfig {
         batch_size: usize,
         replace: bool,
         disable_foreign_key_checks: bool,
+        transaction_isolation: RdbTransactionIsolation,
     },
 
     Pg {

--- a/dt-common/src/config/task_config.rs
+++ b/dt-common/src/config/task_config.rs
@@ -10,7 +10,10 @@ use anyhow::{bail, Ok};
 #[cfg(feature = "metrics")]
 use crate::config::metrics_config::MetricsConfig;
 use crate::{
-    config::{config_enums::ResumeType, global_config::GlobalConfig},
+    config::{
+        config_enums::{RdbTransactionIsolation, ResumeType},
+        global_config::GlobalConfig,
+    },
     error::Error,
     utils::task_util::TaskUtil,
 };
@@ -438,6 +441,11 @@ impl TaskConfig {
                         SINKER,
                         DISABLE_FOREIGN_KEY_CHECKS,
                         true,
+                    ),
+                    transaction_isolation: loader.get_with_default(
+                        SINKER,
+                        "transaction_isolation",
+                        RdbTransactionIsolation::ReadCommitted,
                     ),
                 },
 

--- a/dt-common/src/utils/task_util.rs
+++ b/dt-common/src/utils/task_util.rs
@@ -3,12 +3,9 @@ use std::{
     hash::{Hash, Hasher},
 };
 
-use crate::{
-    config::{
-        extractor_config::BasicExtractorConfig, filter_config::FilterConfig,
-        router_config::RouterConfig, sinker_config::BasicSinkerConfig,
-    },
-    log_info,
+use crate::config::{
+    extractor_config::BasicExtractorConfig, filter_config::FilterConfig,
+    router_config::RouterConfig, sinker_config::BasicSinkerConfig,
 };
 
 pub struct TaskUtil {}
@@ -26,9 +23,7 @@ impl TaskUtil {
         filter.hash(&mut hasher);
         router.hash(&mut hasher);
 
-        let task_id = format!("{:x}", hasher.finish());
-        log_info!("generate task id: {}", task_id);
-        task_id
+        format!("{:x}", hasher.finish())
     }
 }
 

--- a/dt-connector/src/extractor/base_extractor.rs
+++ b/dt-connector/src/extractor/base_extractor.rs
@@ -20,7 +20,7 @@ use dt_common::{
         struct_meta::struct_data::StructData,
     },
     rdb_filter::RdbFilter,
-    utils::{sql_util::SqlUtil, time_util::TimeUtil},
+    utils::sql_util::SqlUtil,
 };
 use dt_common::{
     meta::{

--- a/dt-pipeline/src/base_pipeline.rs
+++ b/dt-pipeline/src/base_pipeline.rs
@@ -24,7 +24,6 @@ use dt_common::{
         syncer::Syncer,
     },
     monitor::{counter_type::CounterType, monitor::Monitor},
-    utils::time_util::TimeUtil,
 };
 use dt_connector::{data_marker::DataMarker, extractor::resumer::recorder::Recorder, Sinker};
 use dt_parallelizer::{DataSize, Parallelizer};

--- a/dt-precheck/src/fetcher/mysql/mysql_fetcher.rs
+++ b/dt-precheck/src/fetcher/mysql/mysql_fetcher.rs
@@ -22,7 +22,7 @@ pub struct MysqlFetcher {
 #[async_trait]
 impl Fetcher for MysqlFetcher {
     async fn build_connection(&mut self) -> anyhow::Result<()> {
-        self.pool = Some(TaskUtil::create_mysql_conn_pool(&self.url, 1, true, false).await?);
+        self.pool = Some(TaskUtil::create_mysql_conn_pool(&self.url, 1, true, None).await?);
         Ok(())
     }
 

--- a/dt-task/src/extractor_util.rs
+++ b/dt-task/src/extractor_util.rs
@@ -566,7 +566,7 @@ impl ExtractorUtil {
         let meta_manager = match task_config.extractor_basic.db_type {
             DbType::Mysql => {
                 let conn_pool =
-                    TaskUtil::create_mysql_conn_pool(extractor_url, 1, true, false).await?;
+                    TaskUtil::create_mysql_conn_pool(extractor_url, 1, true, None).await?;
                 let meta_manager = MysqlMetaManager::new(conn_pool.clone()).await?;
                 Some(RdbMetaManager::from_mysql(meta_manager))
             }

--- a/dt-task/src/sinker_util.rs
+++ b/dt-task/src/sinker_util.rs
@@ -103,6 +103,7 @@ impl SinkerUtil {
                 ..
             } => {
                 let router = create_router!(task_config, Mysql);
+
                 let conn_pool = match sinker_client {
                     ConnClient::MySQL(conn_pool) => conn_pool,
                     _ => {
@@ -110,9 +111,7 @@ impl SinkerUtil {
                     }
                 };
                 let meta_manager = MysqlMetaManager::new(conn_pool.clone()).await?;
-                // to avoid contention for monitor write lock between sinker threads,
-                // create a monitor for each sinker instead of sharing a single monitor between sinkers,
-                // sometimes a sinker may cost several millis to get write lock for a global monitor.
+
                 for _ in 0..parallel_size {
                     let sinker = MysqlSinker {
                         url: url.to_string(),
@@ -452,7 +451,7 @@ impl SinkerUtil {
                         &url,
                         parallel_size * 2,
                         enable_sqlx_log,
-                        false,
+                        None,
                     )
                     .await?;
                     let meta_manager = MysqlMetaManager::new_mysql_compatible(
@@ -491,7 +490,7 @@ impl SinkerUtil {
                 conflict_policy,
             } => {
                 let conn_pool =
-                    TaskUtil::create_mysql_conn_pool(&url, 2, enable_sqlx_log, false).await?;
+                    TaskUtil::create_mysql_conn_pool(&url, 2, enable_sqlx_log, None).await?;
                 let filter = create_filter!(task_config, Mysql);
                 let router = create_router!(task_config, Mysql);
                 let extractor_meta_manager = ExtractorUtil::get_extractor_meta_manager(task_config)
@@ -596,7 +595,7 @@ impl SinkerUtil {
                     &url,
                     parallel_size * 2,
                     enable_sqlx_log,
-                    false,
+                    None,
                 )
                 .await?;
                 let s3_client = TaskUtil::create_s3_client(&s3_config)?;
@@ -661,7 +660,7 @@ impl SinkerUtil {
                     &url,
                     parallel_size * 2,
                     enable_sqlx_log,
-                    false,
+                    None,
                 )
                 .await?;
                 let s3_client = TaskUtil::create_s3_client(&s3_config)?;
@@ -705,7 +704,7 @@ impl SinkerUtil {
                     &url,
                     parallel_size * 2,
                     enable_sqlx_log,
-                    false,
+                    None,
                 )
                 .await?;
                 let s3_client = TaskUtil::create_s3_client(&s3_config)?;
@@ -734,7 +733,7 @@ impl SinkerUtil {
                     &url,
                     parallel_size * 2,
                     enable_sqlx_log,
-                    false,
+                    None,
                 )
                 .await?;
                 let sinker = FoxlakeStructSinker {

--- a/dt-task/src/task_runner.rs
+++ b/dt-task/src/task_runner.rs
@@ -137,6 +137,12 @@ impl TaskRunner {
             log_error!("panic: {}\nbacktrace:\n{}", panic_info, backtrace);
         }));
 
+        log_info!(
+            "start task: [taskID: {}, taskType: {:?}]",
+            &self.config.global.task_id,
+            &self.task_type
+        );
+
         let db_type = &self.config.extractor_basic.db_type;
         let router = Arc::new(RdbRouter::from_config(&self.config.router, db_type)?);
         let (recorder, recovery) = match &self.task_type {

--- a/dt-task/src/task_util.rs
+++ b/dt-task/src/task_util.rs
@@ -4,7 +4,7 @@ use anyhow::bail;
 use futures::TryStreamExt;
 use mongodb::bson::doc;
 use mongodb::options::ClientOptions;
-use opendal::{Builder, Operator};
+use opendal::Operator;
 use sqlx::{
     mysql::{MySqlConnectOptions, MySqlPoolOptions},
     postgres::{PgConnectOptions, PgPoolOptions},
@@ -13,7 +13,7 @@ use sqlx::{
 
 use dt_common::{
     config::{
-        config_enums::{DbType, TaskType},
+        config_enums::{DbType, RdbTransactionIsolation, TaskType},
         extractor_config::ExtractorConfig,
         global_config::GlobalConfig,
         meta_center_config::MetaCenterConfig,
@@ -48,7 +48,7 @@ impl TaskUtil {
         url: &str,
         max_connections: u32,
         enable_sqlx_log: bool,
-        disable_foreign_key_checks: bool,
+        after_connect_settings: Option<Vec<&'static str>>,
     ) -> anyhow::Result<Pool<MySql>> {
         let mut conn_options = MySqlConnectOptions::from_str(url)?;
         // The default character set is `utf8mb4`
@@ -60,20 +60,57 @@ impl TaskUtil {
             conn_options.disable_statement_logging();
         }
 
-        let conn_pool = MySqlPoolOptions::new()
-            .max_connections(max_connections)
-            .after_connect(move |conn, _meta| {
-                Box::pin(async move {
-                    if disable_foreign_key_checks {
-                        conn.execute(sqlx::query("SET foreign_key_checks = 0;"))
-                            .await?;
-                    }
-                    Ok(())
+        let mut conn_pool = MySqlPoolOptions::new().max_connections(max_connections);
+        if let Some(settings) = after_connect_settings {
+            if !settings.is_empty() {
+                conn_pool = conn_pool.after_connect(move |conn, _meta| {
+                    let additions = settings.clone();
+                    Box::pin(async move {
+                        log_info!(
+                            "execute addition settings after create new connection: {:?}",
+                            additions
+                        );
+                        for addition in additions {
+                            conn.execute(sqlx::query(addition)).await?;
+                        }
+                        Ok(())
+                    })
                 })
-            })
-            .connect_with(conn_options)
-            .await?;
-        Ok(conn_pool)
+            }
+        }
+
+        Ok(conn_pool.connect_with(conn_options).await?)
+    }
+
+    pub fn build_mysql_conn_settings(
+        disable_foreign_key_checks: bool,
+        transaction_isolation: &RdbTransactionIsolation,
+    ) -> Option<Vec<&'static str>> {
+        let mut settings: Vec<&'static str> = Vec::new();
+
+        if disable_foreign_key_checks {
+            settings.push("SET FOREIGN_KEY_CHECKS=0");
+        }
+        match transaction_isolation {
+            RdbTransactionIsolation::ReadUncommitted => {
+                settings.push("SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED")
+            }
+            RdbTransactionIsolation::ReadCommitted => {
+                settings.push("SET TRANSACTION ISOLATION LEVEL READ COMMITTED")
+            }
+            RdbTransactionIsolation::RepeatableRead => {
+                settings.push("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ")
+            }
+            RdbTransactionIsolation::Serializable => {
+                settings.push("SET TRANSACTION ISOLATION LEVEL SERIALIZABLE")
+            }
+            _ => {}
+        }
+        if settings.is_empty() {
+            None
+        } else {
+            Some(settings)
+        }
     }
 
     pub async fn create_pg_conn_pool(
@@ -165,7 +202,7 @@ impl TaskUtil {
         let enable_sqlx_log = Self::check_enable_sqlx_log(log_level);
         let conn_pool = match &conn_pool_opt {
             Some(conn_pool) => conn_pool.clone(),
-            None => Self::create_mysql_conn_pool(url, 1, enable_sqlx_log, false).await?,
+            None => Self::create_mysql_conn_pool(url, 1, enable_sqlx_log, None).await?,
         };
         let mut meta_manager = MysqlMetaManager::new_mysql_compatible(conn_pool, db_type).await?;
 
@@ -177,7 +214,7 @@ impl TaskUtil {
         {
             let meta_center_conn_pool = match &conn_pool_opt {
                 Some(conn_pool) => conn_pool.clone(),
-                None => Self::create_mysql_conn_pool(url, 1, enable_sqlx_log, false).await?,
+                None => Self::create_mysql_conn_pool(url, 1, enable_sqlx_log, None).await?,
             };
             let meta_center = MysqlDbEngineMetaCenter::new(
                 url.clone(),
@@ -611,7 +648,7 @@ impl ConnClient {
                     url,
                     extractor_max_connections,
                     enable_sqlx_log,
-                    false,
+                    None,
                 )
                 .await?,
             ),
@@ -636,17 +673,37 @@ impl ConnClient {
             _ => ConnClient::None,
         };
         let sinker_client = match &task_config.sinker {
-            SinkerConfig::Mysql { url, .. }
-            | SinkerConfig::MysqlStruct { url, .. }
-            | SinkerConfig::MysqlCheck { url, .. } => ConnClient::MySQL(
-                TaskUtil::create_mysql_conn_pool(
-                    url,
-                    sinker_max_connections,
-                    enable_sqlx_log,
-                    false,
+            SinkerConfig::Mysql {
+                url,
+                disable_foreign_key_checks,
+                transaction_isolation,
+                ..
+            } => {
+                let conn_settings = TaskUtil::build_mysql_conn_settings(
+                    *disable_foreign_key_checks,
+                    transaction_isolation,
+                );
+                ConnClient::MySQL(
+                    TaskUtil::create_mysql_conn_pool(
+                        url,
+                        sinker_max_connections,
+                        enable_sqlx_log,
+                        conn_settings,
+                    )
+                    .await?,
                 )
-                .await?,
-            ),
+            }
+            SinkerConfig::MysqlStruct { url, .. } | SinkerConfig::MysqlCheck { url, .. } => {
+                ConnClient::MySQL(
+                    TaskUtil::create_mysql_conn_pool(
+                        url,
+                        sinker_max_connections,
+                        enable_sqlx_log,
+                        None,
+                    )
+                    .await?,
+                )
+            }
             SinkerConfig::Pg { url, .. }
             | SinkerConfig::PgStruct { url, .. }
             | SinkerConfig::PgCheck { url, .. } => ConnClient::PostgreSQL(

--- a/dt-tests/tests/mysql_to_mysql/snapshot/basic_test/task_config.ini
+++ b/dt-tests/tests/mysql_to_mysql/snapshot/basic_test/task_config.ini
@@ -8,6 +8,9 @@ db_type=mysql
 sink_type=write
 url={mysql_sinker_url}
 batch_size=2
+# [read_uncommitted, read_committed, repeatable_read, serializable, default]
+transaction_isolation=read_committed
+disable_foreign_key_checks=true
 
 [filter]
 do_dbs=

--- a/dt-tests/tests/test_runner/rdb_redis_test_runner.rs
+++ b/dt-tests/tests/test_runner/rdb_redis_test_runner.rs
@@ -30,7 +30,7 @@ impl RdbRedisTestRunner {
         let config = TaskConfig::new(&base.task_config_file).unwrap();
 
         let mysql_conn_pool = Some(
-            TaskUtil::create_mysql_conn_pool(&config.extractor_basic.url, 1, false, true).await?,
+            TaskUtil::create_mysql_conn_pool(&config.extractor_basic.url, 1, false, None).await?,
         );
         let redis_conn = match config.sinker {
             SinkerConfig::Redis { url, .. } => RedisUtil::create_redis_conn(&url).await.unwrap(),

--- a/dt-tests/tests/test_runner/rdb_test_runner.rs
+++ b/dt-tests/tests/test_runner/rdb_test_runner.rs
@@ -66,10 +66,19 @@ impl RdbTestRunner {
         let src_url = &config.extractor_basic.url;
         let dst_url = &config.sinker_basic.url;
 
+        let mysql_conn_settings = Some(vec!["SET FOREIGN_KEY_CHECKS=0"]);
+
         match src_db_type {
             DbType::Mysql => {
-                src_conn_pool_mysql =
-                    Some(TaskUtil::create_mysql_conn_pool(src_url, 1, false, true).await?);
+                src_conn_pool_mysql = Some(
+                    TaskUtil::create_mysql_conn_pool(
+                        src_url,
+                        1,
+                        false,
+                        mysql_conn_settings.clone(),
+                    )
+                    .await?,
+                );
             }
             DbType::Pg => {
                 src_conn_pool_pg =
@@ -85,8 +94,15 @@ impl RdbTestRunner {
                 | DbType::StarRocks
                 | DbType::Doris
                 | DbType::Tidb => {
-                    dst_conn_pool_mysql =
-                        Some(TaskUtil::create_mysql_conn_pool(dst_url, 1, false, true).await?);
+                    dst_conn_pool_mysql = Some(
+                        TaskUtil::create_mysql_conn_pool(
+                            dst_url,
+                            1,
+                            false,
+                            mysql_conn_settings.clone(),
+                        )
+                        .await?,
+                    );
                 }
                 DbType::Pg => {
                     dst_conn_pool_pg =
@@ -101,7 +117,7 @@ impl RdbTestRunner {
         let filter = RdbFilter::from_config(&config.filter, dst_db_type).unwrap();
         let meta_center_pool_mysql = match &config.meta_center {
             Some(MetaCenterConfig::MySqlDbEngine { url, .. }) => Some(
-                TaskUtil::create_mysql_conn_pool(url, 1, false, true)
+                TaskUtil::create_mysql_conn_pool(url, 1, false, mysql_conn_settings.clone())
                     .await
                     .unwrap(),
             ),


### PR DESCRIPTION
you can configure the transaction isolation level used by the MySQL sinker.
```
[sinker]
db_type=mysql
sink_type=write
url={mysql_sinker_url}
# [read_uncommitted, read_committed, repeatable_read, serializable, default]
transaction_isolation=read_committed
```