### PR TITLE
fix: compatible with fields using collation=binary(such as utf8_bin)

### DIFF
--- a/dt-common/src/meta/adaptor/mysql_col_value_convertor.rs
+++ b/dt-common/src/meta/adaptor/mysql_col_value_convertor.rs
@@ -1,18 +1,22 @@
 use std::io::Cursor;
 
-use crate::{
-    config::config_enums::DbType, error::Error, meta::time::dt_utc_time::DtNaiveTime,
-    utils::sql_util::SqlUtil,
-};
 use anyhow::bail;
 use byteorder::{LittleEndian, ReadBytesExt};
 use chrono::{TimeZone, Utc};
+use sqlx::{mysql::MySqlRow, types::BigDecimal, Row};
+
 use mysql_binlog_connector_rust::column::{
     column_value::ColumnValue, json::json_binary::JsonBinary,
 };
-use sqlx::{mysql::MySqlRow, types::BigDecimal, Row};
 
-use crate::meta::{col_value::ColValue, mysql::mysql_col_type::MysqlColType};
+use crate::{
+    config::config_enums::DbType,
+    error::Error,
+    meta::{
+        col_value::ColValue, mysql::mysql_col_type::MysqlColType, time::dt_utc_time::DtNaiveTime,
+    },
+    utils::sql_util::SqlUtil,
+};
 
 pub struct MysqlColValueConvertor {}
 
