### PR TITLE
feat: support PG unchangedtoast col in CDC

### DIFF
--- a/dt-common/src/meta/avro/avro_converter.rs
+++ b/dt-common/src/meta/avro/avro_converter.rs
@@ -328,7 +328,7 @@ impl AvroConverter {
             ColValue::MongoDoc(v) => Value::String(v.to_string()),
 
             ColValue::Bool(v) => Value::Boolean(*v),
-            ColValue::None => Value::Null,
+            ColValue::None | ColValue::UnchangedToast => Value::Null,
         }
     }
 

--- a/dt-common/src/meta/col_value.rs
+++ b/dt-common/src/meta/col_value.rs
@@ -14,6 +14,7 @@ use serde::{Deserialize, Serialize, Serializer};
 #[allow(dead_code)]
 pub enum ColValue {
     None,
+    UnchangedToast,
     Bool(bool),
     Tiny(i8),
     UnsignedTiny(u8),
@@ -155,7 +156,7 @@ impl ColValue {
 
     pub fn hash_code(&self) -> u64 {
         match self {
-            ColValue::None => 0,
+            ColValue::None | ColValue::UnchangedToast => 0,
             _ => {
                 let mut hasher = DefaultHasher::new();
                 self.to_option_string().hash(&mut hasher);
@@ -196,6 +197,7 @@ impl ColValue {
             ColValue::Json2(_) => "Json2",
             ColValue::Json3(_) => "Json3",
             ColValue::MongoDoc(_) => "MongoDoc",
+            ColValue::UnchangedToast => "UnchangedToast",
         }
     }
 
@@ -230,8 +232,12 @@ impl ColValue {
             ColValue::Blob(v) => Some(hex::encode(v)),
             ColValue::MongoDoc(v) => Some(Self::mongo_doc_to_string(v)),
             ColValue::Bool(v) => Some(v.to_string()),
-            ColValue::None => Option::None,
+            ColValue::None | ColValue::UnchangedToast => Option::None,
         }
+    }
+
+    pub fn is_unchanged_toast(&self) -> bool {
+        matches!(self, ColValue::UnchangedToast)
     }
 
     pub fn is_nan(&self) -> bool {
@@ -267,7 +273,7 @@ impl ColValue {
             ColValue::Json(v) | ColValue::Blob(v) | ColValue::RawString(v) => v.len(),
             ColValue::Json3(v) => v.to_string().len(),
             ColValue::MongoDoc(v) => Self::get_bson_size_doc(v),
-            ColValue::None => 0,
+            ColValue::None | ColValue::UnchangedToast => 0,
         }
     }
 
@@ -350,7 +356,7 @@ impl Serialize for ColValue {
             ColValue::MongoDoc(v) => Bson::Document(v.clone())
                 .into_relaxed_extjson()
                 .serialize(serializer),
-            ColValue::None => serializer.serialize_none(),
+            ColValue::None | ColValue::UnchangedToast => serializer.serialize_none(),
         }
     }
 }

--- a/dt-common/src/meta/row_data.rs
+++ b/dt-common/src/meta/row_data.rs
@@ -254,6 +254,12 @@ impl RowData {
         Ok(hash_code)
     }
 
+    pub fn contains_unchanged_toast(&self) -> bool {
+        self.after
+            .as_ref()
+            .is_some_and(|values| values.values().any(ColValue::is_unchanged_toast))
+    }
+
     pub fn refresh_data_size(&mut self) {
         self.data_size = self.get_data_malloc_size();
     }

--- a/dt-connector/src/extractor/pg/pg_cdc_extractor.rs
+++ b/dt-connector/src/extractor/pg/pg_cdc_extractor.rs
@@ -9,7 +9,6 @@ use std::{
     time::UNIX_EPOCH,
 };
 
-use anyhow::bail;
 use async_trait::async_trait;
 use futures::StreamExt;
 use postgres_protocol::message::backend::{
@@ -37,7 +36,6 @@ use dt_common::{
         config_enums::DbType, config_token_parser::ConfigTokenParser,
         connection_auth_config::ConnectionAuthConfig,
     },
-    error::Error,
     log_error, log_info, log_warn,
     meta::{
         adaptor::pg_col_value_convertor::PgColValueConvertor,
@@ -503,9 +501,13 @@ impl PgCdcExtractor {
                 }
 
                 TupleData::UnchangedToast => {
-                    bail! {Error::ExtractorError(
-                        "unexpected UnchangedToast value received".into(),
-                    )}
+                    log_warn!(
+                        "schema: {}, tb: {}, col: {}, UnchangedToast value received",
+                        tb_meta.basic.schema,
+                        tb_meta.basic.tb,
+                        col
+                    );
+                    col_values.insert(col.to_string(), ColValue::UnchangedToast);
                 }
             }
         }

--- a/dt-connector/src/rdb_query_builder.rs
+++ b/dt-connector/src/rdb_query_builder.rs
@@ -1101,4 +1101,43 @@ mod tests {
             r#"ON CONFLICT ("id") DO UPDATE SET "code"=EXCLUDED."code","name"=EXCLUDED."name""#
         ));
     }
