### PR TITLE
test: add ZooKeeper integration runners

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1885,6 +1885,7 @@ dependencies = [
  "tokio",
  "url",
  "uuid",
+ "zookeeper-client",
 ]
 
 [[package]]

--- a/dt-tests/Cargo.toml
+++ b/dt-tests/Cargo.toml
@@ -37,6 +37,7 @@ url = { workspace = true }
 rust_decimal = { workspace = true }
 uuid = { workspace = true }
 openssl = { workspace = true }
+zookeeper-client = { workspace = true }
 
 [dev-dependencies]
 rand = "0.9.2"

--- a/dt-tests/docker-compose.integration.yml
+++ b/dt-tests/docker-compose.integration.yml
@@ -1404,6 +1404,22 @@ services:
     stdin_open: true
     tty: true
 
+  zk-src:
+    image: zookeeper:3.9
+    container_name: zk-src-it
+    ports:
+      - "2181:2181"
+    environment:
+      ZOO_MY_ID: 1
+
+  zk-dst:
+    image: zookeeper:3.9
+    container_name: zk-dst-it
+    ports:
+      - "2182:2181"
+    environment:
+      ZOO_MY_ID: 2
+
 networks:
   default:
     name: ape-dts-integration-network

--- a/dt-tests/tests/.env
+++ b/dt-tests/tests/.env
@@ -158,3 +158,7 @@ clickhouse_url=http://admin:123456@127.0.0.1:8123
 
 # tidb
 tidb_sinker_url=mysql://root:@127.0.0.1:4000?ssl-mode=disabled
+
+# zookeeper
+zk_src_url=127.0.0.1:2181
+zk_dst_url=127.0.0.1:2182

--- a/dt-tests/tests/integration_test.rs
+++ b/dt-tests/tests/integration_test.rs
@@ -20,3 +20,4 @@ mod pg_to_starrocks;
 mod redis_to_redis;
 mod test_config_util;
 mod test_runner;
+mod zk_to_zk;

--- a/dt-tests/tests/test_runner/mod.rs
+++ b/dt-tests/tests/test_runner/mod.rs
@@ -21,3 +21,5 @@ pub mod redis_statistic_runner;
 pub mod redis_test_runner;
 pub mod redis_test_util;
 pub mod test_base;
+pub mod zk_cycle_test_runner;
+pub mod zk_test_runner;

--- a/dt-tests/tests/test_runner/test_base.rs
+++ b/dt-tests/tests/test_runner/test_base.rs
@@ -13,7 +13,7 @@ use super::{
     rdb_redis_test_runner::RdbRedisTestRunner, rdb_sql_test_runner::RdbSqlTestRunner,
     rdb_starrocks_test_runner::RdbStarRocksTestRunner, rdb_struct_test_runner::RdbStructTestRunner,
     rdb_test_runner::RdbTestRunner, redis_statistic_runner::RedisStatisticTestRunner,
-    redis_test_runner::RedisTestRunner,
+    redis_test_runner::RedisTestRunner, zk_test_runner::ZkTestRunner,
 };
 
 pub struct TestBase {}
@@ -430,5 +430,13 @@ impl TestBase {
         let runner = RdbTestRunner::new(test_dir).await.unwrap();
         runner.dcl_check_sql_execution().await.unwrap();
         runner.close().await.unwrap();
+    }
+
+    pub async fn run_zk_cdc_test(test_dir: &str, start_millis: u64, parse_millis: u64) {
+        let runner = ZkTestRunner::new(test_dir).await.unwrap();
+        runner
+            .run_cdc_test(start_millis, parse_millis)
+            .await
+            .unwrap();
     }
 }