@@ -483,11 +487,11 @@ impl MysqlColValueConvertor {
                 Ok(ColValue::Bit(value))
             }
             MysqlColType::Set { .. } => {
-                let value: String = row.try_get(col)?;
+                let value: String = SqlUtil::try_get_mysql_string(row, col)?;
                 Ok(ColValue::Set2(value))
             }
             MysqlColType::Enum { .. } => {
-                let value: String = row.try_get(col)?;
+                let value: String = SqlUtil::try_get_mysql_string(row, col)?;
                 Ok(ColValue::Enum2(value))
             }
             MysqlColType::Json => {

--- a/dt-tests/tests/mysql_to_mysql/snapshot/basic_test/dst_prepare.sql
+++ b/dt-tests/tests/mysql_to_mysql/snapshot/basic_test/dst_prepare.sql
@@ -16,6 +16,10 @@ CREATE TABLE test_db_1.one_pk_multi_uk ( f_0 tinyint, f_1 smallint, f_2 mediumin
 
 CREATE TABLE test_db_1.col_has_special_character_table (`p:k` tinyint, `col"1` text, `col,2` text, `col\3` text, PRIMARY KEY(`p:k`));
 
+CREATE TABLE test_db_1.longtext_bin_collation_table (pk int, content longtext CHARACTER SET utf8 COLLATE utf8_bin NOT NULL, PRIMARY KEY(pk)) ENGINE=InnoDB;
+
+CREATE TABLE test_db_1.enum_set_bin_collation_table (pk int, enum_col enum('small','medium','large') CHARACTER SET utf8 COLLATE utf8_bin NOT NULL, set_col set('a','b','c') CHARACTER SET utf8 COLLATE utf8_bin NOT NULL, PRIMARY KEY(pk)) ENGINE=InnoDB;
+
 CREATE TABLE test_db_1.numeric_table ( f_0 tinyint, f_1 tinyint unsigned, f_2 smallint, f_3 smallint unsigned, f_4 mediumint, f_5 mediumint unsigned, f_6 int, f_7 int unsigned, f_8 bigint, f_9 bigint unsigned, PRIMARY KEY(f_0));
 
 CREATE TABLE test_db_1.date_time_table( f_0 tinyint, 
@@ -61,10 +65,10 @@ CREATE TABLE test_db_1.where_condition_3 ( f_0 int, f_1 int );
 -- ```
 
 -- test foreign key
--- CREATE TABLE test_db_1.fk_tb_2 (f_0 int, f_1 int UNIQUE, f_2 int UNIQUE, f_3 int, PRIMARY KEY(f_0));
--- CREATE TABLE test_db_1.fk_tb_1 (f_0 int, f_1 int UNIQUE, f_2 int UNIQUE, f_3 int, PRIMARY KEY(f_0));
--- ALTER TABLE test_db_1.fk_tb_1 ADD CONSTRAINT fk_tb_1_1 FOREIGN KEY (f_1) REFERENCES test_db_1.fk_tb_2 (f_1);
--- ALTER TABLE test_db_1.fk_tb_1 ADD CONSTRAINT fk_tb_1_2 FOREIGN KEY (f_2) REFERENCES test_db_1.fk_tb_2 (f_2);
+CREATE TABLE test_db_1.fk_tb_2 (f_0 int, f_1 int UNIQUE, f_2 int UNIQUE, f_3 int, PRIMARY KEY(f_0));
+CREATE TABLE test_db_1.fk_tb_1 (f_0 int, f_1 int UNIQUE, f_2 int UNIQUE, f_3 int, PRIMARY KEY(f_0));
+ALTER TABLE test_db_1.fk_tb_1 ADD CONSTRAINT fk_tb_1_1 FOREIGN KEY (f_1) REFERENCES test_db_1.fk_tb_2 (f_1);
+ALTER TABLE test_db_1.fk_tb_1 ADD CONSTRAINT fk_tb_1_2 FOREIGN KEY (f_2) REFERENCES test_db_1.fk_tb_2 (f_2);
 
 -- test composite primary key
 CREATE TABLE test_db_1.composite_pk_table (pk1 int, pk2 varchar(10), val int, PRIMARY KEY(pk1, pk2));

--- a/dt-tests/tests/mysql_to_mysql/snapshot/basic_test/src_prepare.sql
+++ b/dt-tests/tests/mysql_to_mysql/snapshot/basic_test/src_prepare.sql
@@ -66,10 +66,10 @@ CREATE TABLE test_db_1.where_condition_3 ( f_0 int, f_1 int );
 -- ```
 
 -- test foreign key
--- CREATE TABLE test_db_1.fk_tb_2 (f_0 int, f_1 int UNIQUE, f_2 int UNIQUE, f_3 int, PRIMARY KEY(f_0));
--- CREATE TABLE test_db_1.fk_tb_1 (f_0 int, f_1 int UNIQUE, f_2 int UNIQUE, f_3 int, PRIMARY KEY(f_0));
--- ALTER TABLE test_db_1.fk_tb_1 ADD CONSTRAINT fk_tb_1_1 FOREIGN KEY (f_1) REFERENCES test_db_1.fk_tb_2 (f_1);
--- ALTER TABLE test_db_1.fk_tb_1 ADD CONSTRAINT fk_tb_1_2 FOREIGN KEY (f_2) REFERENCES test_db_1.fk_tb_2 (f_2);
+CREATE TABLE test_db_1.fk_tb_2 (f_0 int, f_1 int UNIQUE, f_2 int UNIQUE, f_3 int, PRIMARY KEY(f_0));
+CREATE TABLE test_db_1.fk_tb_1 (f_0 int, f_1 int UNIQUE, f_2 int UNIQUE, f_3 int, PRIMARY KEY(f_0));
+ALTER TABLE test_db_1.fk_tb_1 ADD CONSTRAINT fk_tb_1_1 FOREIGN KEY (f_1) REFERENCES test_db_1.fk_tb_2 (f_1);
+ALTER TABLE test_db_1.fk_tb_1 ADD CONSTRAINT fk_tb_1_2 FOREIGN KEY (f_2) REFERENCES test_db_1.fk_tb_2 (f_2);
 
 -- test view filtered
 CREATE OR REPLACE VIEW test_db_1.one_pk_no_uk_view AS SELECT * FROM test_db_1.one_pk_no_uk;

--- a/dt-tests/tests/mysql_to_mysql/snapshot/basic_test/src_prepare.sql
+++ b/dt-tests/tests/mysql_to_mysql/snapshot/basic_test/src_prepare.sql
@@ -16,6 +16,10 @@ CREATE TABLE test_db_1.one_pk_multi_uk ( f_0 tinyint, f_1 smallint, f_2 mediumin
 
 CREATE TABLE test_db_1.col_has_special_character_table (`p:k` tinyint, `col"1` text, `col,2` text, `col\3` text, PRIMARY KEY(`p:k`));
 
+CREATE TABLE test_db_1.longtext_bin_collation_table (pk int, content longtext CHARACTER SET utf8 COLLATE utf8_bin NOT NULL, PRIMARY KEY(pk)) ENGINE=InnoDB;
+
+CREATE TABLE test_db_1.enum_set_bin_collation_table (pk int, enum_col enum('small','medium','large') CHARACTER SET utf8 COLLATE utf8_bin NOT NULL, set_col set('a','b','c') CHARACTER SET utf8 COLLATE utf8_bin NOT NULL, PRIMARY KEY(pk)) ENGINE=InnoDB;
+
 CREATE TABLE test_db_1.numeric_table ( f_0 tinyint, f_1 tinyint unsigned, f_2 smallint, f_3 smallint unsigned, f_4 mediumint, f_5 mediumint unsigned, f_6 int, f_7 int unsigned, f_8 bigint, f_9 bigint unsigned, PRIMARY KEY(f_0));
 
 CREATE TABLE test_db_1.date_time_table( f_0 tinyint, 

--- a/dt-tests/tests/mysql_to_mysql/snapshot/basic_test/src_test.sql
+++ b/dt-tests/tests/mysql_to_mysql/snapshot/basic_test/src_test.sql
@@ -51,6 +51,12 @@ INSERT INTO test_db_1.one_pk_multi_uk VALUES (9, NULL, NULL, NULL, NULL, NULL, N
 INSERT INTO test_db_1.col_has_special_character_table VALUES(1, 'col:1:value', 'col&2:value', 'col\3:value');
 INSERT INTO test_db_1.col_has_special_character_table VALUES(2, NULL, NULL, NULL);
 
+INSERT INTO test_db_1.longtext_bin_collation_table VALUES(1, 'abc');
+INSERT INTO test_db_1.longtext_bin_collation_table VALUES(2, 'CaseSensitiveContent');
+
+INSERT INTO test_db_1.enum_set_bin_collation_table VALUES(1, 'small', 'a,b');
+INSERT INTO test_db_1.enum_set_bin_collation_table VALUES(2, 'large', '');
+
 -- min for each col
 INSERT INTO test_db_1.numeric_table VALUES(-128, 0, -32768, 0, -8388608, 0, -2147483648, 0, -9223372036854775808, 0);
 -- max for each col
@@ -87,8 +93,8 @@ INSERT INTO test_db_1.where_condition_3 VALUES(1, 1),(2, 2),(3, 3),(4, 4),(5, 5)
 -- INSERT INTO test_db_1.zero_date_time_table VALUES(1, '0000-00-00 00:00:00', '00:00:00', '0000-00-00', '0000-00-00 00:00:00');
 
 -- test foreign key
--- insert into test_db_1.fk_tb_2 VALUES(1,1,1,1),(2,2,2,2);
--- insert into test_db_1.fk_tb_1 VALUES(1,1,1,1),(2,2,2,2);
+insert into test_db_1.fk_tb_2 VALUES(1,1,1,1),(2,2,2,2);
+insert into test_db_1.fk_tb_1 VALUES(1,1,1,1),(2,2,2,2);
 
 -- test composite primary key
 INSERT INTO test_db_1.composite_pk_table VALUES(1, '1', 1),(2, '2', 2),(3, '3', 3),(4, '4', 4),(5, '5', 5),(6, '6', 6),(7, '7', 7),(8, '8', 8),(9, '9', 9),(10, '10', 10);


### PR DESCRIPTION
compatible with fields using collation=binary, such as collation = utf8_bin