### PR TITLE
chore: fix security vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG DIST_IMG=gcr.io/distroless/cc:debug
 
 ARG RUST_VERSION=1.85
 # ARG RUST_IMG_ALT=-slim-bullseye
-ARG RUST_IMG_ALT=-bullseye
+ARG RUST_IMG_ALT=-bookworm
 
 FROM --platform=${BUILDPLATFORM} rust:${RUST_VERSION}${RUST_IMG_ALT} as builder
 


### PR DESCRIPTION
## Summary

Upgrade Rust builder base image from Debian 11 (bullseye) to Debian 12 (bookworm) to patch OS-level CVEs in the build environment.

## Changes

- Dockerfile: `rust:1.85-bullseye` → `rust:1.85-bookworm`

## Scan Context

Older versions (2.0.24, 2.0.25, redis.reshard.2.0.9) on Debian 11 had OS CVEs. The latest 2.0.26-alpha.14 built on Debian 12 (bookworm) is clean.

Note: The final runtime image uses `gcr.io/distroless/cc:debug`, which is already based on Debian 12 (bookworm), so the builder and runtime are aligned.

🤖 Generated with Claude Code