--- a/dt-tests/tests/test_runner/zk_cycle_test_runner.rs
+++ b/dt-tests/tests/test_runner/zk_cycle_test_runner.rs
@@ -1,0 +1,194 @@
+use dt_common::utils::time_util::TimeUtil;
+use tokio::task::JoinHandle;
+use zookeeper_client as zk;
+
+use crate::test_config_util::TestConfigUtil;
+
+use super::zk_test_runner::ZkTestRunner;
+
+const SHADOW_PREFIX: &str = "/__ape_dts_shadow";
+const MARKER_PATH: &str = "/__ape_dts_marker";
+
+pub struct ZkCycleTestRunner {}
+
+impl ZkCycleTestRunner {
+    pub async fn run_cycle_cdc_test(test_dir: &str, start_millis: u64, parse_millis: u64) {
+        let sub_paths = TestConfigUtil::get_absolute_sub_dir(test_dir);
+        assert!(
+            !sub_paths.is_empty(),
+            "cycle test requires at least one sub-directory in {}",
+            test_dir
+        );
+
+        let mut handlers: Vec<JoinHandle<()>> = vec![];
+        let mut runners: Vec<(String, ZkTestRunner)> = vec![];
+
+        for sub_path in &sub_paths {
+            let runner = ZkTestRunner::new(format!("{}/{}", test_dir, sub_path.1).as_str())
+                .await
+                .unwrap();
+            runners.push((sub_path.1.clone(), runner));
+        }
+
+        let first_runner = &runners[0].1;
+        let src = zk::Client::connect(&first_runner.src_url).await.unwrap();
+        let dst = zk::Client::connect(&first_runner.dst_url).await.unwrap();
+
+        let options = zk::CreateMode::Persistent.with_acls(zk::Acls::anyone_all());
+        ZkCycleTestRunner::ensure_path(&src, "/app", &options).await;
+        ZkCycleTestRunner::ensure_path(&dst, "/app", &options).await;
+        ZkCycleTestRunner::delete_children(&src, "/app").await;
+        ZkCycleTestRunner::delete_children(&dst, "/app").await;
+
+        ZkCycleTestRunner::delete_children(&src, SHADOW_PREFIX).await;
+        ZkCycleTestRunner::delete_node(&src, SHADOW_PREFIX).await;
+        ZkCycleTestRunner::delete_children(&dst, SHADOW_PREFIX).await;
+        ZkCycleTestRunner::delete_node(&dst, SHADOW_PREFIX).await;
+        ZkCycleTestRunner::delete_node(&src, MARKER_PATH).await;
+        ZkCycleTestRunner::delete_node(&dst, MARKER_PATH).await;
+
+        for (_, runner) in &runners {
+            handlers.push(runner.base.spawn_task().await.unwrap());
+            TimeUtil::sleep_millis(start_millis).await;
+        }
+
+        src.create("/app/from-node1", b"hello-from-1", &options)
+            .await
+            .unwrap();
+        dst.create("/app/from-node2", b"hello-from-2", &options)
+            .await
+            .unwrap();
+
+        TimeUtil::sleep_millis(parse_millis).await;
+
+        // data sync assertions
+        let (src_data_1, _) = src.get_data("/app/from-node1").await.unwrap();
+        let (dst_data_1, _) = dst.get_data("/app/from-node1").await.unwrap();
+        assert_eq!(src_data_1, dst_data_1, "from-node1 data mismatch");
+
+        let (src_data_2, _) = src.get_data("/app/from-node2").await.unwrap();
+        let (dst_data_2, _) = dst.get_data("/app/from-node2").await.unwrap();
+        assert_eq!(src_data_2, dst_data_2, "from-node2 data mismatch");
+
+        // shadow metadata assertions — verify shadow znodes exist on both sides
+        Self::assert_shadow_exists(&dst, "/app/from-node1").await;
+        Self::assert_shadow_exists(&src, "/app/from-node2").await;
+
+        // marker assertions — verify data markers written on both sides
+        Self::assert_marker_exists(&src).await;
+        Self::assert_marker_exists(&dst).await;
+
+        // anti-loop stability — sleep again and verify data hasn't changed (no bounce-back loop)
+        let snapshot_src_1 = src.get_data("/app/from-node1").await.unwrap();
+        let snapshot_dst_2 = dst.get_data("/app/from-node2").await.unwrap();
+        TimeUtil::sleep_millis(parse_millis / 2).await;
+        let check_src_1 = src.get_data("/app/from-node1").await.unwrap();
+        let check_dst_2 = dst.get_data("/app/from-node2").await.unwrap();
+        assert_eq!(
+            snapshot_src_1.1.version, check_src_1.1.version,
+            "anti-loop: /app/from-node1 on src was modified again (version changed {} -> {})",
+            snapshot_src_1.1.version, check_src_1.1.version
+        );
+        assert_eq!(
+            snapshot_dst_2.1.version, check_dst_2.1.version,
+            "anti-loop: /app/from-node2 on dst was modified again (version changed {} -> {})",
+            snapshot_dst_2.1.version, check_dst_2.1.version
+        );
+
+        for handler in handlers {
+            handler.abort();
+            while !handler.is_finished() {
+                TimeUtil::sleep_millis(1).await;
+            }
+        }
+    }
+
+    async fn assert_shadow_exists(client: &zk::Client, data_path: &str) {
+        let shadow_path = format!("{}{}", SHADOW_PREFIX, data_path);
+        let (data, _) = client
+            .get_data(&shadow_path)
+            .await
+            .unwrap_or_else(|e| panic!("shadow znode {} should exist: {}", shadow_path, e));
+        let json: serde_json::Value = serde_json::from_slice(&data)
+            .unwrap_or_else(|e| panic!("shadow {} invalid JSON: {}", shadow_path, e));
+        assert!(
+            json.get("source_id")
+                .and_then(|v| v.as_str())
+                .map_or(false, |v| !v.is_empty()),
+            "shadow {} missing or empty source_id",
+            shadow_path
+        );
+        assert!(
+            json.get("source_order_millis")
+                .and_then(|v| v.as_i64())
+                .map_or(false, |v| v > 0),
+            "shadow {} missing or zero source_order_millis",
+            shadow_path
+        );
+        assert!(
+            json.get("version").and_then(|v| v.as_i64()).is_some(),
+            "shadow {} missing or invalid version",
+            shadow_path
+        );
+        assert_eq!(
+            json.get("deleted").and_then(|v| v.as_bool()),
+            Some(false),
+            "shadow {} should have deleted=false",
+            shadow_path
+        );
+    }
+
+    async fn assert_marker_exists(client: &zk::Client) {
+        let (data, _) = client
+            .get_data(MARKER_PATH)
+            .await
+            .unwrap_or_else(|e| panic!("marker {} should exist: {}", MARKER_PATH, e));
+        let json: serde_json::Value = serde_json::from_slice(&data)
+            .unwrap_or_else(|e| panic!("marker {} invalid JSON: {}", MARKER_PATH, e));
+        assert!(
+            json.get("source_id")
+                .and_then(|v| v.as_str())
+                .map_or(false, |v| !v.is_empty()),
+            "marker {} missing or empty source_id",
+            MARKER_PATH
+        );
+    }
+
+    async fn delete_node(client: &zk::Client, path: &str) {
+        match client.delete(path, None).await {
+            Ok(()) => {}
+            Err(ref e) if matches!(e, zk::Error::NoNode) => {}
+            Err(e) => panic!("delete_node {} failed: {}", path, e),
+        }
+    }
+
+    async fn ensure_path(client: &zk::Client, path: &str, options: &zk::CreateOptions<'_>) {
+        match client.create(path, &[], options).await {
+            Ok(_) => {}
+            Err(ref e) if matches!(e, zk::Error::NodeExists) => {}
+            Err(e) => panic!("ensure_path {} failed: {}", path, e),
+        }
+    }
+
+    fn delete_children<'a>(
+        client: &'a zk::Client,
+        path: &'a str,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + 'a>> {
+        Box::pin(async move {
+            let children = match client.get_children(path).await {
+                Ok((children, _)) => children,
+                Err(ref e) if matches!(e, zk::Error::NoNode) => return,
+                Err(e) => panic!("get_children {} failed: {}", path, e),
+            };
+            for child in children {
+                let child_path = format!("{}/{}", path, child);
+                Self::delete_children(client, &child_path).await;
+                match client.delete(&child_path, None).await {
+                    Ok(()) => {}
+                    Err(ref e) if matches!(e, zk::Error::NoNode) => {}
+                    Err(e) => panic!("delete {} failed: {}", child_path, e),
+                }
+            }
+        })
+    }
+}

