### PR TITLE
fix: idle pipeline cause high cpu

### DIFF
--- a/dt-common/src/meta/dt_queue.rs
+++ b/dt-common/src/meta/dt_queue.rs
@@ -2,19 +2,29 @@ use std::sync::{
     atomic::{AtomicU64, Ordering},
     Arc,
 };
-use tokio::sync::Notify;
 
 use concurrent_queue::{ConcurrentQueue, PopError, PushError};
+use tokio::{sync::Notify, time::timeout, time::Duration};
 
 use crate::limiter::buffer_limiter::BufferLimiter;
 
 use super::dt_data::DtItem;
+
+#[derive(Debug, thiserror::Error)]
+pub enum DtQueuePopError {
+    #[error("queue pop error: {0}")]
+    Queue(#[from] PopError),
+
+    #[error("dequeue limiter error: {0}")]
+    DequeueLimiter(#[source] anyhow::Error),
+}
 
 pub struct DtQueue {
     queue: ConcurrentQueue<DtItem>,
     check_memory: bool,
     max_bytes: u64,
     cur_bytes: AtomicU64,
+    not_empty: Arc<Notify>,
     not_full: Arc<Notify>,
     enqueue_limiter: Option<Arc<BufferLimiter>>,
     dequeue_limiter: Option<Arc<BufferLimiter>>,
@@ -32,6 +42,7 @@ impl DtQueue {
             max_bytes,
             check_memory: max_bytes > 0,
             cur_bytes: AtomicU64::new(0),
+            not_empty: Arc::new(Notify::new()),
             not_full: Arc::new(Notify::new()),
             enqueue_limiter,
             dequeue_limiter,
@@ -69,6 +80,7 @@ impl DtQueue {
                 match res {
                     Ok(_) => {
                         self.cur_bytes.fetch_add(item_size, Ordering::Release);
+                        self.not_empty.notify_one();
                         return Ok(());
                     }
                     Err(PushError::Full(returned_item)) => {
@@ -81,18 +93,23 @@ impl DtQueue {
         }
     }
 
-    pub async fn pop(&self) -> anyhow::Result<DtItem, PopError> {
+    pub async fn pop(&self) -> Result<DtItem, DtQueuePopError> {
         let item = self.queue.pop()?;
 
         if let Some(enqueue_limiter) = &self.enqueue_limiter {
             enqueue_limiter.release(&item).await;
         }
-        if let Some(dequeue_limiter) = &self.dequeue_limiter {
-            // error can not be returned here, the item has been popped out,
-            // and the limiter acquire should not fail.
-            dequeue_limiter.acquire(&item).await.unwrap();
-            dequeue_limiter.release(&item).await;
-        }
+        let dequeue_result = if let Some(dequeue_limiter) = &self.dequeue_limiter {
+            match dequeue_limiter.acquire(&item).await {
+                Ok(()) => {
+                    dequeue_limiter.release(&item).await;
+                    Ok(())
+                }
+                Err(error) => Err(DtQueuePopError::DequeueLimiter(error)),
+            }
+        } else {
+            Ok(())
+        };
 
         if self.queue.is_empty() {
             self.cur_bytes.store(0, Ordering::Release);
@@ -103,7 +120,12 @@ impl DtQueue {
 
         self.not_full.notify_one();
 
+        dequeue_result?;
         Ok(item)
+    }
+
+    pub async fn wait_for_data(&self, max_wait: Duration) {
+        let _ = timeout(max_wait, self.not_empty.notified()).await;
     }
 
     #[inline(always)]
@@ -113,5 +135,92 @@ impl DtQueue {
         } else {
             false
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashMap, sync::Arc, time::Duration};
+
+    use tokio::time::{sleep, timeout};
+
+    use super::{DtQueue, DtQueuePopError};
+    use crate::{
+        config::limiter_config::RateLimiterConfig,
+        limiter::buffer_limiter::BufferLimiter,
+        meta::{
+            col_value::ColValue,
+            dt_data::{DtData, DtItem},
+            position::Position,
+            row_data::RowData,
+            row_type::RowType,
+        },
+    };
+
+    fn heartbeat_item() -> DtItem {
+        DtItem {
+            dt_data: DtData::Heartbeat {},
+            position: Position::None,
+            data_origin_node: String::new(),
+        }
+    }
+
+    fn bytes_item(data_size: usize) -> DtItem {
+        DtItem {
+            dt_data: DtData::Dml {
+                row_data: RowData {
+                    schema: "db".to_string(),
+                    tb: "tb".to_string(),
+                    chunk_id: 0,
+                    row_type: RowType::Insert,
+                    before: None,
+                    after: Some(HashMap::from([(
+                        "c1".to_string(),
+                        ColValue::RawString(Vec::new()),
+                    )])),
+                    data_size,
+                    is_not_origin: false,
+                },
+            },
+            position: Position::None,
+            data_origin_node: String::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn wait_for_data_wakes_after_push() {
+        let queue = Arc::new(DtQueue::new(8, 0, None, None));
+        let waiter_queue = queue.clone();
+        let waiter = tokio::spawn(async move {
+            waiter_queue.wait_for_data(Duration::from_secs(30)).await;
+        });
+
+        sleep(Duration::from_millis(20)).await;
+        assert!(!waiter.is_finished());
+
+        queue.push(heartbeat_item()).await.unwrap();
+        timeout(Duration::from_millis(200), waiter)
+            .await
+            .expect("waiter should wake after push")
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn pop_returns_dequeue_limiter_error_without_panicking() {
+        let rate_config = RateLimiterConfig {
+            max_mbps: 1,
+            max_rps: 0,
+        };
+        let dequeue_limiter = BufferLimiter::from_config(Some(&rate_config), None)
+            .map(Arc::new)
+            .unwrap();
+        let queue = DtQueue::new(1, 0, None, Some(dequeue_limiter));
+        queue.push(bytes_item(2 * 1024 * 1024)).await.unwrap();
+
+        let error = queue.pop().await.unwrap_err();
+
+        assert!(matches!(error, DtQueuePopError::DequeueLimiter(_)));
+        assert!(queue.is_empty());
+        assert_eq!(queue.get_curr_size(), 0);
     }
 }

--- a/dt-parallelizer/src/base_parallelizer.rs
+++ b/dt-parallelizer/src/base_parallelizer.rs
@@ -1,19 +1,22 @@
 use std::{collections::VecDeque, future::Future, sync::Arc};
 
 use anyhow::bail;
+use concurrent_queue::PopError;
+use tokio::task::JoinSet;
 
 use dt_common::{
-    error::Error,
     meta::{
-        dcl_meta::dcl_data::DclData, ddl_meta::ddl_data::DdlData, dt_data::DtItem,
-        dt_queue::DtQueue, row_data::RowData,
+        dcl_meta::dcl_data::DclData,
+        ddl_meta::ddl_data::DdlData,
+        dt_data::DtItem,
+        dt_queue::{DtQueue, DtQueuePopError},
+        row_data::RowData,
     },
     monitor::{
         counter::Counter, counter_type::CounterType, task_monitor_handle::TaskMonitorHandle,
     },
 };
 use dt_connector::Sinker;
-use tokio::task::JoinSet;
 
 type SharedSinker = Arc<async_mutex::Mutex<Box<dyn Sinker + Send>>>;
 
@@ -32,7 +35,7 @@ impl BaseParallelizer {
 
         let mut record_size_counter = Counter::new(0, 0);
         // ddls and dmls should be drained separately
-        while let Ok(item) = self.pop(buffer, &mut record_size_counter).await {
+        while let Some(item) = self.pop(buffer, &mut record_size_counter).await? {
             if data.is_empty()
                 || (data[0].get_row_sql_type() == item.get_row_sql_type()
                     && data[0].data_origin_node == item.data_origin_node)
@@ -56,7 +59,7 @@ impl BaseParallelizer {
     ) -> anyhow::Result<Vec<DtItem>> {
         let mut data = Vec::new();
         let mut record_size_counter = Counter::new(0, 0);
-        while let Ok(item) = self.pop(buffer, &mut record_size_counter).await {
+        while let Some(item) = self.pop(buffer, &mut record_size_counter).await? {
             data.push(item);
             if data.len() >= max_count {
                 break;
@@ -70,16 +73,17 @@ impl BaseParallelizer {
         &self,
         buffer: &DtQueue,
         record_size_counter: &mut Counter,
-    ) -> anyhow::Result<DtItem> {
+    ) -> anyhow::Result<Option<DtItem>> {
         match buffer.pop().await {
             Ok(item) => {
                 record_size_counter.add(
                     item.dt_data.get_data_size(),
                     item.dt_data.get_data_count() as u64,
                 );
-                Ok(item)
+                Ok(Some(item))
             }
-            Err(error) => bail! {Error::PipelineError(format!("buffer pop error: {}", error))},
+            Err(DtQueuePopError::Queue(PopError::Empty)) => Ok(None),
+            Err(error) => Err(error.into()),
         }
     }
 
@@ -223,5 +227,23 @@ impl BaseParallelizer {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use dt_common::{meta::dt_queue::DtQueue, monitor::counter::Counter};
+
+    use super::BaseParallelizer;
+
+    #[tokio::test]
+    async fn pop_returns_none_when_queue_is_empty() {
+        let parallelizer = BaseParallelizer::default();
+        let queue = DtQueue::new(1, 0, None, None);
+        let mut counter = Counter::new(0, 0);
+
+        let item = parallelizer.pop(&queue, &mut counter).await.unwrap();
+
+        assert!(item.is_none());
     }
 }

--- a/dt-parallelizer/src/partition_parallelizer.rs
+++ b/dt-parallelizer/src/partition_parallelizer.rs
@@ -31,10 +31,10 @@ impl Parallelizer for PartitionParallelizer {
     async fn drain(&mut self, buffer: &DtQueue) -> anyhow::Result<Vec<DtItem>> {
         let mut data = Vec::new();
         let mut record_size_counter = Counter::new(0, 0);
-        while let Ok(item) = self
+        while let Some(item) = self
             .base_parallelizer
             .pop(buffer, &mut record_size_counter)
-            .await
+            .await?
         {
             match &item.dt_data {
                 DtData::Dml { row_data } => {

--- a/dt-pipeline/src/base_pipeline.rs
+++ b/dt-pipeline/src/base_pipeline.rs
@@ -7,7 +7,7 @@ use std::sync::{
 use tokio::{
     sync::{Mutex, RwLock},
     task::yield_now,
-    time::Instant,
+    time::{Duration, Instant},
 };
 
 use crate::{lua_processor::LuaProcessor, Pipeline};
@@ -93,10 +93,20 @@ impl Pipeline for BasePipeline {
         let mut last_commit_positions = HashMap::new();
         let mut record_time = Instant::now();
 
-        while !self.shut_down.load(Ordering::Acquire)
-            || !self.buffer.is_empty()
-            || !self.pending_snapshot_finished.is_empty()
-        {
+        loop {
+            let shutting_down = self.shut_down.load(Ordering::Acquire);
+            let buffer_empty = self.buffer.is_empty();
+            let pending_finish_empty = self.pending_snapshot_finished.is_empty();
+            let has_pending_work = !buffer_empty || !pending_finish_empty;
+
+            if shutting_down && !has_pending_work {
+                break;
+            }
+
+            if !has_pending_work {
+                self.buffer.wait_for_data(Duration::from_secs(1)).await;
+            }
+
             // to avoid too many sub counters, only add counter when buffer is not empty
             if !self.buffer.is_empty() {
                 self.monitor


### PR DESCRIPTION
1. If dt_queue is empty, we should wait for incoming data and wake up when new data is available.
2. pop should not fail when the queue is empty. It should simply return None.