+
+    #[test]
+    fn test_pg_update_query_skips_unchanged_toast_cols() {
+        let tb_meta = build_pg_tb_meta();
+        let row_data = build_update_row_data_with_unchanged_toast(false);
+        let builder = RdbQueryBuilder::new_for_pg(&tb_meta, None);
+
+        let query_info = builder.get_query_info(&row_data, false).unwrap();
+
+        assert!(query_info.sql.contains(r#""name"="#));
+        assert!(!query_info.sql.contains(r#""code"="#));
+    }
+
+    #[test]
+    fn test_pg_replace_pk_changed_update_with_unchanged_toast_falls_back_to_update() {
+        let tb_meta = build_pg_tb_meta();
+        let row_data = build_update_row_data_with_unchanged_toast(true);
+        let builder = RdbQueryBuilder::new_for_pg(&tb_meta, None);
+
+        let query_info = builder.get_query_info(&row_data, true).unwrap();
+
+        assert!(query_info.sql.starts_with(r#"UPDATE "public"."t1" SET"#));
+        assert!(!query_info.sql.contains("WITH deleted AS"));
+        assert!(!query_info.sql.contains(r#""code"="#));
+    }
+
+    #[test]
+    fn test_pg_update_query_with_only_unchanged_toast_does_not_include_toast_cols() {
+        let tb_meta = build_pg_tb_meta();
+        let row_data = build_update_row_data_with_only_unchanged_toast();
+        let builder = RdbQueryBuilder::new_for_pg(&tb_meta, None);
+
+        let query_info = builder.get_query_info(&row_data, false).unwrap();
+
+        assert!(query_info.sql.starts_with(r#"UPDATE "public"."t1" SET"#));
+        assert!(query_info.sql.contains(r#""id"="#));
+        assert!(!query_info.sql.contains(r#""code"="#));
+        assert!(!query_info.sql.contains(r#""name"="#));
+    }
 }

--- a/dt-connector/src/rdb_query_builder.rs
+++ b/dt-connector/src/rdb_query_builder.rs
@@ -127,7 +127,10 @@ impl RdbQueryBuilder<'_> {
                 }
             }
             RowType::Update => {
-                if replace && self.db_type == DbType::Pg && self.check_primary_key_changed(row_data)
+                if replace
+                    && self.db_type == DbType::Pg
+                    && !row_data.contains_unchanged_toast()
+                    && self.check_primary_key_changed(row_data)
                 {
                     self.get_pg_pk_changed_update_replace_query(row_data, placeholder)
                 } else {
@@ -443,10 +446,13 @@ impl RdbQueryBuilder<'_> {
         let after = row_data.require_after()?;
 
         let mut index = 1;
-        let mut set_cols: Vec<String> = after.keys().cloned().collect();
-        set_cols.sort();
-        let mut set_pairs = Vec::with_capacity(self.rdb_tb_meta.cols.len());
-        for col in set_cols.iter() {
+        let mut set_cols = Vec::new();
+        let mut set_pairs = Vec::new();
+        for (col, col_value) in after.iter() {
+            if col_value.is_unchanged_toast() {
+                continue;
+            }
+            set_cols.push(col.clone());
             let sql_value = self.get_sql_value(index, col, &after.get(col), placeholder)?;
             set_pairs.push(format!("{}={}", self.escape(col), sql_value));
             index += 1;
@@ -689,16 +695,21 @@ impl RdbQueryBuilder<'_> {
             return self.get_placeholder(index, col);
         }
 
-        let col_value = match col_value {
-            Some(value) => value,
-            None => return Ok("NULL".to_string()),
-        };
-
-        if self.mysql_tb_meta.is_some() {
-            return self.get_mysql_sql_value(col, col_value);
+        if col_value.is_none() {
+            return Ok("NULL".to_string());
+        }
+        if col_value.unwrap().is_unchanged_toast() {
+            bail! {Error::Unexpected(format!(
+                "schema: {}, tb: {}, col: {}, UnchangedToast should not be converted to sql value directly",
+                self.rdb_tb_meta.schema, self.rdb_tb_meta.tb, col
+            ))}
         }
 
-        Ok(self.get_pg_sql_value(col_value))
+        if self.mysql_tb_meta.is_some() {
+            return self.get_mysql_sql_value(col, col_value.unwrap());
+        }
+
+        Ok(self.get_pg_sql_value(col_value.unwrap()))
     }
 
     fn get_pg_sql_value(&self, col_value: &ColValue) -> String {
@@ -956,6 +967,49 @@ mod tests {
         after.insert("id".to_string(), ColValue::Long(2));
         after.insert("code".to_string(), ColValue::String("xx".to_string()));
         after.insert("name".to_string(), ColValue::String("n2".to_string()));
+
+        RowData::new(
+            "public".to_string(),
+            "t1".to_string(),
+            RowType::Update,
+            Some(before),
+            Some(after),
+        )
+    }
+
+    fn build_update_row_data_with_unchanged_toast(pk_changed: bool) -> RowData {
+        let mut before = HashMap::new();
+        before.insert("id".to_string(), ColValue::Long(1));
+        before.insert("code".to_string(), ColValue::String("xx".to_string()));
+        before.insert("name".to_string(), ColValue::String("n1".to_string()));
+
+        let mut after = HashMap::new();
+        after.insert(
+            "id".to_string(),
+            ColValue::Long(if pk_changed { 2 } else { 1 }),
+        );
+        after.insert("code".to_string(), ColValue::UnchangedToast);
+        after.insert("name".to_string(), ColValue::String("n2".to_string()));
+
+        RowData::new(
+            "public".to_string(),
+            "t1".to_string(),
+            RowType::Update,
+            Some(before),
+            Some(after),
+        )
+    }
+
+    fn build_update_row_data_with_only_unchanged_toast() -> RowData {
+        let mut before = HashMap::new();
+        before.insert("id".to_string(), ColValue::Long(1));
+        before.insert("code".to_string(), ColValue::String("xx".to_string()));
+        before.insert("name".to_string(), ColValue::String("n1".to_string()));
+
+        let mut after = HashMap::new();
+        after.insert("id".to_string(), ColValue::Long(1));
+        after.insert("code".to_string(), ColValue::UnchangedToast);
+        after.insert("name".to_string(), ColValue::UnchangedToast);
 
         RowData::new(
             "public".to_string(),

--- a/dt-connector/src/sinker/base_checker.rs
+++ b/dt-connector/src/sinker/base_checker.rs
@@ -485,6 +485,9 @@ impl BaseChecker {
 
         let mut diff_col_values = HashMap::new();
         for (col, src_val) in src {
+            if src_val.is_unchanged_toast() {
+                continue;
+            }
             let dst_val = dst.get(col);
             let maybe_diff = match dst_val {
                 Some(dst_val) if src_val == dst_val => None,

--- a/dt-parallelizer/src/rdb_merger.rs
+++ b/dt-parallelizer/src/rdb_merger.rs
@@ -63,6 +63,11 @@ impl RdbMerger {
             .get_tb_meta(&row_data.schema, &row_data.tb)
             .await?;
 
+        if row_data.contains_unchanged_toast() {
+            merged.unmerged_rows.push(row_data);
+            return Ok(());
+        }
+
         // case 1: table has no primary/unique key
         // case 2: any key col value is NULL
         let hash_code = Self::get_hash_code(&row_data, tb_meta).await?;

--- a/dt-pipeline/src/lua_processor.rs
+++ b/dt-pipeline/src/lua_processor.rs
@@ -149,7 +149,8 @@ impl LuaProcessor {
             | ColValue::Blob(_)
             | ColValue::Json(_)
             | ColValue::MongoDoc(_)
-            | ColValue::None => mlua::Value::NULL,
+            | ColValue::None
+            | ColValue::UnchangedToast => mlua::Value::NULL,
         };
         Ok(lua_value)
     }


### PR DESCRIPTION
Previously, the program would panic upon encountering an `unchangedtoast` column. Considering that `unchangedtoast` only appears in update statements where the large column hasn't changed, this PR adds support for this scenario.