--- a/dt-tests/tests/test_runner/zk_test_runner.rs
+++ b/dt-tests/tests/test_runner/zk_test_runner.rs
@@ -1,4 +1,4 @@
-use anyhow::bail;
+use anyhow::{bail, ensure};
 use dt_common::{
     config::{
         extractor_config::ExtractorConfig, sinker_config::SinkerConfig, task_config::TaskConfig,
@@ -11,6 +11,7 @@ use zookeeper_client as zk;
 use super::base_test_runner::BaseTestRunner;
 
 const SHADOW_PREFIX: &str = "/__ape_dts_shadow";
+const POLL_INTERVAL_MILLIS: u64 = 200;
 
 pub struct ZkTestRunner {
     pub base: BaseTestRunner,
@@ -51,18 +52,31 @@ impl ZkTestRunner {
         self.prepare_znodes(&src, &dst).await?;
 
         let task = self.base.spawn_task().await?;
-        TimeUtil::sleep_millis(start_millis).await;
+        let test_result = async {
+            TimeUtil::sleep_millis(start_millis).await;
 
-        self.execute_test_operations(&src).await?;
-        TimeUtil::sleep_millis(parse_millis).await;
+            self.execute_live_test_operations(&src).await?;
+            Self::wait_for_live_sync(&dst, "/app/svc-gamma", b"gamma-v1", parse_millis).await?;
 
-        self.compare_znodes(&src, &dst, "/app").await?;
+            src.delete("/app/svc-gamma", None)
+                .await
+                .map_err(|e| anyhow::anyhow!("delete /app/svc-gamma failed: {}", e))?;
+            Self::wait_for_tombstone(&dst, "/app/svc-gamma", parse_millis).await?;
 
-        Self::assert_shadow_metadata(&dst, "/app/svc-alpha").await?;
-        Self::assert_shadow_metadata(&dst, "/app/svc-beta").await?;
-        Self::assert_shadow_tombstone(&dst, "/app/svc-gamma").await?;
+            Self::compare_znodes(&src, &dst, "/app").await?;
+            Self::assert_shadow_metadata(&dst, "/app/svc-alpha").await?;
+            Self::assert_shadow_metadata(&dst, "/app/svc-beta").await
+        }
+        .await;
 
-        self.base.abort_task(&task).await
+        let abort_result = self.base.abort_task(&task).await;
+        match test_result {
+            Ok(()) => abort_result,
+            Err(error) => {
+                let _ = abort_result;
+                Err(error)
+            }
+        }
     }
 
     async fn prepare_znodes(&self, src: &zk::Client, dst: &zk::Client) -> anyhow::Result<()> {
@@ -80,7 +94,7 @@ impl ZkTestRunner {
         Ok(())
     }
 
-    async fn execute_test_operations(&self, src: &zk::Client) -> anyhow::Result<()> {
+    async fn execute_live_test_operations(&self, src: &zk::Client) -> anyhow::Result<()> {
         let options = zk::CreateMode::Persistent.with_acls(zk::Acls::anyone_all());
 
         src.create("/app/svc-alpha", b"alpha-v1", &options)
@@ -99,15 +113,138 @@ impl ZkTestRunner {
             .await
             .map_err(|e| anyhow::anyhow!("create /app/svc-gamma failed: {}", e))?;
 
-        src.delete("/app/svc-gamma", None)
-            .await
-            .map_err(|e| anyhow::anyhow!("delete /app/svc-gamma failed: {}", e))?;
-
         Ok(())
     }
 
+    async fn wait_for_live_sync(
+        client: &zk::Client,
+        data_path: &str,
+        expected_data: &[u8],
+        timeout_millis: u64,
+    ) -> anyhow::Result<()> {
+        let shadow_path = format!("{}{}", SHADOW_PREFIX, data_path);
+        let deadline =
+            tokio::time::Instant::now() + tokio::time::Duration::from_millis(timeout_millis);
+
+        loop {
+            let (data_matches, data_observation) = match client.get_data(data_path).await {
+                Ok((data, _)) => (
+                    data == expected_data,
+                    format!("data={:?}", String::from_utf8_lossy(&data)),
+                ),
+                Err(ref e) if matches!(e, zk::Error::NoNode) => {
+                    (false, String::from("data=missing"))
+                }
+                Err(e) => bail!("get live data {} failed: {}", data_path, e),
+            };
+
+            let (shadow_matches, shadow_observation) = match client.get_data(&shadow_path).await {
+                Ok((data, _)) => {
+                    let json: serde_json::Value = serde_json::from_slice(&data).map_err(|e| {
+                        anyhow::anyhow!("shadow {} invalid JSON: {}", shadow_path, e)
+                    })?;
+                    (Self::live_shadow_matches(&json), format!("shadow={}", json))
+                }
+                Err(ref e) if matches!(e, zk::Error::NoNode) => {
+                    (false, String::from("shadow=missing"))
+                }
+                Err(e) => bail!("get live shadow {} failed: {}", shadow_path, e),
+            };
+
+            if data_matches && shadow_matches {
+                return Ok(());
+            }
+            let last_observation = format!("{}, {}", data_observation, shadow_observation);
+            if tokio::time::Instant::now() >= deadline {
+                bail!(
+                    "live sync {} did not converge within {}ms; last observation: {}",
+                    data_path,
+                    timeout_millis,
+                    last_observation
+                );
+            }
+            TimeUtil::sleep_millis(POLL_INTERVAL_MILLIS).await;
+        }
+    }
+
+    async fn wait_for_tombstone(
+        client: &zk::Client,
+        data_path: &str,
+        timeout_millis: u64,
+    ) -> anyhow::Result<()> {
+        let shadow_path = format!("{}{}", SHADOW_PREFIX, data_path);
+        let deadline =
+            tokio::time::Instant::now() + tokio::time::Duration::from_millis(timeout_millis);
+
+        loop {
+            let (data_absent, data_observation) = match client.get_data(data_path).await {
+                Ok((data, _)) => (false, format!("data={:?}", String::from_utf8_lossy(&data))),
+                Err(ref e) if matches!(e, zk::Error::NoNode) => {
+                    (true, String::from("data=missing"))
+                }
+                Err(e) => bail!("get deleted data {} failed: {}", data_path, e),
+            };
+
+            let (shadow_matches, shadow_observation) = match client.get_data(&shadow_path).await {
+                Ok((data, _)) => {
+                    let json: serde_json::Value = serde_json::from_slice(&data).map_err(|e| {
+                        anyhow::anyhow!("tombstone shadow {} invalid JSON: {}", shadow_path, e)
+                    })?;
+                    (
+                        Self::tombstone_shadow_matches(&json),
+                        format!("shadow={}", json),
+                    )
+                }
+                Err(ref e) if matches!(e, zk::Error::NoNode) => {
+                    (false, String::from("shadow=missing"))
+                }
+                Err(e) => bail!("get tombstone shadow {} failed: {}", shadow_path, e),
+            };
+
+            if data_absent && shadow_matches {
+                return Ok(());
+            }
+            let last_observation = format!("{}, {}", data_observation, shadow_observation);
+            if tokio::time::Instant::now() >= deadline {
+                bail!(
+                    "delete sync {} did not converge within {}ms; last observation: {}",
+                    data_path,
+                    timeout_millis,
+                    last_observation
+                );
+            }
+            TimeUtil::sleep_millis(POLL_INTERVAL_MILLIS).await;
+        }
+    }
+
+    fn live_shadow_matches(json: &serde_json::Value) -> bool {
+        json.get("source_id")
+            .and_then(|v| v.as_str())
+            .is_some_and(|v| !v.is_empty())
+            && json
+                .get("source_order_millis")
+                .and_then(|v| v.as_i64())
+                .is_some_and(|v| v > 0)
+            && json.get("version").and_then(|v| v.as_i64()).is_some()
+            && json.get("deleted").and_then(|v| v.as_bool()) == Some(false)
+    }
+
+    fn tombstone_shadow_matches(json: &serde_json::Value) -> bool {
+        json.get("source_id")
+            .and_then(|v| v.as_str())
+            .is_some_and(|v| !v.is_empty())
+            && json.get("deleted").and_then(|v| v.as_bool()) == Some(true)
+            && json
+                .get("source_order_millis")
+                .and_then(|v| v.as_i64())
+                .is_some_and(|v| v > 0)
+            && json
+                .get("source_zxid")
+                .and_then(|v| v.as_i64())
+                .is_some_and(|v| v > 0)
+    }
+
     fn compare_znodes<'a>(
-        &'a self,
         src: &'a zk::Client,
         dst: &'a zk::Client,
         path: &'a str,
@@ -139,10 +276,12 @@ impl ZkTestRunner {
                 .filter(|c| !c.starts_with("__ape_dts_"))
                 .collect();
 
-            assert_eq!(
-                src_filtered, dst_filtered,
+            ensure!(
+                src_filtered == dst_filtered,
                 "children mismatch at {}: src={:?}, dst={:?}",
-                path, src_filtered, dst_filtered
+                path,
+                src_filtered,
+                dst_filtered
             );
 
             for child in &src_filtered {
@@ -157,16 +296,15 @@ impl ZkTestRunner {
                     .await
                     .map_err(|e| anyhow::anyhow!("get_data dst {} failed: {}", child_path, e))?;
 
-                assert_eq!(
-                    src_data,
-                    dst_data,
+                ensure!(
+                    src_data == dst_data,
                     "data mismatch at {}: src={:?}, dst={:?}",
                     child_path,
                     String::from_utf8_lossy(&src_data),
                     String::from_utf8_lossy(&dst_data)
                 );
 
-                self.compare_znodes(src, dst, &child_path).await?;
+                Self::compare_znodes(src, dst, &child_path).await?;
             }
 
             Ok(())
@@ -181,68 +319,11 @@ impl ZkTestRunner {
             .map_err(|e| anyhow::anyhow!("shadow znode {} should exist: {}", shadow_path, e))?;
         let json: serde_json::Value = serde_json::from_slice(&data)
             .map_err(|e| anyhow::anyhow!("shadow {} invalid JSON: {}", shadow_path, e))?;
-        assert!(
-            json.get("source_id")
-                .and_then(|v| v.as_str())
-                .map_or(false, |v| !v.is_empty()),
-            "shadow {} missing or empty source_id",
-            shadow_path
-        );
-        assert!(
-            json.get("source_order_millis")
-                .and_then(|v| v.as_i64())
-                .map_or(false, |v| v > 0),
-            "shadow {} missing or zero source_order_millis",
-            shadow_path
-        );
-        assert!(
-            json.get("version").and_then(|v| v.as_i64()).is_some(),
-            "shadow {} missing or invalid version",
-            shadow_path
-        );
-        assert_eq!(
-            json.get("deleted").and_then(|v| v.as_bool()),
-            Some(false),
-            "shadow {} should have deleted=false",
-            shadow_path
-        );
-        Ok(())
-    }
-
-    async fn assert_shadow_tombstone(client: &zk::Client, data_path: &str) -> anyhow::Result<()> {
-        let shadow_path = format!("{}{}", SHADOW_PREFIX, data_path);
-        let (data, _) = client
-            .get_data(&shadow_path)
-            .await
-            .map_err(|e| anyhow::anyhow!("tombstone shadow {} should exist: {}", shadow_path, e))?;
-        let json: serde_json::Value = serde_json::from_slice(&data)
-            .map_err(|e| anyhow::anyhow!("tombstone shadow {} invalid JSON: {}", shadow_path, e))?;
-        assert!(
-            json.get("source_id")
-                .and_then(|v| v.as_str())
-                .map_or(false, |v| !v.is_empty()),
-            "tombstone shadow {} missing or empty source_id",
-            shadow_path
-        );
-        assert_eq!(
-            json.get("deleted").and_then(|v| v.as_bool()),
-            Some(true),
-            "tombstone shadow {} should have deleted=true",
-            shadow_path
-        );
-        assert!(
-            json.get("source_order_millis")
-                .and_then(|v| v.as_i64())
-                .map_or(false, |v| v > 0),
-            "tombstone shadow {} should have source_order_millis > 0",
-            shadow_path
-        );
-        assert!(
-            json.get("source_zxid")
-                .and_then(|v| v.as_i64())
-                .map_or(false, |v| v > 0),
-            "tombstone shadow {} should have source_zxid > 0",
-            shadow_path
+        ensure!(
+            Self::live_shadow_matches(&json),
+            "shadow {} missing required live metadata: {}",
+            shadow_path,
+            json
         );
         Ok(())
     }

--- a/dt-tests/tests/test_runner/zk_test_runner.rs
+++ b/dt-tests/tests/test_runner/zk_test_runner.rs
@@ -1,0 +1,293 @@
+use anyhow::bail;
+use dt_common::{
+    config::{
+        extractor_config::ExtractorConfig, sinker_config::SinkerConfig, task_config::TaskConfig,
+    },
+    error::Error,
+    utils::time_util::TimeUtil,
+};
+use zookeeper_client as zk;
+
+use super::base_test_runner::BaseTestRunner;
+
+const SHADOW_PREFIX: &str = "/__ape_dts_shadow";
+
+pub struct ZkTestRunner {
+    pub base: BaseTestRunner,
+    pub src_url: String,
+    pub dst_url: String,
+}
+
+impl ZkTestRunner {
+    pub async fn new(relative_test_dir: &str) -> anyhow::Result<Self> {
+        let base = BaseTestRunner::new(relative_test_dir).await?;
+        let config = TaskConfig::new(&base.task_config_file)?;
+
+        let src_url = match &config.extractor {
+            ExtractorConfig::Zk { url, .. } => url.clone(),
+            _ => bail!(Error::ConfigError("expected Zk extractor config".into())),
+        };
+
+        let dst_url = match &config.sinker {
+            SinkerConfig::Zk { url, .. } => url.clone(),
+            _ => bail!(Error::ConfigError("expected Zk sinker config".into())),
+        };
+
+        Ok(Self {
+            base,
+            src_url,
+            dst_url,
+        })
+    }
+
+    pub async fn run_cdc_test(&self, start_millis: u64, parse_millis: u64) -> anyhow::Result<()> {
+        let src = zk::Client::connect(&self.src_url)
+            .await
+            .map_err(|e| anyhow::anyhow!("connect src ZK failed: {}", e))?;
+        let dst = zk::Client::connect(&self.dst_url)
+            .await
+            .map_err(|e| anyhow::anyhow!("connect dst ZK failed: {}", e))?;
+
+        self.prepare_znodes(&src, &dst).await?;
+
+        let task = self.base.spawn_task().await?;
+        TimeUtil::sleep_millis(start_millis).await;
+
+        self.execute_test_operations(&src).await?;
+        TimeUtil::sleep_millis(parse_millis).await;
+
+        self.compare_znodes(&src, &dst, "/app").await?;
+
+        Self::assert_shadow_metadata(&dst, "/app/svc-alpha").await?;
+        Self::assert_shadow_metadata(&dst, "/app/svc-beta").await?;
+        Self::assert_shadow_tombstone(&dst, "/app/svc-gamma").await?;
+
+        self.base.abort_task(&task).await
+    }
+
+    async fn prepare_znodes(&self, src: &zk::Client, dst: &zk::Client) -> anyhow::Result<()> {
+        let options = zk::CreateMode::Persistent.with_acls(zk::Acls::anyone_all());
+
+        Self::ensure_path(src, "/app", &options).await?;
+        Self::ensure_path(dst, "/app", &options).await?;
+
+        Self::delete_children(src, "/app").await?;
+        Self::delete_children(dst, "/app").await?;
+
+        Self::delete_children(dst, SHADOW_PREFIX).await?;
+        Self::delete_node(dst, SHADOW_PREFIX).await?;
+
+        Ok(())
+    }
+
+    async fn execute_test_operations(&self, src: &zk::Client) -> anyhow::Result<()> {
+        let options = zk::CreateMode::Persistent.with_acls(zk::Acls::anyone_all());
+
+        src.create("/app/svc-alpha", b"alpha-v1", &options)
+            .await
+            .map_err(|e| anyhow::anyhow!("create /app/svc-alpha failed: {}", e))?;
+
+        src.create("/app/svc-beta", b"beta-v1", &options)
+            .await
+            .map_err(|e| anyhow::anyhow!("create /app/svc-beta failed: {}", e))?;
+
+        src.set_data("/app/svc-alpha", b"alpha-v2", None)
+            .await
+            .map_err(|e| anyhow::anyhow!("update /app/svc-alpha failed: {}", e))?;
+
+        src.create("/app/svc-gamma", b"gamma-v1", &options)
+            .await
+            .map_err(|e| anyhow::anyhow!("create /app/svc-gamma failed: {}", e))?;
+
+        src.delete("/app/svc-gamma", None)
+            .await
+            .map_err(|e| anyhow::anyhow!("delete /app/svc-gamma failed: {}", e))?;
+
+        Ok(())
+    }
+
+    fn compare_znodes<'a>(
+        &'a self,
+        src: &'a zk::Client,
+        dst: &'a zk::Client,
+        path: &'a str,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<()>> + 'a>> {
+        Box::pin(async move {
+            let src_children = match src.get_children(path).await {
+                Ok((children, _)) => children,
+                Err(ref e) if matches!(e, zk::Error::NoNode) => vec![],
+                Err(e) => bail!("get_children src {} failed: {}", path, e),
+            };
+
+            let dst_children = match dst.get_children(path).await {
+                Ok((children, _)) => children,
+                Err(ref e) if matches!(e, zk::Error::NoNode) => vec![],
+                Err(e) => bail!("get_children dst {} failed: {}", path, e),
+            };
+
+            let mut src_sorted = src_children.clone();
+            src_sorted.sort();
+            let mut dst_sorted = dst_children.clone();
+            dst_sorted.sort();
+
+            let src_filtered: Vec<&String> = src_sorted
+                .iter()
+                .filter(|c| !c.starts_with("__ape_dts_"))
+                .collect();
+            let dst_filtered: Vec<&String> = dst_sorted
+                .iter()
+                .filter(|c| !c.starts_with("__ape_dts_"))
+                .collect();
+
+            assert_eq!(
+                src_filtered, dst_filtered,
+                "children mismatch at {}: src={:?}, dst={:?}",
+                path, src_filtered, dst_filtered
+            );
+
+            for child in &src_filtered {
+                let child_path = format!("{}/{}", path, child);
+
+                let (src_data, _) = src
+                    .get_data(&child_path)
+                    .await
+                    .map_err(|e| anyhow::anyhow!("get_data src {} failed: {}", child_path, e))?;
+                let (dst_data, _) = dst
+                    .get_data(&child_path)
+                    .await
+                    .map_err(|e| anyhow::anyhow!("get_data dst {} failed: {}", child_path, e))?;
+
+                assert_eq!(
+                    src_data,
+                    dst_data,
+                    "data mismatch at {}: src={:?}, dst={:?}",
+                    child_path,
+                    String::from_utf8_lossy(&src_data),
+                    String::from_utf8_lossy(&dst_data)
+                );
+
+                self.compare_znodes(src, dst, &child_path).await?;
+            }
+
+            Ok(())
+        })
+    }
+
+    async fn assert_shadow_metadata(client: &zk::Client, data_path: &str) -> anyhow::Result<()> {
+        let shadow_path = format!("{}{}", SHADOW_PREFIX, data_path);
+        let (data, _) = client
+            .get_data(&shadow_path)
+            .await
+            .map_err(|e| anyhow::anyhow!("shadow znode {} should exist: {}", shadow_path, e))?;
+        let json: serde_json::Value = serde_json::from_slice(&data)
+            .map_err(|e| anyhow::anyhow!("shadow {} invalid JSON: {}", shadow_path, e))?;
+        assert!(
+            json.get("source_id")
+                .and_then(|v| v.as_str())
+                .map_or(false, |v| !v.is_empty()),
+            "shadow {} missing or empty source_id",
+            shadow_path
+        );
+        assert!(
+            json.get("source_order_millis")
+                .and_then(|v| v.as_i64())
+                .map_or(false, |v| v > 0),
+            "shadow {} missing or zero source_order_millis",
+            shadow_path
+        );
+        assert!(
+            json.get("version").and_then(|v| v.as_i64()).is_some(),
+            "shadow {} missing or invalid version",
+            shadow_path
+        );
+        assert_eq!(
+            json.get("deleted").and_then(|v| v.as_bool()),
+            Some(false),
+            "shadow {} should have deleted=false",
+            shadow_path
+        );
+        Ok(())
+    }
+
+    async fn assert_shadow_tombstone(client: &zk::Client, data_path: &str) -> anyhow::Result<()> {
+        let shadow_path = format!("{}{}", SHADOW_PREFIX, data_path);
+        let (data, _) = client
+            .get_data(&shadow_path)
+            .await
+            .map_err(|e| anyhow::anyhow!("tombstone shadow {} should exist: {}", shadow_path, e))?;
+        let json: serde_json::Value = serde_json::from_slice(&data)
+            .map_err(|e| anyhow::anyhow!("tombstone shadow {} invalid JSON: {}", shadow_path, e))?;
+        assert!(
+            json.get("source_id")
+                .and_then(|v| v.as_str())
+                .map_or(false, |v| !v.is_empty()),
+            "tombstone shadow {} missing or empty source_id",
+            shadow_path
+        );
+        assert_eq!(
+            json.get("deleted").and_then(|v| v.as_bool()),
+            Some(true),
+            "tombstone shadow {} should have deleted=true",
+            shadow_path
+        );
+        assert!(
+            json.get("source_order_millis")
+                .and_then(|v| v.as_i64())
+                .map_or(false, |v| v > 0),
+            "tombstone shadow {} should have source_order_millis > 0",
+            shadow_path
+        );
+        assert!(
+            json.get("source_zxid")
+                .and_then(|v| v.as_i64())
+                .map_or(false, |v| v > 0),
+            "tombstone shadow {} should have source_zxid > 0",
+            shadow_path
+        );
+        Ok(())
+    }
+
+    async fn delete_node(client: &zk::Client, path: &str) -> anyhow::Result<()> {
+        match client.delete(path, None).await {
+            Ok(()) => Ok(()),
+            Err(ref e) if matches!(e, zk::Error::NoNode) => Ok(()),
+            Err(e) => bail!("delete_node {} failed: {}", path, e),
+        }
+    }
+
+    async fn ensure_path(
+        client: &zk::Client,
+        path: &str,
+        options: &zk::CreateOptions<'_>,
+    ) -> anyhow::Result<()> {
+        match client.create(path, &[], options).await {
+            Ok(_) => Ok(()),
+            Err(ref e) if matches!(e, zk::Error::NodeExists) => Ok(()),
+            Err(e) => bail!("ensure_path {} failed: {}", path, e),
+        }
+    }
+
+    fn delete_children<'a>(
+        client: &'a zk::Client,
+        path: &'a str,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<()>> + 'a>> {
+        Box::pin(async move {
+            let children = match client.get_children(path).await {
+                Ok((children, _)) => children,
+                Err(ref e) if matches!(e, zk::Error::NoNode) => return Ok(()),
+                Err(e) => bail!("get_children {} failed: {}", path, e),
+            };
+
+            for child in children {
+                let child_path = format!("{}/{}", path, child);
+                Self::delete_children(client, &child_path).await?;
+                match client.delete(&child_path, None).await {
+                    Ok(()) => {}
+                    Err(ref e) if matches!(e, zk::Error::NoNode) => {}
+                    Err(e) => bail!("delete {} failed: {}", child_path, e),
+                }
+            }
+            Ok(())
+        })
+    }
+}

--- a/dt-tests/tests/zk_to_zk/cdc/basic_test/task_config.ini
+++ b/dt-tests/tests/zk_to_zk/cdc/basic_test/task_config.ini
@@ -1,21 +1,21 @@
 [extractor]
 db_type=zk
 extract_type=cdc
-url=localhost:2181
+url={zk_src_url}
 watch_paths=/app,/config
 scan_interval_secs=5
 include_ephemeral=false
 heartbeat_interval_secs=10
 
 [zk_filter]
-do_paths=*
+do_paths=/app,/config
 ignore_paths=/zookeeper,/__ape_dts_shadow
 include_ephemeral=false
 
 [sinker]
 db_type=zk
 sink_type=write
-url=localhost:2182
+url={zk_dst_url}
 batch_size=1
 create_if_not_exists=true
 sync_ephemeral_as_persistent=true

--- a/dt-tests/tests/zk_to_zk/cdc/basic_test/topo1_node1_to_node2/task_config.ini
+++ b/dt-tests/tests/zk_to_zk/cdc/basic_test/topo1_node1_to_node2/task_config.ini
@@ -1,7 +1,7 @@
 [extractor]
 db_type=zk
 extract_type=cdc
-url=localhost:2181
+url={zk_src_url}
 watch_paths=/app
 scan_interval_secs=5
 include_ephemeral=false
@@ -24,7 +24,7 @@ marker=/__ape_dts_marker
 [sinker]
 db_type=zk
 sink_type=write
-url=localhost:2182
+url={zk_dst_url}
 batch_size=200
 create_if_not_exists=true
 sync_ephemeral_as_persistent=false

--- a/dt-tests/tests/zk_to_zk/cdc/basic_test/topo1_node2_to_node1/task_config.ini
+++ b/dt-tests/tests/zk_to_zk/cdc/basic_test/topo1_node2_to_node1/task_config.ini
@@ -1,7 +1,7 @@
 [extractor]
 db_type=zk
 extract_type=cdc
-url=localhost:2182
+url={zk_dst_url}
 watch_paths=/app
 scan_interval_secs=5
 include_ephemeral=false
@@ -24,7 +24,7 @@ marker=/__ape_dts_marker
 [sinker]
 db_type=zk
 sink_type=write
-url=localhost:2181
+url={zk_src_url}
 batch_size=200
 create_if_not_exists=true
 sync_ephemeral_as_persistent=false

--- a/dt-tests/tests/zk_to_zk/cdc_tests.rs
+++ b/dt-tests/tests/zk_to_zk/cdc_tests.rs
@@ -1,0 +1,18 @@
+#[cfg(test)]
+mod test {
+    use crate::test_runner::{test_base::TestBase, zk_cycle_test_runner::ZkCycleTestRunner};
+
+    use serial_test::serial;
+
+    #[tokio::test]
+    #[serial]
+    async fn cdc_basic_test() {
+        TestBase::run_zk_cdc_test("zk_to_zk/cdc/basic_test", 3000, 8000).await;
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn cdc_cycle_basic_test() {
+        ZkCycleTestRunner::run_cycle_cdc_test("zk_to_zk/cdc/basic_test", 2000, 10000).await;
+    }
+}

--- a/dt-tests/tests/zk_to_zk/mod.rs
+++ b/dt-tests/tests/zk_to_zk/mod.rs
@@ -1,0 +1,1 @@
+mod cdc_tests;


### PR DESCRIPTION
## Summary

- add local ZooKeeper source/target services for dt-tests
- add one-way and cycle ZK integration runners
- make ZK test endpoints configurable through the existing `.env` substitution path
- assert live shadow metadata, tombstones, markers, data convergence, and anti-loop version stability
- require the live data + live shadow precondition before testing delete/tombstone convergence

## Candidate pin

- stacked base: PR #504 branch `feat/zk-connector-interface`
- base commit tested: `de88a916afd6c4e6b84cfc3fb359133069bc9cfc`
- initial patch commit: `547164793135e4b150a3f623ab4e2fa86d38ef62`
- current patch head: `e2c2f293b9ab7381fe6f55a6a9a2c411afc411a3`

## Verification

Local gates on the current head:

- `git diff --check`: PASS
- `cargo fmt --all --check`: PASS
- `cargo test --package dt-tests --test integration_test --no-run`: PASS
- ordinary clippy: PASS with six pre-existing warnings outside the changed file
- independent 8-class design-contract review by @Vicky: no blocker

Manual GitHub workflows on the exact current head (the stacked base does not auto-trigger pull-request workflows):

- CI run [29128577141](https://github.com/apecloud/ape-dts/actions/runs/29128577141): 2/2 jobs success
- Integration Tests run [29128577120](https://github.com/apecloud/ape-dts/actions/runs/29128577120): 33/33 jobs success

Focused IDC2 ZooKeeper runtime on the exact current head:

- one-way `cdc_basic_test`: N=1 PASS, 1 passed / 0 failed, 3.62s
- cycle `cdc_cycle_basic_test`: N=1 PASS, 1 passed / 0 failed, 19.19s
- source and target cleanup: `/app`, `/__ape_dts_shadow`, and `/__ape_dts_marker` have no ape-dts residue

The original head produced one focused one-way FAIL because the runner created and immediately deleted `svc-gamma` before the extractor recorded its live state. The current head fixes that Layer 3 test-ordering defect with bounded live-precondition and tombstone-convergence checks; the focused rerun then passed.

## Boundary

This PR remains stacked on unmerged PR #504. The evidence above is exact-head static/compile, one manual CI workflow, one manual Integration Tests workflow, and focused IDC runtime N=1+1. It is sufficient for code review but is not a full-acceptance or release-ready claim. If PR #504 merges to a different final SHA, this branch must be re-pinned and affected gates rerun before retargeting to `main`.
