### PR TITLE
fix: refactor checker framework

### DIFF
--- a/docs/en/cdc/sync.md
+++ b/docs/en/cdc/sync.md
@@ -14,16 +14,16 @@ If you need validation in the CDC pipeline, use the [inline cdc check flow](../s
 
 Compared with the default CDC-only sync path, inline cdc check requires:
 - keep `[sinker] sink_type=write`
-- add `[checker] enable=true`
+- add `[checker_cdc] is_enabled=true`
 - add `[resumer] resume_type=from_target` or `from_db`
 - use `[parallelizer] parallel_type=rdb_merge`
 
-The checker reuses the parsed `[sinker]` target directly, so `[checker]` must not set `db_type`, `url`, `username`, or `password`.
+The checker reuses the parsed `[sinker]` target directly, so the checker target comes from `[sinker]`; common check options remain under `[checker]`.
 
 This flow is currently supported only for MySQL and PostgreSQL write sinkers.
 
 Inline cdc check is best-effort: CDC writes stay on the main path. If the checker queue reaches
-`[checker].queue_size`, the oldest pending checker batch is dropped instead of blocking new writes.
+`[checker_cdc].queue_size`, the oldest pending checker batch is dropped instead of blocking new writes.
 Checker-side runtime errors are logged, but they do not block CDC writes, checkpoint persistence,
 or metadata refresh delivery on the main path.
 
@@ -38,7 +38,7 @@ Notes:
 - `check off` means CDC only: `[extractor] extract_type=cdc`, `[sinker] sink_type=write`,
   `[parallelizer] parallel_type=rdb_merge`.
 - `check on` means the same CDC path plus inline cdc check:
-  `[checker] enable=true`, `[checker] batch_size=200`, and
+  `[checker_cdc] is_enabled=true`, `[checker] batch_size=200`, and
   `[resumer] resume_type=from_target`.
 - The shared task-side tuning in these reruns is:
   `[sinker] batch_size=200`, `[parallelizer] parallel_size=8`,

--- a/docs/en/cdc/two_way.md
+++ b/docs/en/cdc/two_way.md
@@ -8,14 +8,14 @@ To enable two-way data sync, we need to configure CDC tasks for both "source -> 
 
 If you also want validation in each CDC direction, use the [inline cdc check flow](../snapshot/check.md#inline-cdc-check).
 
-For each task, keep `[sinker] sink_type=write`, add `[checker] enable=true`, add `[resumer] resume_type=from_target` or `from_db`, and use `[parallelizer] parallel_type=rdb_merge`.
+For each task, keep `[sinker] sink_type=write`, add `[checker_cdc] is_enabled=true`, add `[resumer] resume_type=from_target` or `from_db`, and use `[parallelizer] parallel_type=rdb_merge`.
 
-The checker reuses the parsed `[sinker]` target directly, so `[checker]` must not set `db_type`, `url`, `username`, or `password`.
+The checker reuses the parsed `[sinker]` target directly, so the checker target comes from `[sinker]`; common check options remain under `[checker]`.
 
 This flow is currently supported only for MySQL and PostgreSQL write sinkers.
 
 Inline cdc check is best-effort here as well: writes stay on the main path. If the checker queue
-reaches `[checker].queue_size`, the oldest pending checker batch is dropped instead of blocking new
+reaches `[checker_cdc].queue_size`, the oldest pending checker batch is dropped instead of blocking new
 writes. Checker-side runtime errors are logged, but they do not block CDC writes, checkpoint
 persistence, or metadata refresh on the main path.
 

--- a/docs/en/config.md
+++ b/docs/en/config.md
@@ -111,115 +111,111 @@ server setup require a CA certificate.
 
 # [checker]
 
-The `[checker]` section is used by three documented data check flows:
+Common row/structure comparison settings. The section is used in these modes:
 
-- Standalone snapshot check: run a snapshot check task only (no data write). Set
-  `sink_type=dummy` or omit `[sinker]`, and configure the checker target explicitly in
-  `[checker]`. Standalone snapshot checker targets support MySQL, PostgreSQL, and MongoDB. This
-  flow is data-only and does not run structure check automatically.
-- Inline snapshot check: for snapshot tasks with `sink_type=write`, the checker runs after sink
-  and reuses the parsed `[sinker]` target directly.
-- Inline cdc check: for CDC tasks with `extract_type=cdc` and `sink_type=write`, the checker
-  validates applied changes after write, reuses the parsed `[sinker]` target, and requires
-  resumer state persistence.
+- Standalone snapshot/struct/check-log: set `[sinker].sink_type=check`. The target connection,
+  authentication, TLS, connection limits, and database-specific options are all loaded from
+  `[sinker]`.
+- Inline snapshot: use `extract_type=snapshot`, `[sinker].sink_type=write`, and add a
+  `[checker]` section. Checking runs synchronously after each successful sink operation.
+- Inline CDC: use `extract_type=cdc`, `[sinker].sink_type=write`, and enable
+  `[checker_cdc].is_enabled=true`. Checking runs asynchronously after sink through the CDC
+  checker queue.
 
-Struct check is supported only for standalone MySQL/PostgreSQL checker targets.
-
-| Config                      | Description                                                            | Example     | Default                           |
-| --------------------------- | ---------------------------------------------------------------------- | ----------- | --------------------------------- |
-| enable                      | whether to enable the checker when `[checker]` section is present      | true        | required                          |
-| queue_size                  | checker queue capacity, counted in pending batches/messages            | 200         | 200                               |
-| max_connections             | max connections for checker pool                                       | 8           | 8                                 |
-| batch_size                  | checker chunk size; also used for checker chunking in inline cdc check | 200         | 200                               |
-| sample_rate                 | percentage sample rate for snapshot and CDC checks                     | 25          | empty (check all rows/changes)    |
-| output_full_row             | output full row in diff log                                            | false       | false                             |
-| output_revise_sql           | write generated revise SQL to `sql.log`                                | false       | false                             |
-| revise_match_full_row       | match full row when building revise SQL                                | false       | false                             |
-| retry_interval_secs         | retry interval in seconds (forced to 0 in inline cdc check)            | 0           | 0                                 |
-| max_retries                 | retry count (forced to 0 in inline cdc check)                          | 0           | 0                                 |
-| check_log_dir               | check log dir                                                          | /tmp/check  | empty (use runtime.log_dir/check) |
-| check_log_file_size         | local per-log file size limit (`diff.log` / `miss.log` / `sql.log`)    | 100mb       | 100mb                             |
-| check_log_max_rows          | CDC check snapshot max rows (`diff.log` / `miss.log`)                  | 1000        | 1000                              |
-| db_type                     | checker target db type (standalone target only)                        | mysql       | -                                 |
-| url                         | checker target URL (standalone target only)                            | mysql://... | -                                 |
-| username                    | checker target username (standalone target only)                       | root        | empty                             |
-| password                    | checker target password (standalone target only)                       | password    | empty                             |
-| ssl_mode                    | checker target TLS mode (standalone target only)                       | verify_full | not set                           |
-| ssl_ca_path                 | checker target CA certificate path (standalone target only)            | /ca.pem     | empty                             |
-| check_log_s3                | upload check logs to S3 for standalone snapshot or inline CDC check    | false       | false                             |
-| cdc_check_log_interval_secs | interval (seconds) for periodic CDC check snapshot output              | 30          | 30                                |
-| s3_bucket                   | S3 bucket for check log upload                                         | my-bucket   | -                                 |
-| s3_access_key_id            | S3 access key id                                                       | AKIA...     | -                                 |
-| s3_secret_access_key        | S3 secret access key                                                   | \*\*\*\*    | -                                 |
-| s3_region                   | S3 region                                                              | us-east-1   | -                                 |
-| s3_endpoint                 | S3 endpoint                                                            | https://... | -                                 |
-| s3_root_dir                 | local or mounted root directory used by the S3 helper                  | /tmp/check  | empty                             |
-| s3_root_url                 | root URL used by the S3 helper                                         | s3://bucket | empty                             |
-| s3_key_prefix               | S3 key prefix for check logs                                           | task1/check | empty                             |
+| Config                | Description                                      | Example | Default                        |
+| --------------------- | ------------------------------------------------ | ------- | ------------------------------ |
+| batch_size            | maximum rows processed by one checker query      | 200     | 200                            |
+| sample_percent        | percentage sampled for snapshot/CDC checks       | 25      | empty (check every row/change) |
+| recheck_count         | number of retries for a temporary inconsistency  | 4       | 0                              |
+| recheck_interval_secs | interval between retries, in seconds             | 5       | 0                              |
+| recheck_queue_size    | maximum pending rows in the retry buffer         | 10000   | 10000                          |
+| recheck_queue_memory_mb | retry-buffer memory limit in MiB               | 256     | 256                            |
 
 Notes:
 
-**General behavior**
+- Checker tasks support only `[pipeline].pipeline_type=basic`.
+- `sample_percent` accepts `1..=100` and applies only to snapshot checks and inline CDC checks.
+  Standalone snapshot applies sampling during extraction. Inline snapshot/CDC writes every
+  row/change and applies deterministic key-hash sampling before target fetch.
+- Standalone snapshot check supports MySQL, PostgreSQL, and MongoDB targets. Standalone struct check
+  supports MySQL and PostgreSQL.
+- Inline snapshot check supports MySQL, PostgreSQL, and MongoDB write targets.
+- `recheck_count` and `recheck_interval_secs` are not used by inline CDC reconciliation.
+- When either retry-buffer limit is reached, the checker does not drop the result; newly found
+  inconsistencies skip retry and are finalized immediately.
 
-- Checker only supports `[pipeline] pipeline_type=basic`.
-- `sample_rate` only supports snapshot check and inline CDC check. Valid values are `1..=100`; an
-  empty value means all rows/changes are checked. Standalone MySQL/PostgreSQL/MongoDB snapshot check
-  applies it during extraction, so later checker work receives fewer rows. When row estimates are
-  available, the extractor limits source reads to roughly `row_count * sample_rate / 100`.
-  `row_count` is estimated from the table, or from the table's configured `where_conditions` when
-  present. If no useful estimate is available, extraction reads the
-  full source stream. This sampling is source-side Top-N limiting, not key-hash or random sampling.
-  Inline snapshot check and inline CDC check write all rows/changes first, then apply deterministic
-  checker-side key-hash sampling before target fetch, so rows/changes with the same key are sampled
-  consistently.
-- `queue_size` counts queued checker DML batches, not rows. Control signals such as checkpoint and
-  `refresh_meta` bypass this queue.
-- In inline write-after-check flows, if the checker DML queue is full, the oldest pending batch is
-  dropped with a warning log instead of blocking the write path.
-- Checker runtime errors (batch check failure, checkpoint failure, output failure) are logged but do
-  not affect the main CDC write path. Checkpoint and meta refresh delivery remain best-effort.
+## Standalone target example
 
-**Flow selection and target rules**
+```ini
+[extractor]
+db_type=mysql
+extract_type=snapshot
+url=mysql://source-host:3306
 
-- For inline write-after-check flows, one queued batch is usually close to the effective sink batch
-  size. In practice this is often about `[sinker].batch_size` rows, but the final batch may be
-  smaller and upstream partitioning can also change the actual count.
-- For standalone / dummy-sinker check flows, queued batch size is decided by the upstream
-  parallelizer. After dequeue, the checker processes non-CDC rows in chunks of `[checker].batch_size`.
-- Struct tasks only support standalone MySQL/PostgreSQL checker targets. If `[checker]` is enabled
-  for struct tasks, use `sink_type=dummy` or omit `[sinker]`. Run structure check explicitly when
-  structure verification is needed; standalone snapshot check does not start it automatically.
-- Inline snapshot check is supported only when `[extractor] extract_type=snapshot`,
-  `[sinker] sink_type=write`, and `[sinker].db_type` is `mysql`, `pg`, or `mongo`.
-- Inline cdc check is currently supported only when `[extractor] extract_type=cdc`,
-  `[sinker] sink_type=write`, `[checker].enable=true`, `[parallelizer].parallel_type=rdb_merge`,
-  and `[sinker].db_type` is `mysql` or `pg`.
-- In inline cdc check, the checker uses `[checker].batch_size`. It does not fall back to
-  `[sinker].batch_size`. For example, if `[checker].batch_size=100` and `queue_size=200`, the
-  checker queue can hold about 200 pending batches, which is roughly 20,000 rows when batches are full.
-- In inline snapshot check and inline cdc check, `[checker]` must not set `db_type`, `url`,
-  `username`, or `password`; the checker always reuses the parsed `[sinker]` target.
-- In inline cdc check, `[resumer] resume_type=from_target` or `from_db` is required to persist
-  checker state.
-- In inline cdc check, the following combinations fail fast with `ConfigError`: `[checker]`
-  section present without `enable`; `[pipeline].pipeline_type != basic`; `[sinker].sink_type != write`;
-  `[parallelizer].parallel_type != rdb_merge`; `[sinker].db_type` not in `mysql` / `pg`; or any
-  target field (`db_type` / `url` / `username` / `password`) set under `[checker]`.
+[sinker]
+db_type=mysql
+sink_type=check
+url=mysql://target-host:3306
+username=root
+password=target-password
+max_connections=8
 
-**Inline cdc check log / retry behavior**
+[checker]
+batch_size=200
+sample_percent=25
+recheck_count=4
+recheck_interval_secs=5
+recheck_queue_size=10000
+recheck_queue_memory_mb=256
+```
 
-- In inline cdc check, `[checker].max_retries` / `[checker].retry_interval_secs` are forced to `0`.
-- When `check_log_dir` is empty, `runtime.log_dir/check` is used consistently for checker logs (including CDC check outputs).
-- Standalone snapshot check writes check results locally first. If `check_log_s3=true`, the final
-  local `summary.log` plus non-empty `miss.log`, `diff.log`, and `sql.log` are uploaded to S3
-  after the check task finishes.
-- In inline cdc check, periodic check snapshots are always written locally under `check_log_dir`;
-  `check_log_s3` controls only S3 upload. Outside inline cdc check, S3 upload is supported only by
-  standalone snapshot check.
-- `check_log_file_size` limits local `diff.log` / `miss.log` / `sql.log`. `summary.log` is not
-  size-limited.
-- `check_log_max_rows` only applies to CDC check snapshots for `diff.log` / `miss.log`; when either
-  threshold is hit, only the latest records are kept.
+# [checker_output]
+
+Check-result output configuration. If this section is omitted, results are written as local logs
+under `runtime.log_dir/check`.
+
+| Config               | Description                                                         | Example       | Default |
+| -------------------- | ------------------------------------------------------------------- | ------------- | ------- |
+| output_type          | result destination: `logs` or `s3`                              | logs          | logs    |
+| output_full_row      | include complete source/target rows in difference logs              | false         | false   |
+| output_revise_sql    | generate repair statements in `sql.log`                           | true          | false   |
+| revise_match_full_row| use the complete row in generated repair predicates                 | false         | false   |
+| check_log_dir        | local check-log directory                                           | /tmp/check    | empty (use `runtime.log_dir/check`) |
+| check_log_file_size  | per-file size limit for `diff.log`, `miss.log`, and `sql.log` | 100mb         | 100mb   |
+| check_log_max_rows   | maximum rows in CDC `diff.log`/`miss.log` snapshots             | 1000          | 1000    |
+| s3_bucket            | S3 bucket; required for `output_type=s3`                           | my-bucket     | -       |
+| s3_access_key_id     | S3 access key                                                       | AKIA...       | empty   |
+| s3_secret_access_key | S3 secret key                                                       | ****          | empty   |
+| s3_region            | S3 region                                                           | us-east-1     | empty   |
+| s3_endpoint          | custom S3 endpoint                                                   | https://...   | empty   |
+| s3_root_dir          | local/mounted root used by the S3 helper                            | /tmp/check    | empty   |
+| s3_root_url          | root URL used by the S3 helper                                      | s3://bucket   | empty   |
+| s3_key_prefix        | key prefix for uploaded check logs                                  | task1/check   | empty   |
+
+`output_type=s3` is supported for standalone snapshot check and inline CDC check. S3 output still
+uses the configured local rolling-log directory and limits before upload. Structure check, check-log
+review, and inline snapshot check support `output_type=logs` only.
+
+# [checker_cdc]
+
+CDC-only asynchronous checker settings.
+
+| Config                  | Description                                          | Example | Default |
+| ----------------------- | ---------------------------------------------------- | ------- | ------- |
+| is_enabled              | enable inline CDC check                              | true    | false   |
+| queue_size              | pending CDC checker batches                          | 200     | 200     |
+| check_log_interval_secs | periodic CDC check-result output interval in seconds | 30      | 30      |
+
+Inline CDC check additionally requires:
+
+- `[extractor].extract_type=cdc`
+- `[sinker].sink_type=write` with a MySQL/PostgreSQL target
+- `[parallelizer].parallel_type=rdb_merge`
+- `[resumer].resume_type=from_target` or `from_db`
+
+The CDC checker queue is deliberately decoupled from the migration pipeline. When full, it evicts
+the oldest pending batch instead of blocking writes. Checker processing/output failures are logged
+without failing the main CDC write path. Snapshot and structure checks do not use this queue.
 
 # [filter]
 
@@ -341,8 +337,8 @@ Same with [filter].
 | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- | ---------- | -------------------- |
 | snapshot  | Records in cache are divided into [parallel_size] partitions, and each partition will be synced in batches in a separate thread.                                                                                                                                              | snapshot tasks for mysql/pg/mongo   | fast       |                      |
 | serial    | Single thread, one by one.                                                                                                                                                                                                                                                    | all                                 |            | slow                 |
-| rdb_merge | Merge row changes in cache into write-friendly insert + delete batches, then divide them into [parallel_size] partitions for parallel syncing. When `[checker].enable=true`, checker-enabled MySQL/PG flows reuse this parallelizer and switch to check sink mode internally. | mysql/pg CDC, check, review, revise | fast       | eventual consistency |
-| mongo     | Mongo version of merge parallelization. When `[checker].enable=true`, checker-enabled Mongo flows reuse this parallelizer and switch to check sink mode internally.                                                                                                           | mongo CDC, check, review            |            |                      |
+| rdb_merge | Merge row changes in cache into write-friendly insert + delete batches, then divide them into [parallel_size] partitions for parallel syncing. It is used by MySQL/PG CDC, check, review, and revise flows. | mysql/pg CDC, check, review, revise | fast       | eventual consistency |
+| mongo     | Mongo version of merge parallelization, also used by standalone MongoDB check and review flows.                                                                                                           | mongo CDC, check, review            |            |                      |
 | redis     | Single thread, batch/serial writing(determined by [sinker] batch_size)                                                                                                                                                                                                        | snapshot/CDC tasks for redis        |            |                      |
 
 ## snapshot chunk rebalance

--- a/docs/en/config_changelog.md
+++ b/docs/en/config_changelog.md
@@ -8,10 +8,13 @@ Current reference: [Config details](/docs/en/config.md).
 
 | Removed in 2.0.26 | Replacement |
 | ----------------- | ----------- |
-| `[sinker].sink_type=check` | Add `[checker] enable=true`. Standalone check: put target fields in `[checker]`. Inline check: keep `sink_type=write`. |
+| `[checker].enable` | Standalone check: use `[sinker].sink_type=check`. Inline snapshot: add `[checker]`. Inline CDC: use `[checker_cdc].is_enabled=true`. |
 | `[parallelizer].parallel_type=rdb_check` | Use `rdb_merge` for RDB check/review/revise and inline CDC; use the normal write parallelizer for inline snapshot. |
-| `[extractor].sample_interval` | Use `[checker].sample_rate=1..100`; empty means full check. |
-| Check target fields under `[sinker]`, including `check_log_dir` | Move them to `[checker]` for standalone check. Inline check reuses `[sinker]`. |
+| `[extractor].sample_interval`, `[checker].sample_rate` | Use `[checker].sample_percent=1..100`; empty means full check. |
+| Checker target fields under `[checker]` | Use normal database fields under `[sinker]`; standalone check sets `sink_type=check`. |
+| Checker output fields under `[checker]`, including `check_log_s3` | Move them to `[checker_output]`; use `output_type=logs` or `s3`. |
+| `[checker].retry_interval_secs`, `[checker].max_retries` | Use `recheck_interval_secs`, `recheck_count`. |
+| `[checker].queue_size`, `[checker].cdc_check_log_interval_secs` | Use `[checker_cdc].queue_size`, `check_log_interval_secs`. |
 | `[pipeline].max_rps` | Use `[extractor].max_rps` and/or `[sinker].max_rps`. |
 | `[resumer].resume_from_log`, `resume_log_dir`, `resume_config_file` | Use `resume_type=from_log`, `log_dir`, `config_file`. Old keys return `ConfigError`. |
 | `[pipeline].pipeline_type=http_server`, `http_host`, `http_port`, pipeline `with_field_defs` | Removed. Only `pipeline_type=basic` remains. Kafka `[sinker].with_field_defs` is unchanged. |
@@ -30,11 +33,10 @@ Current reference: [Config details](/docs/en/config.md).
 | Redis extractor/sinker | `is_cluster` | Auto-detect | `true`: cluster; `false`: single node; empty: auto. |
 | MongoDB sinker | `mongo_require_shard_key_filter` | `true` | Require complete target shard key in write filters. |
 | MongoDB struct task | `extract_type=struct`, `sink_type=struct` | — | Migrate collections and shard keys. |
-| `[checker]` | `enable`, `queue_size`, `max_connections`, `batch_size`, `sample_rate` | Required, `200`, `8`, `200`, empty | Enable and size checker. |
-| `[checker]` | `output_full_row`, `output_revise_sql`, `revise_match_full_row` | All `false` | Control diff and revise SQL output. |
-| `[checker]` | `retry_interval_secs`, `max_retries` | `0`, `0` | Checker retry policy. |
-| `[checker]` | `check_log_dir`, `check_log_file_size`, `check_log_max_rows` | Empty, `100mb`, `1000` | Local check logs and limits. |
-| `[checker]` | `check_log_s3`, `s3_*`, `cdc_check_log_interval_secs` | `false`, empty, `30` | S3 upload and CDC check-log interval. |
+| `[checker]` | `batch_size`, `sample_percent`, `recheck_count`, `recheck_interval_secs`, `recheck_queue_size`, `recheck_queue_memory_mb` | `200`, empty, `0`, `0`, `10000`, `256` | Common check behavior and bounded retry buffering. |
+| `[checker_output]` | `output_type`, `output_full_row`, `output_revise_sql`, `revise_match_full_row` | `logs`, all `false` | Select output medium and content. |
+| `[checker_output]` | `check_log_dir`, `check_log_file_size`, `check_log_max_rows`, `s3_*` | Empty, `100mb`, `1000`, empty | Local rolling logs and optional S3 upload. |
+| `[checker_cdc]` | `is_enabled`, `queue_size`, `check_log_interval_secs` | `false`, `200`, `30` | Enable and configure asynchronous inline CDC check. |
 | Snapshot `[parallelizer]` | `rebalance_strategy`, `rebalance_cost`, `rebalance_max_partitions_per_sinker`, `rebalance_min_partition_rows`, `rebalance_split_skew_ratio` | `none`, `rows`, `2`, sinker batch size, `1.0` | Sink partition rebalance. |
 | `[runtime]` | `check_result_stdout_only` | `false` | Print only checker result logs to stdout. |
 | `[tracing]` | `task_summary_mode`, `output_format` | `marker`, `plain` | Trace aggregation and format. |
@@ -51,7 +53,6 @@ Current reference: [Config details](/docs/en/config.md).
 | MongoDB snapshot `batch_size` | Not used by snapshot config | Used as cursor batch size; must fit `u32` |
 | `[sinker].batch_size=0` | Accepted during config loading | Rejected for non-dummy sinkers |
 | MongoDB shard-key filter | No config-level requirement | Required by default; set `mongo_require_shard_key_filter=false` to disable |
-| Standalone check | Target configured as check sinker | `[sinker]` may be omitted; target configured in `[checker]` |
-| Inline check | Check-specific sinker/parallelizer | Keep `sink_type=write`; checker reuses sinker target |
-| Inline CDC check | Not supported | MySQL/PostgreSQL only; requires `rdb_merge` and resumer `from_target`/`from_db` |
-| `resumer=from_target` with dummy sinker | Uses sinker target | Uses standalone checker target |
+| Standalone check | Target configured as check sinker | Keep `[sinker].sink_type=check`; target uses the normal sinker database configuration |
+| Inline snapshot check | Check-specific sinker/parallelizer | Keep `sink_type=write`; adding `[checker]` enables synchronous post-sink check |
+| Inline CDC check | Not supported | MySQL/PostgreSQL only; enable with `[checker_cdc]`, requires `rdb_merge` and resumer `from_target`/`from_db` |

--- a/docs/en/snapshot/check.md
+++ b/docs/en/snapshot/check.md
@@ -4,10 +4,10 @@ After data migration, you may want to compare the source and target data row by 
 
 Supports comparison for MySQL, PostgreSQL, and MongoDB.
 
-Snapshot and inline CDC checks support sampling via `[checker].sample_rate`.
-For standalone MySQL/PostgreSQL/MongoDB snapshot check, `sample_rate` is applied during extraction
+Snapshot and inline CDC checks support sampling via `[checker].sample_percent`.
+For standalone MySQL/PostgreSQL/MongoDB snapshot check, `sample_percent` is applied during extraction
 before rows enter later checker work. When table/collection row estimates are available, the source
-query is capped with `LIMIT ceil(estimated_rows * sample_rate / 100)`. If no useful estimate is
+query is capped with `LIMIT ceil(estimated_rows * sample_percent / 100)`. If no useful estimate is
 available, extraction reads the full source stream. This sampling is source-side Top-N limiting, not
 key-hash based or random. Inline snapshot check and inline CDC check write all rows/changes first,
 then apply deterministic checker-side key-hash sampling before target fetch. Rows/changes with the
@@ -20,8 +20,8 @@ Data check is documented in three flows:
 ### Standalone snapshot check
 
 - Use `extract_type=snapshot`.
-- Set `sink_type=dummy` or omit `[sinker]`.
-- Configure the checker target explicitly in `[checker]`, and set `[checker].enable=true`.
+- Configure the target in `[sinker]` and set `[sinker].sink_type=check`.
+- Connection, authentication, TLS, and database-specific target options use the normal `[sinker]` fields.
 - Standalone snapshot checker targets support MySQL, PostgreSQL, and MongoDB.
 - Use `parallel_type=rdb_merge` for MySQL/PostgreSQL checker targets, and `parallel_type=mongo`
   for MongoDB checker targets.
@@ -76,8 +76,8 @@ source rows
 - Use `extract_type=cdc` and `[sinker] sink_type=write`.
 - The checker validates applied CDC changes after they are written to the target.
 - The checker reuses the parsed `[sinker]` target directly.
-- Set `[checker].enable=true`.
-- `[checker]` must not set `db_type`, `url`, `username`, or `password`.
+- Set `[checker_cdc].is_enabled=true`.
+- Configure `queue_size` and `check_log_interval_secs` in `[checker_cdc]`.
 - `[resumer] resume_type=from_target` or `from_db` is required to persist checker state.
 - Currently supported only when `[sinker].db_type` is `mysql` or `pg`.
 - Use `parallel_type=rdb_merge`.
@@ -118,12 +118,12 @@ templates now separate standalone snapshot check, inline snapshot check, and inl
 
 ### Sampling Check
 
-For snapshot and inline CDC checks, add `sample_rate` to the `[checker]` section. For standalone
+For snapshot and inline CDC checks, add `sample_percent` to the `[checker]` section. For standalone
 MySQL/PostgreSQL/MongoDB snapshot check, sampling is applied during extraction. With row estimates,
-the extractor limits source reads to roughly `row_count * sample_rate / 100`; `row_count` is
+the extractor limits source reads to roughly `row_count * sample_percent / 100`; `row_count` is
 estimated from the table, or from the table's configured `where_conditions` when present. If the
 estimate is missing or zero, extraction reads the full source stream. For inline
-snapshot check and inline CDC check, `sample_rate=25` still writes all
+snapshot check and inline CDC check, `sample_percent=25` still writes all
 rows/changes, then checks rows/changes whose key hash falls into the sampled percentage before target
 fetch/compare.
 
@@ -133,8 +133,7 @@ decision across resumes.
 
 ```
 [checker]
-enable=true
-sample_rate=25
+sample_percent=25
 ```
 
 ## Limitations
@@ -158,7 +157,7 @@ entries; each non-empty line is one JSON object. `summary.log` contains exactly 
 overall summary. `sql.log` is a plain SQL file, one generated repair statement per line, and contains
 no JSON wrapper or schema/table/id metadata. `sql.log` is generated or written only when
 `output_revise_sql=true` and repair SQL exists. By default, these logs are stored in
-`runtime.log_dir/check`; if `[checker].check_log_dir` is set, that directory is used instead.
+`runtime.log_dir/check`; if `[checker_output].check_log_dir` is set, that directory is used instead.
 
 By default, stdout follows the normal runtime logging configuration. For orchestration paths that
 need stdout to contain only check results, set `[runtime].check_result_stdout_only=true` for that
@@ -204,13 +203,11 @@ embedded in `miss.log`; repair SQL, if enabled, is written only to `sql.log`.
 
 ## Output Full Row
 
-When you need full row content for troubleshooting, enable full row logging in `[checker]`. In
-standalone snapshot check, configure the checker target explicitly in `[checker]`; in inline
-snapshot check and inline cdc check, the checker reuses the parsed `[sinker]` target:
+When you need full row content for troubleshooting, configure it in `[checker_output]`. All modes
+configure the target through `[sinker]`:
 
 ```
-[checker]
-enable=true
+[checker_output]
 output_full_row=true
 ```
 
@@ -248,13 +245,11 @@ After enabling, all `diff.log` entries append `src_row` and `dst_row`, and all `
 
 ## Output Revise SQL
 
-If you need to manually repair inconsistent data, enable SQL output in `[checker]`. In standalone
-snapshot check, configure the checker target explicitly in `[checker]`; in inline snapshot check
-and inline cdc check, the checker reuses the parsed `[sinker]` target:
+If you need to manually repair inconsistent data, enable SQL output in `[checker_output]`. All
+modes configure the target through `[sinker]`:
 
 ```
-[checker]
-enable=true
+[checker_output]
 output_revise_sql=true
 # Optional: force WHERE clause to match the whole row
 revise_match_full_row=true
@@ -329,14 +324,19 @@ source/target roles swapped:
 ```
 # Original: source=A, target=B
 # Reverse: source=B, target=A
+
 [extractor]
-db_type=<original checker db_type>
-url=<original checker url>
+db_type=<original sinker db_type>
+extract_type=snapshot
+url=<original sinker url>
+
+[sinker]
+db_type=<original extractor db_type>
+sink_type=check
+url=<original extractor url>
 
 [checker]
-enable=true
-db_type=<original extractor db_type>
-url=<original extractor url>
+batch_size=200
 ```
 
 # Configuration
@@ -345,7 +345,7 @@ See [config.md](../config.md) for the full `[checker]` configuration list and ta
 
 ## Retry Mechanism
 
-When `max_retries > 0`, the checker automatically retries on inconsistency:
+When `recheck_count > 0`, the checker automatically retries on inconsistency:
 - No logs are written during retry attempts to reduce noise
 - Detailed miss/diff logs are only written on the final check
 - Useful when target data synchronization is not yet complete
@@ -353,9 +353,14 @@ When `max_retries > 0`, the checker automatically retries on inconsistency:
 This retry behavior is the main fit for standalone snapshot check and inline snapshot check. It is
 designed for short-term convergence waiting after write, not for long-running reconciliation state.
 
+Pending rows are held by a bounded retry buffer. `recheck_queue_size` and
+`recheck_queue_memory_mb` limit its row count and estimated data size. When either limit is reached,
+a newly found inconsistency is not dropped; it skips retry and is finalized immediately using the
+current check result.
+
 > **Note:** Retries are not supported in inline cdc check. CDC events arrive as a stream, and
 > subsequent DELETE events may remove data that was correctly written, causing false misses in the
-> retry queue. Even if `max_retries` and `retry_interval_secs` are configured, they are forcibly
+> retry queue. Even if `recheck_count` and `recheck_interval_secs` are configured, they are forcibly
 > ignored (set to 0) in CDC mode, and a warning is logged.
 
 

--- a/docs/en/snapshot/review.md
+++ b/docs/en/snapshot/review.md
@@ -17,10 +17,13 @@ While this configuration is similar to that of snapshot migration, the only diff
 extract_type=check_log
 check_log_dir=./dt-tests/tests/mysql_to_mysql/revise/basic_test/check_log
 
-[checker]
-enable=true
+[sinker]
 db_type=mysql
+sink_type=check
 url=mysql://user:pass@host:3306/db
+
+[checker]
+
 
 [parallelizer]
 parallel_type=rdb_merge

--- a/docs/en/structure/check.md
+++ b/docs/en/structure/check.md
@@ -5,6 +5,11 @@ After structure migration, you can choose from two verification methods. One is 
 Structure check is independent of CDC. Here, `inline cdc check` refers to row-level data check
 (see [data check docs](../snapshot/check.md)).
 
+Built-in structure check is a standalone task: use `extract_type=struct`, configure the target with
+the normal database fields under `[sinker]`, and set `[sinker].sink_type=check`. Common options
+belong to `[checker]`; result formatting and log paths belong to `[checker_output]`. Structure
+check does not create or consume the asynchronous CDC checker queue.
+
 ## Example: MySQL -> MySQL
 
 Refer to [task templates](../../templates/mysql_to_mysql.md)

--- a/docs/en/tutorial/mongo_to_mongo.md
+++ b/docs/en/tutorial/mongo_to_mongo.md
@@ -194,15 +194,19 @@ db.tb_1.updateOne({ "_id" : "2" }, { "$set": { "age" : 200000 } });
 
 ```
 cat <<EOL > /tmp/ape_dts/task_config.ini
+
 [extractor]
 db_type=mongo
 extract_type=snapshot
 url=mongodb://127.0.0.1:27017
 
-[checker]
-enable=true
+[sinker]
 db_type=mongo
+sink_type=check
 url=mongodb://ape_dts:123456@127.0.0.1:27018
+
+[checker]
+
 
 [filter]
 do_dbs=test_db
@@ -303,16 +307,20 @@ docker exec -it dst-mongo mongosh \
 
 ```
 cat <<EOL > /tmp/ape_dts/task_config.ini
+
 [extractor]
 db_type=mongo
 extract_type=check_log
 url=mongodb://127.0.0.1:27017
 check_log_dir=./check_data_task_log
 
-[checker]
-enable=true
+[sinker]
 db_type=mongo
+sink_type=check
 url=mongodb://ape_dts:123456@127.0.0.1:27018
+
+[checker]
+
 
 [filter]
 do_events=*

--- a/docs/en/tutorial/mysql_to_mysql.md
+++ b/docs/en/tutorial/mysql_to_mysql.md
@@ -107,7 +107,7 @@ SHOW TABLES IN test_db;
 ```
 
 # Migrate snapshot data
-- To turn this into **inline snapshot check**, keep `[sinker] sink_type=write` and add a `[checker]` section without target connection fields.
+- To turn this into **inline snapshot check**, keep `[sinker] sink_type=write` and add an empty `[checker]` section or configure its common check options.
 - See [Data Check](../snapshot/check.md#inline-snapshot-check) and the MySQL template for the exact config shape.
 ## Prepare data
 ```
@@ -182,15 +182,19 @@ UPDATE test_db.tb_1 SET value=1 WHERE id=2;
 ## Start task
 ```
 cat <<EOL > /tmp/ape_dts/task_config.ini
+
 [extractor]
 db_type=mysql
 extract_type=snapshot
 url=mysql://root:123456@127.0.0.1:3307?ssl-mode=disabled
 
-[checker]
-enable=true
+[sinker]
 db_type=mysql
+sink_type=check
 url=mysql://root:123456@127.0.0.1:3308?ssl-mode=disabled
+
+[checker]
+
 
 [filter]
 do_dbs=test_db
@@ -284,16 +288,20 @@ SELECT * FROM test_db.tb_1;
 ## Start task
 ```
 cat <<EOL > /tmp/ape_dts/task_config.ini
+
 [extractor]
 db_type=mysql
 extract_type=check_log
 url=mysql://root:123456@127.0.0.1:3307?ssl-mode=disabled
 check_log_dir=./check_data_task_log
 
-[checker]
-enable=true
+[sinker]
 db_type=mysql
+sink_type=check
 url=mysql://root:123456@127.0.0.1:3308?ssl-mode=disabled
+
+[checker]
+
 
 [filter]
 do_events=*
@@ -321,9 +329,8 @@ docker run --rm --network host \
 
 # Cdc task
 
-- To turn this into **inline cdc check**, add `[checker] enable=true` plus `[resumer]`, keep
-  `[sinker] sink_type=write`, use `[parallelizer] parallel_type=rdb_merge`, and do not configure
-  checker target fields. See [Data Check](../snapshot/check.md#inline-cdc-check) and the MySQL
+- To turn this into **inline cdc check**, add `[checker_cdc] is_enabled=true` plus `[resumer]`, keep
+  `[sinker] sink_type=write`, use `[parallelizer] parallel_type=rdb_merge`, and configure common check options under `[checker]`. See [Data Check](../snapshot/check.md#inline-cdc-check) and the MySQL
   template.
 
 ## Start task

--- a/docs/en/tutorial/pg_to_pg.md
+++ b/docs/en/tutorial/pg_to_pg.md
@@ -103,7 +103,7 @@ SET search_path TO test_db;
 
 # Migrate snapshot data
 
-- To turn this into **inline snapshot check**, keep `[sinker] sink_type=write` and add a `[checker]` section without target connection fields.
+- To turn this into **inline snapshot check**, keep `[sinker] sink_type=write` and add an empty `[checker]` section or configure its common check options.
 - See [Data Check](../snapshot/check.md#inline-snapshot-check) and the Postgres template for the exact config shape.
 
 ## Prepare data
@@ -184,15 +184,19 @@ UPDATE test_db.tb_1 SET value=1 WHERE id=2;
 
 ```
 cat <<EOL > /tmp/ape_dts/task_config.ini
+
 [extractor]
 db_type=pg
 extract_type=snapshot
 url=postgres://postgres:postgres@127.0.0.1:5433/postgres?options[statement_timeout]=10s
 
-[checker]
-enable=true
+[sinker]
 db_type=pg
+sink_type=check
 url=postgres://postgres:postgres@127.0.0.1:5434/postgres?options[statement_timeout]=10s
+
+[checker]
+
 
 [filter]
 do_dbs=test_db
@@ -293,16 +297,20 @@ SELECT * FROM test_db.tb_1 ORDER BY id;
 
 ```
 cat <<EOL > /tmp/ape_dts/task_config.ini
+
 [extractor]
 db_type=pg
 extract_type=check_log
 url=postgres://postgres:postgres@127.0.0.1:5433/postgres?options[statement_timeout]=10s
 check_log_dir=./check_data_task_log
 
-[checker]
-enable=true
+[sinker]
 db_type=pg
+sink_type=check
 url=postgres://postgres:postgres@127.0.0.1:5434/postgres?options[statement_timeout]=10s
+
+[checker]
+
 
 [filter]
 do_events=*
@@ -331,9 +339,8 @@ docker run --rm --network host \
 
 # CDC task
 
-- To turn this into **inline cdc check**, add `[checker] enable=true` plus `[resumer]`, keep
-  `[sinker] sink_type=write`, use `[parallelizer] parallel_type=rdb_merge`, and do not configure
-  checker target fields. See [Data Check](../snapshot/check.md#inline-cdc-check) and the Postgres
+- To turn this into **inline cdc check**, add `[checker_cdc] is_enabled=true` plus `[resumer]`, keep
+  `[sinker] sink_type=write`, use `[parallelizer] parallel_type=rdb_merge`, and configure common check options under `[checker]`. See [Data Check](../snapshot/check.md#inline-cdc-check) and the Postgres
   template.
 
 ## Drop replication slot if exists

--- a/docs/en/tutorial/snapshot_and_cdc_without_data_loss.md
+++ b/docs/en/tutorial/snapshot_and_cdc_without_data_loss.md
@@ -6,7 +6,7 @@ This article tells you what to do before starting a snapshot task, and how to co
 
 ## Validate CDC-applied data
 
-If you want to validate CDC-applied data after the snapshot + CDC pipeline, use [inline cdc check](../snapshot/check.md#inline-cdc-check) on the CDC task: keep `[sinker] sink_type=write`, add `[checker] enable=true`, add `[resumer]`, and keep `[parallelizer] parallel_type=rdb_merge`.
+If you want to validate CDC-applied data after the snapshot + CDC pipeline, use [inline cdc check](../snapshot/check.md#inline-cdc-check) on the CDC task: keep `[sinker] sink_type=write`, add `[checker_cdc] is_enabled=true`, add `[resumer]`, and keep `[parallelizer] parallel_type=rdb_merge`.
 
 This flow is currently supported only for MySQL and PostgreSQL write sinkers.
 

--- a/docs/templates/mongo_to_mongo.md
+++ b/docs/templates/mongo_to_mongo.md
@@ -223,10 +223,12 @@ db_type=mongo
 extract_type=snapshot
 url=mongodb://ape_dts:123456@mongo1:9042/?replicaSet=rs0
 
-[checker]
-enable=true
+[sinker]
 db_type=mongo
+sink_type=check
 url=mongodb://ape_dts:123456@127.0.0.1:27018
+
+[checker]
 batch_size=100
 
 [filter]
@@ -272,7 +274,6 @@ url=mongodb://ape_dts:123456@127.0.0.1:27018
 batch_size=200
 
 [checker]
-enable=true
 batch_size=200
 
 [filter]
@@ -368,10 +369,12 @@ url=mongodb://ape_dts:123456@mongo1:9042/?replicaSet=rs0
 check_log_dir=./logs/origin_check_log
 batch_size=200
 
-[checker]
-enable=true
+[sinker]
 db_type=mongo
+sink_type=check
 url=mongodb://ape_dts:123456@127.0.0.1:27018
+
+[checker]
 batch_size=100
 
 [filter]

--- a/docs/templates/mysql_to_mysql.md
+++ b/docs/templates/mysql_to_mysql.md
@@ -222,10 +222,13 @@ db_type=mysql
 extract_type=struct
 url=mysql://root:123456@127.0.0.1:3307?ssl-mode=disabled
 
-[checker]
-enable=true
+[sinker]
 db_type=mysql
+sink_type=check
 url=mysql://root:123456@127.0.0.1:3308?ssl-mode=disabled
+
+[checker]
+
 
 [filter]
 do_dbs=test_db
@@ -263,10 +266,12 @@ extract_type=snapshot
 url=mysql://root:123456@127.0.0.1:3307?ssl-mode=disabled
 batch_size=10000
 
-[checker]
-enable=true
+[sinker]
 db_type=mysql
+sink_type=check
 url=mysql://root:123456@127.0.0.1:3308?ssl-mode=disabled
+
+[checker]
 batch_size=100
 
 [filter]
@@ -314,7 +319,6 @@ batch_size=200
 replace=true
 
 [checker]
-enable=true
 batch_size=200
 
 [filter]
@@ -375,8 +379,10 @@ url=mysql://root:123456@127.0.0.1:3308?ssl-mode=disabled
 replace=true
 
 [checker]
-enable=true
 batch_size=200
+
+[checker_cdc]
+is_enabled=true
 
 [resumer]
 resume_type=from_target
@@ -402,7 +408,9 @@ log4rs_file=./log4rs.yaml
 ```
 
 - the output will be in {log_dir}/check/
-- `[checker]` intentionally omits `db_type` / `url` / `username` / `password`; inline cdc check reuses the parsed `[sinker]` target, requires `[checker].enable=true` plus `[resumer]`, and uses `[parallelizer] parallel_type=rdb_merge`.
+- Inline CDC check reuses the parsed `[sinker]` target, is enabled by
+  `[checker_cdc].is_enabled=true`, requires `[resumer]`, and uses
+  `[parallelizer].parallel_type=rdb_merge`. Common check options remain under `[checker]`.
 
 # Data revise
 
@@ -462,10 +470,12 @@ url=mysql://root:123456@127.0.0.1:3307?ssl-mode=disabled
 check_log_dir=./logs/origin_check_log
 batch_size=200
 
-[checker]
-enable=true
+[sinker]
 db_type=mysql
+sink_type=check
 url=mysql://root:123456@127.0.0.1:3308?ssl-mode=disabled
+
+[checker]
 batch_size=100
 
 [filter]

--- a/docs/templates/pg_to_pg.md
+++ b/docs/templates/pg_to_pg.md
@@ -215,10 +215,13 @@ db_type=pg
 extract_type=struct
 url=postgres://postgres:postgres@127.0.0.1:5433/postgres?options[statement_timeout]=10s
 
-[checker]
-enable=true
+[sinker]
 db_type=pg
+sink_type=check
 url=postgres://postgres:postgres@127.0.0.1:5434/postgres?options[statement_timeout]=10s
+
+[checker]
+
 
 [filter]
 do_dbs=
@@ -256,10 +259,12 @@ extract_type=snapshot
 url=postgres://postgres:postgres@127.0.0.1:5433/postgres?options[statement_timeout]=10s
 batch_size=10000
 
-[checker]
-enable=true
+[sinker]
 db_type=pg
+sink_type=check
 url=postgres://postgres:postgres@127.0.0.1:5434/postgres?options[statement_timeout]=10s
+
+[checker]
 batch_size=100
 
 [filter]
@@ -307,7 +312,6 @@ batch_size=200
 replace=true
 
 [checker]
-enable=true
 batch_size=200
 
 [filter]
@@ -353,8 +357,10 @@ heartbeat_interval_secs=1
 heartbeat_tb=heartbeat_db.ape_dts_heartbeat
 
 [checker]
-enable=true
 batch_size=200
+
+[checker_cdc]
+is_enabled=true
 
 [resumer]
 resume_type=from_target
@@ -394,7 +400,9 @@ log_dir=./logs
 ```
 
 - the output will be in {log_dir}/check/
-- `[checker]` intentionally omits `db_type` / `url` / `username` / `password`; inline cdc check reuses the parsed `[sinker]` target, requires `[checker].enable=true` plus `[resumer]`, and uses `[parallelizer] parallel_type=rdb_merge`.
+- Inline CDC check reuses the parsed `[sinker]` target, is enabled by
+  `[checker_cdc].is_enabled=true`, requires `[resumer]`, and uses
+  `[parallelizer].parallel_type=rdb_merge`. Common check options remain under `[checker]`.
 
 # Data revise
 
@@ -454,10 +462,12 @@ url=postgres://postgres:postgres@127.0.0.1:5433/postgres?options[statement_timeo
 check_log_dir=./logs/origin_check_log
 batch_size=200
 
-[checker]
-enable=true
+[sinker]
 db_type=pg
+sink_type=check
 url=postgres://postgres:postgres@127.0.0.1:5434/postgres?options[statement_timeout]=10s
+
+[checker]
 batch_size=100
 
 [filter]

--- a/docs/zh/cdc/sync.md
+++ b/docs/zh/cdc/sync.md
@@ -14,16 +14,16 @@
 
 相较默认的纯 CDC 同步链路，inline cdc check 还要求：
 - 保持 `[sinker] sink_type=write`
-- 增加 `[checker] enable=true`
+- 增加 `[checker_cdc] is_enabled=true`
 - 增加 `[resumer] resume_type=from_target` 或 `from_db`
 - 使用 `[parallelizer] parallel_type=rdb_merge`
 
-在该模式下，checker 会直接复用 `[sinker]` 已解析的目标端配置，因此 `[checker]` 不接受单独设置 `db_type`、`url`、`username`、`password`。
+在该模式下，checker 会直接复用 `[sinker]` 已解析的目标端配置，因此 checker 目标直接使用 `[sinker]` 配置；公共校验参数仍放在 `[checker]`。
 
 当前该模式仅支持 MySQL / PostgreSQL 的 write sinker。
 
 inline cdc check 是 best-effort 的：CDC 写入仍走主路径。若 checker 队列达到
-`[checker].queue_size`，会淘汰最旧的待校验 batch，而不是阻塞新的写入。
+`[checker_cdc].queue_size`，会淘汰最旧的待校验 batch，而不是阻塞新的写入。
 checker 侧的运行时错误会被记录日志，但不会阻塞主路径上的 CDC 写入、checkpoint 持久化
 或元数据刷新投递。
 
@@ -37,7 +37,7 @@ checker 侧的运行时错误会被记录日志，但不会阻塞主路径上的
 - `check off` 表示纯 CDC 路径：`[extractor] extract_type=cdc`、`[sinker] sink_type=write`、
   `[parallelizer] parallel_type=rdb_merge`。
 - `check on` 表示在相同 CDC 路径上启用 inline cdc check：
-  `[checker] enable=true`、`[checker] batch_size=200`、
+  `[checker_cdc] is_enabled=true`、`[checker] batch_size=200`、
   `[resumer] resume_type=from_target`。
 - 这组复测共用的任务侧调优参数为：
   `[sinker] batch_size=200`、`[parallelizer] parallel_size=8`、

--- a/docs/zh/cdc/two_way.md
+++ b/docs/zh/cdc/two_way.md
@@ -8,14 +8,14 @@
 
 若希望在双向同步的每个 CDC 方向上都做数据校验，请使用 [数据校验](../snapshot/check.md#inline-cdc-check) 中定义的 inline cdc check。
 
-对每个任务，都要保持 `[sinker] sink_type=write`，增加 `[checker] enable=true`，增加 `[resumer] resume_type=from_target` 或 `from_db`，并使用 `[parallelizer] parallel_type=rdb_merge`。
+对每个任务，都要保持 `[sinker] sink_type=write`，增加 `[checker_cdc] is_enabled=true`，增加 `[resumer] resume_type=from_target` 或 `from_db`，并使用 `[parallelizer] parallel_type=rdb_merge`。
 
-在该模式下，checker 会直接复用 `[sinker]` 已解析的目标端配置，因此 `[checker]` 不接受单独设置 `db_type`、`url`、`username`、`password`。
+在该模式下，checker 会直接复用 `[sinker]` 已解析的目标端配置，因此 checker 目标直接使用 `[sinker]` 配置；公共校验参数仍放在 `[checker]`。
 
 当前该模式仅支持 MySQL / PostgreSQL 的 write sinker。
 
 这里的 inline cdc check 同样是 best-effort 的：写入仍走主路径。若 checker 队列达到
-`[checker].queue_size`，会淘汰最旧的待校验 batch，而不是阻塞新的写入。checker 侧的
+`[checker_cdc].queue_size`，会淘汰最旧的待校验 batch，而不是阻塞新的写入。checker 侧的
 运行时错误会被记录日志，但不会阻塞主路径上的 CDC 写入、checkpoint 持久化或元数据刷新。
 
 # 数据循环

--- a/docs/zh/config.md
+++ b/docs/zh/config.md
@@ -106,106 +106,106 @@ url=mysql://user1:abc%25%24%23%3F%40@127.0.0.1:3307?ssl-mode=disabled
 
 # [checker]
 
-`[checker]` 对应三种已文档化的数据校验形态：
+通用的数据/结构校验参数。该 section 对应以下模式：
 
-- standalone snapshot check：只运行 snapshot 校验任务，不执行写入。设置 `sink_type=dummy`
-  或直接省略 `[sinker]`，并在 `[checker]` 中显式配置校验目标。Standalone snapshot checker
-  target 支持 MySQL、PostgreSQL 和 MongoDB。该形态只做数据校验，不会自动执行结构校验。
-- inline snapshot check：用于 `sink_type=write` 的 snapshot 任务，checker 会在写入后执行，
-  并直接复用 `[sinker]` 已解析的目标端配置。
-- inline cdc check：用于 `extract_type=cdc` 且 `sink_type=write` 的 CDC 任务，checker 会在
-  写入后校验已落库变更，直接复用 `[sinker]` 目标，并要求持久化 checker 状态。
+- standalone snapshot/struct/check-log：设置 `[sinker].sink_type=check`。目标连接、认证、TLS、
+  连接数以及数据库专属参数全部沿用 `[sinker]` 配置。
+- inline snapshot：使用 `extract_type=snapshot`、`[sinker].sink_type=write`，并增加
+  `[checker]` section。每次 sink 成功后同步执行校验。
+- inline CDC：使用 `extract_type=cdc`、`[sinker].sink_type=write`，并设置
+  `[checker_cdc].is_enabled=true`。写入后通过 CDC checker queue 异步校验。
 
-struct check 仅支持 standalone MySQL/PostgreSQL checker target。
-
-| 配置                        | 作用                                                            | 示例        | 默认                             |
-| :-------------------------- | :-------------------------------------------------------------- | :---------- | :------------------------------- |
-| enable                      | `[checker]` section 出现时是否启用 checker                      | true        | 必填                             |
-| queue_size                  | checker 队列容量，按待处理批次/消息数计数                       | 200         | 200                              |
-| max_connections             | checker 连接池最大连接数                                        | 8           | 8                                |
-| batch_size                  | checker 的分块大小；inline cdc check 下也用于控制 checker 分块  | 200         | 200                              |
-| sample_rate                 | snapshot 与 CDC check 的百分比抽样率                            | 25          | 空（校验全部行/变更）            |
-| output_full_row             | diff 日志是否输出全量行                                         | false       | false                            |
-| output_revise_sql           | 是否将生成的修复 SQL 写入 `sql.log`                             | false       | false                            |
-| revise_match_full_row       | 生成修复 SQL 时是否按全量行匹配                                 | false       | false                            |
-| retry_interval_secs         | 重试间隔（秒），inline cdc check 下强制为 0                     | 0           | 0                                |
-| max_retries                 | 重试次数，inline cdc check 下强制为 0                           | 0           | 0                                |
-| check_log_dir               | 校验日志目录                                                    | /tmp/check  | 空（默认 runtime.log_dir/check） |
-| check_log_file_size         | 本地单类日志文件大小上限（`diff.log` / `miss.log` / `sql.log`） | 100mb       | 100mb                            |
-| check_log_max_rows          | CDC 校验快照最大行数（`diff.log` / `miss.log`）                 | 1000        | 1000                             |
-| db_type                     | 校验目标库类型（仅 standalone 目标配置）                        | mysql       | -                                |
-| url                         | 校验目标 URL（仅 standalone 目标配置）                          | mysql://... | -                                |
-| username                    | 校验目标用户名（仅 standalone 目标配置）                        | root        | 空                               |
-| password                    | 校验目标密码（仅 standalone 目标配置）                          | password    | 空                               |
-| ssl_mode                    | 校验目标 TLS 模式（仅 standalone 目标配置）                     | verify_full | 不设置                           |
-| ssl_ca_path                 | 校验目标 CA 证书路径（仅 standalone 目标配置）                  | /ca.pem     | 空                               |
-| check_log_s3                | standalone snapshot 或 inline CDC check 上传校验日志到 S3       | false       | false                            |
-| cdc_check_log_interval_secs | CDC 校验快照输出间隔（秒）                                      | 30          | 30                               |
-| s3_bucket                   | 校验日志上传的 S3 存储桶                                        | my-bucket   | -                                |
-| s3_access_key_id            | S3 访问密钥 ID                                                  | AKIA...     | -                                |
-| s3_secret_access_key        | S3 秘密访问密钥                                                 | \*\*\*\*    | -                                |
-| s3_region                   | S3 区域                                                         | us-east-1   | -                                |
-| s3_endpoint                 | S3 端点                                                         | https://... | -                                |
-| s3_root_dir                 | S3 helper 使用的本地或挂载根目录                                | /tmp/check  | 空                               |
-| s3_root_url                 | S3 helper 使用的根 URL                                          | s3://bucket | 空                               |
-| s3_key_prefix               | 校验日志的 S3 键前缀                                            | task1/check | 空                               |
+| 配置                  | 作用                           | 示例 | 默认                  |
+| :-------------------- | :----------------------------- | :--- | :-------------------- |
+| batch_size            | 单次 checker 查询的最大行数    | 200  | 200                   |
+| sample_percent        | snapshot/CDC 校验的百分比抽样  | 25   | 空（校验全部行/变更） |
+| recheck_count         | 临时不一致的重试次数           | 4    | 0                     |
+| recheck_interval_secs | 重试间隔（秒）                 | 5    | 0                     |
+| recheck_queue_size    | 待重试行数上限                 | 10000 | 10000                |
+| recheck_queue_memory_mb | 待重试数据内存上限（MiB）    | 256  | 256                   |
 
 说明：
 
-**通用行为**
+- checker 仅支持 `[pipeline].pipeline_type=basic`。
+- `sample_percent` 有效范围为 `1..=100`，只适用于 snapshot check 和 inline CDC check。
+  Standalone snapshot 在抽取阶段采样；inline snapshot/CDC 会完整写入，再在 fetch 目标数据前按
+  key hash 确定性采样。
+- Standalone snapshot check 支持 MySQL、PostgreSQL、MongoDB；standalone struct check
+  支持 MySQL、PostgreSQL。
+- Inline snapshot check 支持 MySQL、PostgreSQL、MongoDB 写入目标。
+- inline CDC reconciliation 不使用 `recheck_count` 和 `recheck_interval_secs`。
+- Retry buffer 达到行数或内存上限时，不会丢弃检查结果；新发现的不一致会跳过重试并立即输出。
 
-- checker 仅支持 `[pipeline] pipeline_type=basic`。
-- `sample_rate` 仅支持 snapshot check 和 inline CDC check。有效范围是 `1..=100`；空值表示
-  校验全部行/变更。Standalone MySQL/PostgreSQL/MongoDB snapshot check 会在 snapshot 抽取阶段
-  应用该比例，减少后续 checker 工作量。存在行数估算时，extractor 会把源端读取限制到
-  大约 `row_count * sample_rate / 100`。`row_count` 基于表估算；表配置了 `where_conditions`
-  时基于该过滤条件估算。如果没有有效估算，则读取完整源端 stream。该抽样
-  是源端 Top-N limit，不是 key hash 抽样，也不是随机抽样。Inline snapshot check 和 inline CDC
-  check 会先完整写入所有行/变更，然后在 checker 目标端 fetch 前进行确定性的 key hash 抽样；
-- `queue_size` 统计的是 checker DML 队列中的待处理批次数，不是行数。checkpoint、`refresh_meta`
-  这类控制信号会绕过这条队列。
-- 在 inline 写后校验链路里，如果 checker DML 队列已满，会丢弃最旧的待校验批次并记录 warning
-  日志，而不是阻塞写入路径。
-- checker 运行时错误（批次校验失败、checkpoint 失败、输出失败）只会记录日志，不影响主 CDC
-  写入链路；checkpoint 和元数据刷新投递仍按 best-effort 处理。
+## Standalone 目标示例
 
-**目标选择与适用形态**
+```ini
+[extractor]
+db_type=mysql
+extract_type=snapshot
+url=mysql://source-host:3306
 
-- 对 inline 写后校验链路来说，一个排队批次通常接近实际写入批大小；实践中多数情况下约等于
-  `[sinker].batch_size` 行，但最后一个批次可能更小，上游分片策略也会影响实际条数。
-- 对 standalone / dummy-sinker 校验链路来说，进入队列的单批大小由上游 parallelizer 决定；
-  出队后，checker 会再按 `[checker].batch_size` 对非 CDC 数据做内部切块处理。
-- struct 任务只支持 standalone MySQL/PostgreSQL checker target。若为 struct 任务启用
-  `[checker]`，请使用 `sink_type=dummy` 或直接省略 `[sinker]`。需要结构校验时请显式运行
-  struct check；standalone snapshot check 不会自动启动结构校验。
-- inline snapshot check 仅支持 `[extractor] extract_type=snapshot`、`[sinker] sink_type=write`，
-  且 `[sinker].db_type` 为 `mysql`、`pg`、`mongo` 的写入链路。
-- inline cdc check 当前仅支持 `[extractor] extract_type=cdc`、`[sinker] sink_type=write`，
-  `[checker].enable=true`、`[parallelizer].parallel_type=rdb_merge`，且 `[sinker].db_type`
-  为 `mysql` 或 `pg` 的场景。
-- 在 inline cdc check 中，checker 使用 `[checker].batch_size`，不会 fallback 到
-  `[sinker].batch_size`。例如 `[checker].batch_size=100`、`queue_size=200` 时，队列最多可积压 200 个待处理批次；若这些批次都打满，大约就是 20,000 行待校验数据。
-- 在 inline snapshot check 与 inline cdc check 中，`[checker]` 不接受 `db_type`、`url`、
-  `username`、`password`；checker 会直接复用 `[sinker]` 已解析的目标端配置。
-- 在 inline cdc check 中，必须配置 `[resumer] resume_type=from_target` 或 `from_db` 来持久化
-  checker 状态。
-- 对 inline cdc check，下面这些组合会直接报 `ConfigError`：出现 `[checker]` section 但缺少
-  `enable`；`[pipeline].pipeline_type != basic`；`[sinker].sink_type != write`；
-  `[parallelizer].parallel_type != rdb_merge`；`[sinker].db_type` 不属于 `mysql` / `pg`；
-  以及在 `[checker]` 中显式填写目标端字段 `db_type` / `url` / `username` / `password`。
+[sinker]
+db_type=mysql
+sink_type=check
+url=mysql://target-host:3306
+username=root
+password=target-password
+max_connections=8
 
-**inline cdc check 的日志 / 重试行为**
+[checker]
+batch_size=200
+sample_percent=25
+recheck_count=4
+recheck_interval_secs=5
+recheck_queue_size=10000
+recheck_queue_memory_mb=256
+```
 
-- 对 inline cdc check，`max_retries` 与 `retry_interval_secs` 会强制按 0 处理。
-- 当 `check_log_dir` 为空时，统一使用 `runtime.log_dir/check` 作为 checker 日志目录（包含 CDC 校验输出）。
-- standalone snapshot check 先输出本地校验日志；如果 `check_log_s3=true`，任务结束后会将最终的
-  `summary.log` 以及非空的 `miss.log`、`diff.log`、`sql.log` 上传到 S3。
-- 在 inline cdc check 下，会始终先在 `check_log_dir` 本地落盘周期性校验快照；
-  `check_log_s3` 仅控制是否上传 S3。除 inline cdc check 外，S3 上传只支持 standalone
-  snapshot check。
-- `check_log_file_size` 限制本地 `diff.log` / `miss.log` / `sql.log` 的大小，`summary.log`
-  不受该限制。
-- `check_log_max_rows` 仅对 CDC 校验快照的 `diff.log` / `miss.log` 生效；命中任一阈值时仅保留最新记录。
+# [checker_output]
+
+校验结果输出配置。省略该 section 时，默认写入 `runtime.log_dir/check` 下的本地日志。
+
+| 配置                 | 作用                                                         | 示例          | 默认 |
+| :------------------- | :----------------------------------------------------------- | :------------ | :--- |
+| output_type          | 输出介质：`logs` 或 `s3`                                | logs          | logs |
+| output_full_row      | diff 日志是否包含完整源端/目标端行                           | false         | false |
+| output_revise_sql    | 是否生成修复语句到 `sql.log`                               | true          | false |
+| revise_match_full_row| 生成修复语句时是否用完整行作为匹配条件                       | false         | false |
+| check_log_dir        | 本地校验日志目录                                             | /tmp/check    | 空（使用 `runtime.log_dir/check`） |
+| check_log_file_size  | `diff.log`、`miss.log`、`sql.log` 单文件大小上限       | 100mb         | 100mb |
+| check_log_max_rows   | CDC `diff.log`/`miss.log` 快照最大行数                   | 1000          | 1000 |
+| s3_bucket            | S3 bucket，`output_type=s3` 时必填                          | my-bucket     | - |
+| s3_access_key_id     | S3 access key                                                | AKIA...       | 空 |
+| s3_secret_access_key | S3 secret key                                                | ****          | 空 |
+| s3_region            | S3 region                                                    | us-east-1     | 空 |
+| s3_endpoint          | 自定义 S3 endpoint                                           | https://...   | 空 |
+| s3_root_dir          | S3 helper 使用的本地/挂载根目录                              | /tmp/check    | 空 |
+| s3_root_url          | S3 helper 使用的根 URL                                       | s3://bucket   | 空 |
+| s3_key_prefix        | 上传日志的 key prefix                                        | task1/check   | 空 |
+
+`output_type=s3` 仅支持 standalone snapshot check 和 inline CDC check。S3 模式仍会使用配置的
+本地滚动日志目录和限制，再执行上传。Struct check、check-log review 和 inline snapshot check
+只支持 `output_type=logs`。
+
+# [checker_cdc]
+
+仅用于 CDC 异步校验的配置。
+
+| 配置                    | 作用                         | 示例 | 默认 |
+| :---------------------- | :--------------------------- | :--- | :--- |
+| is_enabled              | 启用 inline CDC check        | true | false |
+| queue_size              | 待处理 CDC checker batch 数  | 200  | 200 |
+| check_log_interval_secs | CDC 校验结果周期输出间隔（秒）| 30   | 30 |
+
+Inline CDC check 还要求：
+
+- `[extractor].extract_type=cdc`
+- `[sinker].sink_type=write`，目标为 MySQL/PostgreSQL
+- `[parallelizer].parallel_type=rdb_merge`
+- `[resumer].resume_type=from_target` 或 `from_db`
+
+CDC checker queue 用于主动与迁移 pipeline 解耦；队列满时淘汰最旧的待处理 batch，不阻塞写入。
+Checker 处理/输出失败只记录日志，不让主 CDC 写入链路失败。Snapshot 和 struct check 不使用该队列。
 
 # [filter]
 
@@ -325,8 +325,8 @@ struct check 仅支持 standalone MySQL/PostgreSQL checker target。
 | :-------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :---------------------------------- | :--- | :------------------------------------------- |
 | snapshot  | 缓存中的数据分成 parallel_size 份，多线程并行，且批量写入目标                                                                                                                        | mysql/pg/mongo 全量                 | 快   |                                              |
 | serial    | 单线程，依次单条写入目标                                                                                                                                                             | 所有                                |      | 慢                                           |
-| rdb_merge | 将缓存中的行级变更整合成适合写入的 insert + delete 批次，再按 parallel_size 并行下发。`[checker].enable=true` 时，MySQL/PG 的 checker 相关链路会在内部复用它并切换到 check sink mode | mysql/pg 增量、校验、review、revise | 快   | 最终一致性，破坏源端事务在目标端重放的完整性 |
-| mongo     | merge parallelizer 的 Mongo 版。`[checker].enable=true` 时，Mongo 的 checker 相关链路也会在内部复用它并切换到 check sink mode                                                        | mongo 增量、校验、review            |      |                                              |
+| rdb_merge | 将缓存中的行级变更整合成适合写入的 insert + delete 批次，再按 parallel_size 并行下发；用于 MySQL/PG CDC、check、review、revise 链路 | mysql/pg 增量、校验、review、revise | 快   | 最终一致性，破坏源端事务在目标端重放的完整性 |
+| mongo     | merge parallelizer 的 Mongo 版，也用于 standalone MongoDB check 和 review 链路                                                        | mongo 增量、校验、review            |      |                                              |
 | redis     | 单线程，批量/串行（由 sinker 的 batch_size 决定）写入                                                                                                                                | redis 全量/增量                     |      |                                              |
 
 ## snapshot chunk rebalance

--- a/docs/zh/config_changelog.md
+++ b/docs/zh/config_changelog.md
@@ -8,10 +8,13 @@
 
 | 2.0.26 已移除 | 替代方式 |
 | ------------- | -------- |
-| `[sinker].sink_type=check` | 增加 `[checker] enable=true`。Standalone check：目标配置放入 `[checker]`；inline check：保留 `sink_type=write`。 |
+| `[checker].enable` | Standalone check 使用 `[sinker].sink_type=check`；inline snapshot 增加 `[checker]`；inline CDC 使用 `[checker_cdc].is_enabled=true`。 |
 | `[parallelizer].parallel_type=rdb_check` | RDB check/review/revise、inline CDC 使用 `rdb_merge`；inline snapshot 使用正常写入 parallelizer。 |
-| `[extractor].sample_interval` | 使用 `[checker].sample_rate=1..100`；空值表示全量校验。 |
-| `[sinker]` 下的 check 目标配置，包括 `check_log_dir` | Standalone check 移到 `[checker]`；inline check 复用 `[sinker]`。 |
+| `[extractor].sample_interval`、`[checker].sample_rate` | 使用 `[checker].sample_percent=1..100`；空值表示全量校验。 |
+| `[checker]` 下的 checker 目标字段 | 使用 `[sinker]` 的普通数据库字段；standalone check 设置 `sink_type=check`。 |
+| `[checker]` 下的输出字段，包括 `check_log_s3` | 移到 `[checker_output]`；通过 `output_type=logs` 或 `s3` 选择介质。 |
+| `[checker].retry_interval_secs`、`[checker].max_retries` | 使用 `recheck_interval_secs`、`recheck_count`。 |
+| `[checker].queue_size`、`[checker].cdc_check_log_interval_secs` | 使用 `[checker_cdc].queue_size`、`check_log_interval_secs`。 |
 | `[pipeline].max_rps` | 使用 `[extractor].max_rps` 和/或 `[sinker].max_rps`。 |
 | `[resumer].resume_from_log`、`resume_log_dir`、`resume_config_file` | 使用 `resume_type=from_log`、`log_dir`、`config_file`；旧配置返回 `ConfigError`。 |
 | `[pipeline].pipeline_type=http_server`、`http_host`、`http_port`、pipeline `with_field_defs` | 已删除，仅保留 `pipeline_type=basic`。Kafka `[sinker].with_field_defs` 不受影响。 |
@@ -30,11 +33,10 @@
 | Redis extractor/sinker | `is_cluster` | 自动探测 | `true`：集群；`false`：单节点；空：自动。 |
 | MongoDB sinker | `mongo_require_shard_key_filter` | `true` | 写入 filter 必须包含完整目标 shard key。 |
 | MongoDB struct 任务 | `extract_type=struct`、`sink_type=struct` | — | 迁移 collection 和 shard key。 |
-| `[checker]` | `enable`、`queue_size`、`max_connections`、`batch_size`、`sample_rate` | 必填、`200`、`8`、`200`、空 | 启用 checker 及容量设置。 |
-| `[checker]` | `output_full_row`、`output_revise_sql`、`revise_match_full_row` | 全部 `false` | 控制 diff 和修复 SQL 输出。 |
-| `[checker]` | `retry_interval_secs`、`max_retries` | `0`、`0` | Checker 重试策略。 |
-| `[checker]` | `check_log_dir`、`check_log_file_size`、`check_log_max_rows` | 空、`100mb`、`1000` | 本地校验日志及限制。 |
-| `[checker]` | `check_log_s3`、`s3_*`、`cdc_check_log_interval_secs` | `false`、空、`30` | S3 上传和 CDC 校验日志间隔。 |
+| `[checker]` | `batch_size`、`sample_percent`、`recheck_count`、`recheck_interval_secs`、`recheck_queue_size`、`recheck_queue_memory_mb` | `200`、空、`0`、`0`、`10000`、`256` | 通用校验行为和有界重试缓冲。 |
+| `[checker_output]` | `output_type`、`output_full_row`、`output_revise_sql`、`revise_match_full_row` | `logs`、全部 `false` | 选择输出介质和内容。 |
+| `[checker_output]` | `check_log_dir`、`check_log_file_size`、`check_log_max_rows`、`s3_*` | 空、`100mb`、`1000`、空 | 本地滚动日志和可选 S3 上传。 |
+| `[checker_cdc]` | `is_enabled`、`queue_size`、`check_log_interval_secs` | `false`、`200`、`30` | 启用和配置异步 inline CDC check。 |
 | Snapshot `[parallelizer]` | `rebalance_strategy`、`rebalance_cost`、`rebalance_max_partitions_per_sinker`、`rebalance_min_partition_rows`、`rebalance_split_skew_ratio` | `none`、`rows`、`2`、sinker batch size、`1.0` | 目标端 partition rebalance。 |
 | `[runtime]` | `check_result_stdout_only` | `false` | stdout 只输出校验结果。 |
 | `[tracing]` | `task_summary_mode`、`output_format` | `marker`、`plain` | Trace 聚合和输出格式。 |
@@ -51,7 +53,6 @@
 | MongoDB snapshot `batch_size` | Snapshot 配置不使用 | 作为 cursor batch size，且必须能用 `u32` 表示 |
 | `[sinker].batch_size=0` | 配置加载允许 | 非 dummy sinker 拒绝 |
 | MongoDB shard-key filter | 配置层不强制 | 默认强制；`mongo_require_shard_key_filter=false` 可关闭 |
-| Standalone check | 目标端配置为 check sinker | 可省略 `[sinker]`；目标配置放入 `[checker]` |
-| Inline check | 使用 check 专用 sinker/parallelizer | 保留 `sink_type=write`；checker 复用 sinker 目标 |
-| Inline CDC check | 不支持 | 仅 MySQL/PostgreSQL；要求 `rdb_merge` 和 resumer `from_target`/`from_db` |
-| Dummy sinker 下的 `resumer=from_target` | 使用 sinker 目标 | 使用 standalone checker 目标 |
+| Standalone check | 目标端配置为 check sinker | 保持 `[sinker].sink_type=check`，目标沿用普通 sinker 数据库配置 |
+| Inline snapshot check | 使用 check 专用 sinker/parallelizer | 保留 `sink_type=write`；增加 `[checker]` 后同步执行写后校验 |
+| Inline CDC check | 不支持 | 仅 MySQL/PostgreSQL；使用 `[checker_cdc]` 启用，要求 `rdb_merge` 和 resumer `from_target`/`from_db` |

--- a/docs/zh/snapshot/check.md
+++ b/docs/zh/snapshot/check.md
@@ -4,10 +4,10 @@
 
 支持对 MySQL、PostgreSQL、MongoDB 进行比对。
 
-全量校验和 inline CDC check 支持通过 `[checker].sample_rate` 进行抽样。
+全量校验和 inline CDC check 支持通过 `[checker].sample_percent` 进行抽样。
 Standalone MySQL/PostgreSQL/MongoDB snapshot check 会在抽取阶段、进入后续 checker 前应用
-`sample_rate`。当表/collection 的统计行数可用时，源端查询会加上
-`LIMIT ceil(estimated_rows * sample_rate / 100)`。如果拿不到有效估算值，则读取完整源端
+`sample_percent`。当表/collection 的统计行数可用时，源端查询会加上
+`LIMIT ceil(estimated_rows * sample_percent / 100)`。如果拿不到有效估算值，则读取完整源端
 stream。该抽样是源端 Top-N limit，不是 key hash 抽样，也不是随机抽样。Inline snapshot check
 和 inline CDC check 会先完整写入行/变更，然后在 checker 目标端 fetch 前进行确定性的 key hash
 抽样；相同 key 的行/变更会保持一致的抽样结果。
@@ -19,8 +19,8 @@ stream。该抽样是源端 Top-N limit，不是 key hash 抽样，也不是随�
 ### Standalone snapshot check
 
 - 使用 `extract_type=snapshot`。
-- 设置 `sink_type=dummy`，或直接省略 `[sinker]`。
-- 在 `[checker]` 中显式配置校验目标，并设置 `[checker].enable=true`。
+- 在 `[sinker]` 中配置目标并设置 `[sinker].sink_type=check`。
+- 连接、认证、TLS 及数据库专属目标参数均使用普通 `[sinker]` 字段。
 - Standalone snapshot checker target 支持 MySQL、PostgreSQL 和 MongoDB。
 - MySQL/PostgreSQL checker target 使用 `parallel_type=rdb_merge`；MongoDB checker target
   使用 `parallel_type=mongo`。
@@ -75,8 +75,8 @@ stream。该抽样是源端 Top-N limit，不是 key hash 抽样，也不是随�
 - 使用 `extract_type=cdc` 且 `[sinker] sink_type=write`。
 - checker 会在变更写入目标端后校验 CDC 已落库数据。
 - checker 直接复用 `[sinker]` 已解析的目标端配置。
-- 设置 `[checker].enable=true`。
-- `[checker]` 不接受 `db_type`、`url`、`username`、`password`。
+- 设置 `[checker_cdc].is_enabled=true`。
+- 在 `[checker_cdc]` 中配置 `queue_size` 和 `check_log_interval_secs`。
 - 必须通过 `[resumer] resume_type=from_target` 或 `from_db` 持久化 checker 状态。
 - 当前仅支持 `[sinker].db_type` 为 `mysql` 或 `pg`。
 - 使用 `parallel_type=rdb_merge`。
@@ -118,11 +118,11 @@ stream。该抽样是源端 Top-N limit，不是 key hash 抽样，也不是随�
 
 ### 抽样校验
 
-全量校验和 inline CDC check 可在 `[checker]` 中添加 `sample_rate`。对于 standalone
+全量校验和 inline CDC check 可在 `[checker]` 中添加 `sample_percent`。对于 standalone
 MySQL/PostgreSQL/MongoDB snapshot check，抽样发生在抽取阶段。存在行数估算时，extractor
-会把源端读取限制到大约 `row_count * sample_rate / 100`；`row_count` 基于表估算，表配置了
+会把源端读取限制到大约 `row_count * sample_percent / 100`；`row_count` 基于表估算，表配置了
 `where_conditions` 时基于该过滤条件估算。如果估算缺失或为 0，则读取完整源端 stream。对于
-inline snapshot check 和 inline CDC check，`sample_rate=25` 仍会完整写入所有行/变更，然后在目标端 fetch/compare 前只检查 key
+inline snapshot check 和 inline CDC check，`sample_percent=25` 仍会完整写入所有行/变更，然后在目标端 fetch/compare 前只检查 key
 hash 落入抽样百分比的行/变更。
 
 Standalone snapshot check 使用源端 limit，因此恢复运行后的抽样行集合可能不同于一次不中断运行。
@@ -131,8 +131,7 @@ Inline snapshot check 和 inline CDC check 使用 key hash 抽样，相同 key �
 
 ```
 [checker]
-enable=true
-sample_rate=25
+sample_percent=25
 ```
 
 ## 限制
@@ -153,7 +152,7 @@ sample_rate=25
 JSON 对象。`summary.log` 只包含一行总体 summary JSON。`sql.log` 是纯 SQL 文件，每行一条生成的
 修复语句，不包含 JSON 包装，也不携带 schema/table/id metadata。`sql.log` 仅在
 `output_revise_sql=true` 且存在修复 SQL 时生成或写入。默认写入 `runtime.log_dir/check`；若配置了
-`[checker].check_log_dir`，则写入该目录。
+`[checker_output].check_log_dir`，则写入该目录。
 
 默认情况下，stdout 仍遵循普通运行日志配置。若编排系统需要 stdout 只包含校验结果，请只给该
 check 任务设置 `[runtime].check_result_stdout_only=true`。在该模式下，上述文件仍是校验
@@ -198,13 +197,11 @@ payload 与 `sql.log` 中的纯 SQL 语句一致。
 
 ## 输出完整行
 
-当需要完整行内容用于排查问题时，可在 `[checker]` 中开启全行日志。对于 standalone
-snapshot check，需要在 `[checker]` 中显式配置校验目标；对于 inline snapshot check 与
-inline cdc check，checker 会直接复用 `[sinker]` 已解析的目标端配置：
+当需要完整行内容用于排查问题时，在 `[checker_output]` 中开启全行日志。所有模式的目标端
+均通过 `[sinker]` 配置：
 
 ```
-[checker]
-enable=true
+[checker_output]
 output_full_row=true
 ```
 
@@ -242,13 +239,11 @@ output_full_row=true
 
 ## 输出修复 SQL
 
-如需人工修复差异数据，可在 `[checker]` 中开启 SQL 输出。对于 standalone snapshot
-check，需要在 `[checker]` 中显式配置校验目标；对于 inline snapshot check 与 inline cdc
-check，checker 会直接复用 `[sinker]` 已解析的目标端配置：
+如需人工修复差异数据，在 `[checker_output]` 中开启 SQL 输出。所有模式的目标端均通过
+`[sinker]` 配置：
 
 ```
-[checker]
-enable=true
+[checker_output]
 output_revise_sql=true
 # 可选：强制使用全字段匹配 WHERE 条件
 revise_match_full_row=true
@@ -320,14 +315,19 @@ INSERT INTO `test_db_1`.`test_table`(`id`,`name`,`age`,`email`) VALUES(3,'Charli
 ```
 # 原始：源端=A，目标端=B
 # 反向：源端=B，目标端=A
+
 [extractor]
-db_type=<原 checker 的 db_type>
-url=<原 checker 的 url>
+db_type=<原 sinker 的 db_type>
+extract_type=snapshot
+url=<原 sinker 的 url>
+
+[sinker]
+db_type=<原 extractor 的 db_type>
+sink_type=check
+url=<原 extractor 的 url>
 
 [checker]
-enable=true
-db_type=<原 extractor 的 db_type>
-url=<原 extractor 的 url>
+batch_size=200
 ```
 
 # 配置
@@ -336,14 +336,18 @@ url=<原 extractor 的 url>
 
 ## 重试机制
 
-当 `max_retries > 0` 时，checker 会在检测到不一致时自动重试：
+当 `recheck_count > 0` 时，checker 会在检测到不一致时自动重试：
 - 重试期间不记录日志，避免噪音
 - 仅在最后一次检查时记录详细的 miss/diff 日志
 - 适用于目标端数据尚未完全同步的场景
 
+待重试数据由有界 retry buffer 保存，可通过 `recheck_queue_size` 和
+`recheck_queue_memory_mb` 限制行数及估算数据大小。达到任一上限时，新发现的不一致不会被
+丢弃，而是跳过重试并立即按本次检查结果输出。
+
 > **注意：** inline cdc check 下不支持重试。CDC 事件是流式到达的，后续的 DELETE
-> 事件可能会移除已正确写入的数据，导致重试队列中出现误报。即使配置了 `max_retries`
-> 和 `retry_interval_secs`，CDC 模式下也会被强制忽略（设为 0），并输出警告日志。
+> 事件可能会移除已正确写入的数据，导致重试队列中出现误报。即使配置了 `recheck_count`
+> 和 `recheck_interval_secs`，CDC 模式下也会被强制忽略（设为 0），并输出警告日志。
 
 
 ## 集成测试参考

--- a/docs/zh/snapshot/review.md
+++ b/docs/zh/snapshot/review.md
@@ -17,10 +17,13 @@
 extract_type=check_log
 check_log_dir=./dt-tests/tests/mysql_to_mysql/revise/basic_test/check_log
 
-[checker]
-enable=true
+[sinker]
 db_type=mysql
+sink_type=check
 url=mysql://user:pass@host:3306/db
+
+[checker]
+
 
 [parallelizer]
 parallel_type=rdb_merge

--- a/docs/zh/structure/check.md
+++ b/docs/zh/structure/check.md
@@ -5,6 +5,10 @@
 结构校验与 CDC 无直接关系。这里的 `inline cdc check` 指行级数据校验
 （见 [数据校验文档](../snapshot/check.md)）。
 
+内置结构校验是 standalone 任务：使用 `extract_type=struct`，在 `[sinker]` 中按普通数据库
+配置目标端，并设置 `[sinker].sink_type=check`。通用校验参数放在 `[checker]`，结果格式和
+日志路径放在 `[checker_output]`。结构校验不会创建或消费 CDC checker 的异步队列。
+
 ## 示例: MySQL -> MySQL
 
 参考 [任务模版](../../templates/mysql_to_mysql.md)

--- a/dt-common/src/config/checker_config.rs
+++ b/dt-common/src/config/checker_config.rs
@@ -1,52 +1,112 @@
-use super::{
-    config_enums::DbType, connection_auth_config::ConnectionAuthConfig, s3_config::S3Config,
-};
+use super::s3_config::S3Config;
 
-#[derive(Clone)]
+pub const DEFAULT_CHECKER_BATCH_SIZE: usize = 200;
+pub const DEFAULT_CHECKER_QUEUE_SIZE: usize = 200;
+pub const DEFAULT_RECHECK_QUEUE_SIZE: usize = 10_000;
+pub const DEFAULT_RECHECK_QUEUE_MEMORY_MB: usize = 256;
+pub const DEFAULT_CHECK_LOG_FILE_SIZE: &str = "100mb";
+pub const DEFAULT_CHECK_LOG_MAX_ROWS: usize = 1000;
+pub const DEFAULT_CDC_CHECK_LOG_INTERVAL_SECS: u64 = 30;
+
+/// Common checker settings.
+///
+/// Standalone snapshot/struct/check-log tasks use `[sinker] sink_type=check`; the checker target
+/// connection is loaded through the regular MySQL/PostgreSQL/MongoDB sinker configuration.
+/// `[checker_output]` owns result output settings. CDC inline check is enabled separately through
+/// `[checker_cdc] is_enabled=true`.
+#[derive(Clone, Debug)]
 pub struct CheckerConfig {
-    pub queue_size: usize,
-    pub max_connections: u32,
     pub batch_size: usize,
-    pub sample_rate: Option<u8>,
-    pub output_full_row: bool,
-    pub output_revise_sql: bool,
-    pub revise_match_full_row: bool,
-    pub retry_interval_secs: u64,
-    pub max_retries: u32,
-    pub check_log_dir: String,
-    pub check_log_file_size: String,
-    pub check_log_max_rows: usize,
-    pub db_type: DbType,
-    pub url: String,
-    pub connection_auth: ConnectionAuthConfig,
-    pub check_log_s3: bool,
-    pub s3_config: Option<S3Config>,
-    pub s3_key_prefix: String,
-    pub cdc_check_log_interval_secs: u64,
+    pub sample_percent: Option<u8>,
+    pub recheck_count: u32,
+    pub recheck_interval_secs: u64,
+    pub recheck_queue_size: usize,
+    pub recheck_queue_memory_mb: usize,
+    pub output: CheckerOutputConfig,
+    pub inline_check: Option<InlineCheckConfig>,
 }
 
 impl Default for CheckerConfig {
     fn default() -> Self {
         Self {
-            queue_size: 200,
-            max_connections: 8,
-            batch_size: 200,
-            sample_rate: None,
+            batch_size: DEFAULT_CHECKER_BATCH_SIZE,
+            sample_percent: None,
+            recheck_count: 0,
+            recheck_interval_secs: 0,
+            recheck_queue_size: DEFAULT_RECHECK_QUEUE_SIZE,
+            recheck_queue_memory_mb: DEFAULT_RECHECK_QUEUE_MEMORY_MB,
+            output: CheckerOutputConfig::default(),
+            inline_check: None,
+        }
+    }
+}
+
+impl CheckerConfig {
+    pub fn log_dir(&self) -> &str {
+        &self.output.log_dir
+    }
+
+    pub fn log_file_size(&self) -> &str {
+        &self.output.log_file_size
+    }
+
+    pub fn log_max_rows(&self) -> usize {
+        self.output.log_max_rows
+    }
+
+    pub fn s3_output(&self) -> Option<(&S3Config, &str)> {
+        match &self.output.output_type {
+            CheckerOutputType::S3 { key_prefix, config } => Some((config, key_prefix)),
+            CheckerOutputType::Logs => None,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct CheckerOutputConfig {
+    pub output_full_row: bool,
+    pub output_revise_sql: bool,
+    pub revise_match_full_row: bool,
+    pub log_dir: String,
+    pub log_file_size: String,
+    pub log_max_rows: usize,
+    pub output_type: CheckerOutputType,
+}
+
+impl Default for CheckerOutputConfig {
+    fn default() -> Self {
+        Self {
             output_full_row: false,
             output_revise_sql: false,
             revise_match_full_row: false,
-            retry_interval_secs: 0,
-            max_retries: 0,
-            check_log_dir: String::new(),
-            check_log_file_size: "100mb".to_string(),
-            check_log_max_rows: 1000,
-            db_type: DbType::default(),
-            url: String::new(),
-            connection_auth: ConnectionAuthConfig::default(),
-            check_log_s3: false,
-            s3_config: None,
-            s3_key_prefix: String::new(),
-            cdc_check_log_interval_secs: 30,
+            log_dir: String::new(),
+            log_file_size: DEFAULT_CHECK_LOG_FILE_SIZE.to_string(),
+            log_max_rows: DEFAULT_CHECK_LOG_MAX_ROWS,
+            output_type: CheckerOutputType::Logs,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum CheckerOutputType {
+    Logs,
+    S3 {
+        key_prefix: String,
+        config: S3Config,
+    },
+}
+
+#[derive(Clone, Debug)]
+pub struct InlineCheckConfig {
+    pub queue_size: usize,
+    pub check_log_interval_secs: u64,
+}
+
+impl Default for InlineCheckConfig {
+    fn default() -> Self {
+        Self {
+            queue_size: DEFAULT_CHECKER_QUEUE_SIZE,
+            check_log_interval_secs: DEFAULT_CDC_CHECK_LOG_INTERVAL_SECS,
         }
     }
 }

--- a/dt-common/src/config/config_enums.rs
+++ b/dt-common/src/config/config_enums.rs
@@ -95,12 +95,6 @@ pub enum ParallelType {
     Redis,
 }
 
-#[derive(EnumString, IntoStaticStr, Clone, Display)]
-pub enum PipelineType {
-    #[strum(serialize = "basic")]
-    Basic,
-}
-
 #[derive(Clone, Debug, EnumString, IntoStaticStr, PartialEq, Default)]
 pub enum ConflictPolicyEnum {
     #[strum(serialize = "ignore")]

--- a/dt-common/src/config/config_enums.rs
+++ b/dt-common/src/config/config_enums.rs
@@ -63,6 +63,8 @@ pub enum SinkType {
     Dummy,
     #[strum(serialize = "write")]
     Write,
+    #[strum(serialize = "check")]
+    Check,
     #[strum(serialize = "struct")]
     Struct,
     #[strum(serialize = "statistic")]

--- a/dt-common/src/config/pipeline_config.rs
+++ b/dt-common/src/config/pipeline_config.rs
@@ -1,10 +1,7 @@
 use crate::config::limiter_config::CapacityLimiterConfig;
 
-use super::config_enums::PipelineType;
-
 #[derive(Clone)]
 pub struct PipelineConfig {
-    pub pipeline_type: PipelineType,
     pub capacity_limiter: CapacityLimiterConfig,
     pub checkpoint_interval_secs: u64,
     pub batch_sink_interval_secs: u64,

--- a/dt-common/src/config/task_config.rs
+++ b/dt-common/src/config/task_config.rs
@@ -21,7 +21,10 @@ use crate::{
 };
 
 use super::{
-    checker_config::CheckerConfig,
+    checker_config::{
+        CheckerConfig, CheckerOutputConfig, CheckerOutputType, InlineCheckConfig,
+        DEFAULT_CHECK_LOG_FILE_SIZE,
+    },
     config_enums::{
         CheckMode, ConflictPolicyEnum, DbType, ExtractType, MetaCenterType, ParallelType,
         PipelineType, SinkType, TaskKind, TaskType,
@@ -69,7 +72,6 @@ pub struct TaskConfig {
 
 pub const DEFAULT_DB_BATCH_SIZE: usize = 100;
 pub const DEFAULT_MAX_CONNECTIONS: u32 = 10;
-pub const DEFAULT_CHECK_LOG_FILE_SIZE: &str = "100mb";
 
 // sections
 const GLOBAL: &str = "global";
@@ -84,6 +86,8 @@ const RESUMER: &str = "resumer";
 const DATA_MARKER: &str = "data_marker";
 const PROCESSOR: &str = "processor";
 const CHECKER: &str = "checker";
+const CHECKER_OUTPUT: &str = "checker_output";
+const CHECKER_CDC: &str = "checker_cdc";
 const META_CENTER: &str = "metacenter";
 const TRACING: &str = "tracing";
 // keys
@@ -93,13 +97,14 @@ const CHECK_LOG_MAX_ROWS: &str = "check_log_max_rows";
 const OUTPUT_FULL_ROW: &str = "output_full_row";
 const OUTPUT_REVISE_SQL: &str = "output_revise_sql";
 const REVISE_MATCH_FULL_ROW: &str = "revise_match_full_row";
-const RETRY_INTERVAL_SECS: &str = "retry_interval_secs";
-const MAX_RETRIES: &str = "max_retries";
-const ENABLE: &str = "enable";
+const RECHECK_INTERVAL_SECS: &str = "recheck_interval_secs";
+const RECHECK_COUNT: &str = "recheck_count";
+const RECHECK_QUEUE_SIZE: &str = "recheck_queue_size";
+const RECHECK_QUEUE_MEMORY_MB: &str = "recheck_queue_memory_mb";
+const IS_ENABLED: &str = "is_enabled";
+const LEGACY_CHECKER_ENABLE: &str = "enable";
 const DB_TYPE: &str = "db_type";
 const URL: &str = "url";
-const USERNAME: &str = "username";
-const PASSWORD: &str = "password";
 const BATCH_SIZE: &str = "batch_size";
 const MAX_CONNECTIONS: &str = "max_connections";
 const PARTITION_COLS: &str = "partition_cols";
@@ -121,10 +126,9 @@ const REPLACE: &str = "replace";
 const DISABLE_FOREIGN_KEY_CHECKS: &str = "disable_foreign_key_checks";
 const RESUME_TYPE: &str = "resume_type";
 const CHECKER_QUEUE_SIZE: &str = "queue_size";
-const CHECK_LOG_S3: &str = "check_log_s3";
 const S3_KEY_PREFIX: &str = "s3_key_prefix";
-const CDC_CHECK_LOG_INTERVAL_SECS: &str = "cdc_check_log_interval_secs";
-const SAMPLE_RATE: &str = "sample_rate";
+const CHECK_LOG_INTERVAL_SECS: &str = "check_log_interval_secs";
+const SAMPLE_PERCENT: &str = "sample_percent";
 const IS_DIRECT_CONNECTION: &str = "is_direct_connection";
 const MONGO_REQUIRE_SHARD_KEY_FILTER: &str = "mongo_require_shard_key_filter";
 const TASK_SUMMARY_MODE: &str = "task_summary_mode";
@@ -146,25 +150,9 @@ impl TaskConfig {
         let filter = Self::load_filter_config(&loader)?;
         let router = Self::load_router_config(&loader)?;
         let parallelizer = Self::load_parallelizer_config(&loader, &sinker_basic, &pipeline)?;
-        let checker = Self::load_checker_config(&loader)?;
+        let checker =
+            Self::load_checker_config(&loader, &extractor_basic.extract_type, &sinker_basic)?;
         if let Some(checker_cfg) = checker.as_ref() {
-            if matches!(extractor_basic.extract_type, ExtractType::Cdc)
-                && !matches!(sinker_basic.sink_type, SinkType::Write)
-            {
-                bail!(Error::ConfigError(
-                    "config [checker] with [extractor] extract_type=cdc requires [sinker] sink_type=write"
-                        .into(),
-                ));
-            }
-            if matches!(extractor_basic.extract_type, ExtractType::Cdc)
-                && !matches!(parallelizer.parallel_type(), ParallelType::RdbMerge)
-            {
-                bail!(Error::ConfigError(
-                    "config [checker].enable=true with [extractor] extract_type=cdc and [sinker] sink_type=write currently supports only [parallelizer] parallel_type=rdb_merge"
-                        .into(),
-                ));
-            }
-
             if !matches!(pipeline.pipeline_type, PipelineType::Basic) {
                 bail!(Error::ConfigError(
                     "config [checker] only supports [pipeline] pipeline_type=basic".into(),
@@ -172,9 +160,9 @@ impl TaskConfig {
             }
 
             let task_type = if matches!(extractor_basic.extract_type, ExtractType::CheckLog)
-                && matches!(sinker_basic.sink_type, SinkType::Dummy)
+                && matches!(sinker_basic.sink_type, SinkType::Check)
                 && matches!(
-                    checker_cfg.db_type,
+                    sinker_basic.db_type,
                     DbType::Mysql | DbType::Pg | DbType::Mongo
                 ) {
                 None
@@ -183,38 +171,30 @@ impl TaskConfig {
                     Self::build_task_type(
                         &extractor_basic.extract_type,
                         &sinker_basic.sink_type,
-                        Self::checker_target_db_type(
-                            &extractor_basic.extract_type,
-                            &sinker_basic,
-                            checker_cfg,
-                        ),
+                        &sinker_basic.db_type,
                         true,
                     )
                     .ok_or_else(|| {
                         Error::ConfigError(format!(
-                            "config [checker] is not supported for [checker] db_type={} with [extractor] extract_type={} and [sinker] sink_type={}",
-                            checker_cfg.db_type, extractor_basic.extract_type, sinker_basic.sink_type
+                            "checker is not supported for [sinker] db_type={} with [extractor] extract_type={} and [sinker] sink_type={}",
+                            sinker_basic.db_type, extractor_basic.extract_type, sinker_basic.sink_type
                         ))
                     })?,
                 )
             };
 
-            let check_log_s3_supported = task_type.is_some_and(|task_type| {
+            let is_s3_output =
+                matches!(checker_cfg.output.output_type, CheckerOutputType::S3 { .. });
+            let s3_supported = task_type.is_some_and(|task_type| {
                 task_type.is_cdc_inline_check() || task_type.is_standalone_snapshot_check()
             });
-            if checker_cfg.check_log_s3 && !check_log_s3_supported {
+            if is_s3_output && !s3_supported {
                 bail!(Error::ConfigError(format!(
-                    "config [checker].{} only supports standalone snapshot check or inline cdc check",
-                    CHECK_LOG_S3
+                    "config [checker_output].output_type=s3 only supports standalone snapshot check or inline cdc check"
                 )));
             }
-            if checker_cfg.check_log_s3 && checker_cfg.s3_config.is_none() {
-                bail!(Error::ConfigError(
-                    "check_log_s3=true but checker s3 config is missing in [checker]".into(),
-                ));
-            }
 
-            if checker_cfg.sample_rate.is_some()
+            if checker_cfg.sample_percent.is_some()
                 && !matches!(
                     task_type,
                     Some(TaskType {
@@ -228,23 +208,30 @@ impl TaskConfig {
             {
                 bail!(Error::ConfigError(format!(
                     "config [checker].{} only supports snapshot check or inline cdc check",
-                    SAMPLE_RATE
+                    SAMPLE_PERCENT
                 )));
             }
 
-            Self::validate_checker_target_config(
-                &loader,
-                task_type.is_some_and(|task_type| task_type.is_inline_check()),
-            )?;
+            if task_type.is_some_and(|task_type| task_type.is_cdc_inline_check()) {
+                if !matches!(parallelizer.parallel_type(), ParallelType::RdbMerge) {
+                    bail!(Error::ConfigError(
+                        "inline cdc check currently supports only [parallelizer] parallel_type=rdb_merge"
+                            .into(),
+                    ));
+                }
+                if checker_cfg.inline_check.is_none() {
+                    bail!(Error::ConfigError(
+                        "inline cdc check requires [checker_cdc].is_enabled=true".into(),
+                    ));
+                }
+            }
         }
-        let resumer =
-            Self::load_resumer_config(&loader, &runtime, &sinker_basic, checker.as_ref())?;
+        let resumer = Self::load_resumer_config(&loader, &runtime, &sinker_basic)?;
         Ok(Self {
             global: Self::load_global_config(
                 &loader,
                 &extractor_basic,
                 &sinker_basic,
-                checker.as_ref(),
                 &filter,
                 &router,
             )?,
@@ -273,15 +260,8 @@ impl TaskConfig {
     }
 
     pub fn checker_target(&self) -> Option<BasicSinkerConfig> {
-        let checker = self.checker.as_ref()?;
-        if self
-            .task_type()
-            .is_some_and(|task_type| task_type.is_inline_check())
-        {
-            self.sink_target()
-        } else {
-            Some(Self::checker_as_basic_sinker(checker))
-        }
+        self.checker.as_ref()?;
+        self.sink_target()
     }
 
     pub fn destination_target(&self) -> Option<BasicSinkerConfig> {
@@ -297,69 +277,12 @@ impl TaskConfig {
             // recorder/recovery/checker-store initialization.
             return None;
         }
-        let target_db_type = self
-            .checker
-            .as_ref()
-            .map(|checker| {
-                Self::checker_target_db_type(
-                    &self.extractor_basic.extract_type,
-                    &self.sinker_basic,
-                    checker,
-                )
-            })
-            .unwrap_or(&self.sinker_basic.db_type);
         Self::build_task_type(
             &self.extractor_basic.extract_type,
             &self.sinker_basic.sink_type,
-            target_db_type,
+            &self.sinker_basic.db_type,
             self.checker.is_some(),
         )
-    }
-
-    fn checker_uses_inline_target(extract_type: &ExtractType, sink_type: &SinkType) -> bool {
-        matches!(sink_type, SinkType::Write)
-            && matches!(extract_type, ExtractType::Snapshot | ExtractType::Cdc)
-    }
-
-    fn checker_target_db_type<'a>(
-        extract_type: &ExtractType,
-        sinker_basic: &'a BasicSinkerConfig,
-        checker: &'a CheckerConfig,
-    ) -> &'a DbType {
-        if Self::checker_uses_inline_target(extract_type, &sinker_basic.sink_type) {
-            &sinker_basic.db_type
-        } else {
-            &checker.db_type
-        }
-    }
-
-    fn validate_checker_target_config(
-        loader: &IniLoader,
-        inline_check: bool,
-    ) -> anyhow::Result<()> {
-        if inline_check
-            && [DB_TYPE, URL, USERNAME, PASSWORD]
-                .iter()
-                .any(|key| loader.contains(CHECKER, key))
-        {
-            bail!(Error::ConfigError(
-                "inline check does not accept [checker] target fields; configure them via [sinker]"
-                    .into(),
-            ));
-        }
-        if !inline_check
-            && [DB_TYPE, URL].iter().any(|key| {
-                loader
-                    .ini
-                    .get(CHECKER, key)
-                    .is_none_or(|value| value.is_empty())
-            })
-        {
-            bail!(Error::ConfigError(
-                "config [checker] standalone target requires non-empty db_type and url".into(),
-            ));
-        }
-        Ok(())
     }
 
     fn write_sink_supports_inline_checker(target_db_type: &DbType) -> bool {
@@ -391,12 +314,12 @@ impl TaskConfig {
             }
         } else {
             match (kind, sink_type, target_db_type) {
-                (TaskKind::Struct, SinkType::Dummy, DbType::Mysql | DbType::Pg) => {
+                (TaskKind::Struct, SinkType::Check, DbType::Mysql | DbType::Pg) => {
                     Some(CheckMode::Standalone)
                 }
                 (
                     TaskKind::Snapshot,
-                    SinkType::Dummy,
+                    SinkType::Check,
                     DbType::Mysql | DbType::Pg | DbType::Mongo,
                 ) => Some(CheckMode::Standalone),
                 (TaskKind::Snapshot, SinkType::Write, db_type)
@@ -418,22 +341,14 @@ impl TaskConfig {
         loader: &IniLoader,
         extractor_basic: &BasicExtractorConfig,
         sinker_basic: &BasicSinkerConfig,
-        checker: Option<&CheckerConfig>,
         filter: &FilterConfig,
         router: &RouterConfig,
     ) -> anyhow::Result<GlobalConfig> {
-        let identity_sinker_basic = if matches!(sinker_basic.sink_type, SinkType::Dummy) {
-            checker
-                .map(Self::checker_as_basic_sinker)
-                .unwrap_or_else(|| sinker_basic.clone())
-        } else {
-            sinker_basic.clone()
-        };
         Ok(GlobalConfig {
             task_id: loader.get_with_default(
                 GLOBAL,
                 "task_id",
-                TaskUtil::generate_task_id(extractor_basic, &identity_sinker_basic, filter, router),
+                TaskUtil::generate_task_id(extractor_basic, sinker_basic, filter, router),
             ),
         })
     }
@@ -771,40 +686,13 @@ impl TaskConfig {
         Ok((basic, extractor))
     }
 
-    fn is_checker_enabled(loader: &IniLoader) -> anyhow::Result<bool> {
-        if !loader.ini.sections().contains(&CHECKER.to_string()) {
-            return Ok(false);
-        }
-        if !loader.contains(CHECKER, ENABLE) {
-            bail!(Error::ConfigError(
-                "config [checker].enable is required when [checker] section is present".into(),
-            ));
-        }
-        Ok(loader.get_with_default(CHECKER, ENABLE, false))
-    }
-
     fn load_sinker_config(loader: &IniLoader) -> anyhow::Result<(BasicSinkerConfig, SinkerConfig)> {
         let has_sinker = loader.ini.sections().contains(&SINKER.to_string());
-        let has_checker = loader.ini.sections().contains(&CHECKER.to_string());
-
         if !has_sinker {
-            if !has_checker {
-                bail!(Error::ConfigError(
-                    "config [sinker] is required when [checker] is not set".into()
-                ));
-            }
-            if !Self::is_checker_enabled(loader)? {
-                bail!(Error::ConfigError(
-                    "config [sinker] is required unless [checker].enable=true".into()
-                ));
-            }
+            bail!(Error::ConfigError("config [sinker] is required".into()));
         }
 
-        let sink_type = if has_sinker {
-            loader.get_with_default(SINKER, "sink_type", SinkType::Write)
-        } else {
-            SinkType::Dummy
-        };
+        let sink_type = loader.get_with_default(SINKER, "sink_type", SinkType::Write);
 
         if let SinkType::Dummy = sink_type {
             return Ok((BasicSinkerConfig::default(), SinkerConfig::Dummy));
@@ -854,7 +742,7 @@ impl TaskConfig {
 
         let sinker = match db_type {
             DbType::Mysql | DbType::Tidb => match sink_type {
-                SinkType::Write => SinkerConfig::Mysql {
+                SinkType::Write | SinkType::Check => SinkerConfig::Mysql {
                     url,
                     connection_auth,
                     batch_size,
@@ -881,7 +769,7 @@ impl TaskConfig {
             },
 
             DbType::Pg => match sink_type {
-                SinkType::Write => SinkerConfig::Pg {
+                SinkType::Write | SinkType::Check => SinkerConfig::Pg {
                     url,
                     connection_auth,
                     batch_size,
@@ -907,7 +795,7 @@ impl TaskConfig {
             },
 
             DbType::Mongo => match sink_type {
-                SinkType::Write => SinkerConfig::Mongo {
+                SinkType::Write | SinkType::Check => SinkerConfig::Mongo {
                     url,
                     connection_auth,
                     is_direct_connection,
@@ -1113,115 +1001,178 @@ impl TaskConfig {
         config
     }
 
-    fn load_checker_config(loader: &IniLoader) -> anyhow::Result<Option<CheckerConfig>> {
-        if !Self::is_checker_enabled(loader)? {
+    fn load_checker_config(
+        loader: &IniLoader,
+        extract_type: &ExtractType,
+        sinker_basic: &BasicSinkerConfig,
+    ) -> anyhow::Result<Option<CheckerConfig>> {
+        if loader.contains(CHECKER, LEGACY_CHECKER_ENABLE) {
+            bail!(Error::ConfigError(
+                "config [checker].enable is no longer supported; use [sinker].sink_type=check for standalone check, [checker] for snapshot inline check, or [checker_cdc].is_enabled=true for CDC inline check"
+                    .into(),
+            ));
+        }
+        let has_checker = loader.ini.sections().contains(&CHECKER.to_string());
+        let cdc_enabled = loader.ini.sections().contains(&CHECKER_CDC.to_string())
+            && loader.get_with_default(CHECKER_CDC, IS_ENABLED, false);
+        let standalone = matches!(sinker_basic.sink_type, SinkType::Check);
+        let snapshot_inline = has_checker
+            && matches!(extract_type, ExtractType::Snapshot)
+            && matches!(sinker_basic.sink_type, SinkType::Write);
+
+        if !standalone && !snapshot_inline && !cdc_enabled {
             return Ok(None);
         }
 
+        if cdc_enabled
+            && (!matches!(extract_type, ExtractType::Cdc)
+                || !matches!(sinker_basic.sink_type, SinkType::Write))
+        {
+            bail!(Error::ConfigError(
+                "config [checker_cdc].is_enabled=true requires [extractor] extract_type=cdc and [sinker] sink_type=write"
+                    .into(),
+            ));
+        }
+        if matches!(extract_type, ExtractType::Cdc) && !cdc_enabled {
+            return Ok(None);
+        }
+        if sinker_basic.url.is_empty() {
+            bail!(Error::ConfigError(
+                "checker target requires non-empty [sinker].url".into(),
+            ));
+        }
+
         let default = CheckerConfig::default();
-        let sample_rate = match loader.ini.get(CHECKER, SAMPLE_RATE) {
+        let sample_percent = match loader.ini.get(CHECKER, SAMPLE_PERCENT) {
             Some(raw) if !raw.is_empty() => {
-                let sample_rate = raw.parse::<usize>().map_err(|_| {
+                let sample_percent = raw.parse::<usize>().map_err(|_| {
                     Error::ConfigError(format!(
                         "config [checker].{}={}, can not be parsed as usize",
-                        SAMPLE_RATE, raw
+                        SAMPLE_PERCENT, raw
                     ))
                 })?;
-                if !(1..=100).contains(&sample_rate) {
+                if !(1..=100).contains(&sample_percent) {
                     bail!(Error::ConfigError(format!(
-                        "config [checker].sample_rate must be between 1 and 100, got {}",
-                        sample_rate
+                        "config [checker].sample_percent must be between 1 and 100, got {}",
+                        sample_percent
                     )));
                 }
-                Some(sample_rate as u8)
+                Some(sample_percent as u8)
             }
             _ => None,
         };
-        let config = CheckerConfig {
-            queue_size: loader.get_with_default(CHECKER, CHECKER_QUEUE_SIZE, default.queue_size),
-            max_connections: loader.get_with_default(
-                CHECKER,
-                MAX_CONNECTIONS,
-                default.max_connections,
-            ),
-            batch_size: loader.get_with_default(CHECKER, BATCH_SIZE, default.batch_size),
-            sample_rate,
-            output_full_row: loader.get_with_default(
-                CHECKER,
-                OUTPUT_FULL_ROW,
-                default.output_full_row,
-            ),
-            output_revise_sql: loader.get_with_default(
-                CHECKER,
-                OUTPUT_REVISE_SQL,
-                default.output_revise_sql,
-            ),
-            revise_match_full_row: loader.get_with_default(
-                CHECKER,
-                REVISE_MATCH_FULL_ROW,
-                default.revise_match_full_row,
-            ),
-            retry_interval_secs: loader.get_with_default(
-                CHECKER,
-                RETRY_INTERVAL_SECS,
-                default.retry_interval_secs,
-            ),
-            max_retries: loader.get_with_default(CHECKER, MAX_RETRIES, default.max_retries),
-            check_log_dir: loader.get_with_default(CHECKER, CHECK_LOG_DIR, default.check_log_dir),
-            check_log_file_size: loader.get_with_default(
-                CHECKER,
-                CHECK_LOG_FILE_SIZE,
-                default.check_log_file_size,
-            ),
-            check_log_max_rows: loader.get_with_default(
-                CHECKER,
-                CHECK_LOG_MAX_ROWS,
-                default.check_log_max_rows,
-            ),
-            check_log_s3: loader.get_with_default(CHECKER, CHECK_LOG_S3, default.check_log_s3),
-            s3_config: {
-                let bucket: String = loader.get_optional(CHECKER, "s3_bucket");
-                if bucket.is_empty() {
-                    None
-                } else {
-                    Some(S3Config {
-                        bucket,
-                        access_key: loader.get_optional(CHECKER, "s3_access_key_id"),
-                        secret_key: loader.get_optional(CHECKER, "s3_secret_access_key"),
-                        region: loader.get_optional(CHECKER, "s3_region"),
-                        endpoint: loader.get_optional(CHECKER, "s3_endpoint"),
-                        root_dir: loader.get_optional(CHECKER, "s3_root_dir"),
-                        root_url: loader.get_optional(CHECKER, "s3_root_url"),
-                    })
-                }
-            },
-            s3_key_prefix: loader.get_with_default(CHECKER, S3_KEY_PREFIX, default.s3_key_prefix),
-            cdc_check_log_interval_secs: loader.get_with_default(
-                CHECKER,
-                CDC_CHECK_LOG_INTERVAL_SECS,
-                default.cdc_check_log_interval_secs,
-            ),
-            db_type: loader.get_optional(CHECKER, DB_TYPE),
-            url: loader.get_optional(CHECKER, URL),
-            connection_auth: ConnectionAuthConfig::from(loader, CHECKER),
-        };
-        Ok(Some(config))
-    }
 
-    // TODO: checker support mongo & redis special configs
-    fn checker_as_basic_sinker(checker: &CheckerConfig) -> BasicSinkerConfig {
-        BasicSinkerConfig {
-            sink_type: SinkType::Dummy,
-            db_type: checker.db_type.clone(),
-            url: checker.url.clone(),
-            connection_auth: checker.connection_auth.clone(),
-            batch_size: checker.batch_size,
-            max_connections: checker.max_connections,
-            rate_limiter: RateLimiterConfig::default(),
-            app_name: Some(APP_NAME.to_string()),
-            is_direct_connection: None,
-            is_cluster: None,
+        let output_default = CheckerOutputConfig::default();
+        let output_type: String =
+            loader.get_with_default(CHECKER_OUTPUT, "output_type", "logs".to_string());
+        let output_type = match output_type.as_str() {
+            "logs" => CheckerOutputType::Logs,
+            "s3" => {
+                let bucket = loader
+                    .ini
+                    .get(CHECKER_OUTPUT, "s3_bucket")
+                    .filter(|value| !value.is_empty())
+                    .ok_or_else(|| {
+                        Error::ConfigError(
+                            "config [checker_output].s3_bucket is required when output_type=s3"
+                                .into(),
+                        )
+                    })?;
+                CheckerOutputType::S3 {
+                    key_prefix: loader.get_optional(CHECKER_OUTPUT, S3_KEY_PREFIX),
+                    config: S3Config {
+                        bucket,
+                        access_key: loader.get_optional(CHECKER_OUTPUT, "s3_access_key_id"),
+                        secret_key: loader.get_optional(CHECKER_OUTPUT, "s3_secret_access_key"),
+                        region: loader.get_optional(CHECKER_OUTPUT, "s3_region"),
+                        endpoint: loader.get_optional(CHECKER_OUTPUT, "s3_endpoint"),
+                        root_dir: loader.get_optional(CHECKER_OUTPUT, "s3_root_dir"),
+                        root_url: loader.get_optional(CHECKER_OUTPUT, "s3_root_url"),
+                    },
+                }
+            }
+            _ => {
+                bail!(Error::ConfigError(format!(
+                    "config [checker_output].output_type must be logs or s3, got {}",
+                    output_type
+                )))
+            }
+        };
+
+        let recheck_queue_size =
+            loader.get_with_default(CHECKER, RECHECK_QUEUE_SIZE, default.recheck_queue_size);
+        if recheck_queue_size == 0 {
+            bail!(Error::ConfigError(
+                "config [checker].recheck_queue_size must be greater than 0".into(),
+            ));
         }
+        let recheck_queue_memory_mb = loader.get_with_default(
+            CHECKER,
+            RECHECK_QUEUE_MEMORY_MB,
+            default.recheck_queue_memory_mb,
+        );
+        if recheck_queue_memory_mb == 0 {
+            bail!(Error::ConfigError(
+                "config [checker].recheck_queue_memory_mb must be greater than 0".into(),
+            ));
+        }
+
+        Ok(Some(CheckerConfig {
+            batch_size: loader.get_with_default(CHECKER, BATCH_SIZE, default.batch_size),
+            sample_percent,
+            recheck_count: loader.get_with_default(CHECKER, RECHECK_COUNT, default.recheck_count),
+            recheck_interval_secs: loader.get_with_default(
+                CHECKER,
+                RECHECK_INTERVAL_SECS,
+                default.recheck_interval_secs,
+            ),
+            recheck_queue_size,
+            recheck_queue_memory_mb,
+            output: CheckerOutputConfig {
+                output_full_row: loader.get_with_default(
+                    CHECKER_OUTPUT,
+                    OUTPUT_FULL_ROW,
+                    output_default.output_full_row,
+                ),
+                output_revise_sql: loader.get_with_default(
+                    CHECKER_OUTPUT,
+                    OUTPUT_REVISE_SQL,
+                    output_default.output_revise_sql,
+                ),
+                revise_match_full_row: loader.get_with_default(
+                    CHECKER_OUTPUT,
+                    REVISE_MATCH_FULL_ROW,
+                    output_default.revise_match_full_row,
+                ),
+                log_dir: loader.get_optional(CHECKER_OUTPUT, CHECK_LOG_DIR),
+                log_file_size: loader.get_with_default(
+                    CHECKER_OUTPUT,
+                    CHECK_LOG_FILE_SIZE,
+                    DEFAULT_CHECK_LOG_FILE_SIZE.to_string(),
+                ),
+                log_max_rows: loader.get_with_default(
+                    CHECKER_OUTPUT,
+                    CHECK_LOG_MAX_ROWS,
+                    super::checker_config::DEFAULT_CHECK_LOG_MAX_ROWS,
+                ),
+                output_type,
+            },
+            inline_check: cdc_enabled.then(|| {
+                let inline_default = InlineCheckConfig::default();
+                InlineCheckConfig {
+                    queue_size: loader.get_with_default(
+                        CHECKER_CDC,
+                        CHECKER_QUEUE_SIZE,
+                        inline_default.queue_size,
+                    ),
+                    check_log_interval_secs: loader.get_with_default(
+                        CHECKER_CDC,
+                        CHECK_LOG_INTERVAL_SECS,
+                        inline_default.check_log_interval_secs,
+                    ),
+                }
+            }),
+        }))
     }
 
     fn load_runtime_config(loader: &IniLoader) -> anyhow::Result<RuntimeConfig> {
@@ -1290,7 +1241,6 @@ impl TaskConfig {
         loader: &IniLoader,
         runtime: &RuntimeConfig,
         sinker_basic: &BasicSinkerConfig,
-        checker: Option<&CheckerConfig>,
     ) -> anyhow::Result<ResumerConfig> {
         let legacy_keys = ["resume_from_log", "resume_log_dir", "resume_config_file"]
             .into_iter()
@@ -1310,30 +1260,18 @@ impl TaskConfig {
                 log_dir: loader.get_with_default(RESUMER, "log_dir", runtime.log_dir.clone()),
                 config_file: loader.get_optional(RESUMER, "config_file"),
             }),
-            ResumeType::FromTarget => {
-                let target = if matches!(sinker_basic.sink_type, SinkType::Dummy) {
-                    let Some(checker) = checker else {
-                        bail!(Error::ConfigError(
-                            "config [checker] target is required when [resumer] resume_type=from_target".into()
-                        ));
-                    };
-                    Self::checker_as_basic_sinker(checker)
-                } else {
-                    sinker_basic.clone()
-                };
-                Ok(ResumerConfig::FromDB {
-                    url: target.url.clone(),
-                    connection_auth: target.connection_auth.clone(),
-                    db_type: target.db_type.clone(),
-                    table_full_name: loader.get_optional(RESUMER, "table_full_name"),
-                    max_connections: loader.get_with_default(
-                        RESUMER,
-                        MAX_CONNECTIONS,
-                        RESUMER_CONNECTION_LIMIT_DEFAULT,
-                    ),
-                    is_direct_connection: target.is_direct_connection,
-                })
-            }
+            ResumeType::FromTarget => Ok(ResumerConfig::FromDB {
+                url: sinker_basic.url.clone(),
+                connection_auth: sinker_basic.connection_auth.clone(),
+                db_type: sinker_basic.db_type.clone(),
+                table_full_name: loader.get_optional(RESUMER, "table_full_name"),
+                max_connections: loader.get_with_default(
+                    RESUMER,
+                    MAX_CONNECTIONS,
+                    RESUMER_CONNECTION_LIMIT_DEFAULT,
+                ),
+                is_direct_connection: sinker_basic.is_direct_connection,
+            }),
             ResumeType::FromDB => {
                 let is_direct_connection = if loader.contains(RESUMER, IS_DIRECT_CONNECTION) {
                     Some(loader.get_optional(RESUMER, IS_DIRECT_CONNECTION))
@@ -1473,12 +1411,18 @@ mod tests {
     use crate::runtime_trace::{TaskSummaryMode, TraceOutputFormat};
 
     use super::{
-        CheckMode, ExtractorConfig, ParallelType, SinkerConfig, TaskConfig, TaskKind, TaskType,
+        CheckMode, CheckerOutputType, ExtractorConfig, ParallelType, SinkerConfig, TaskConfig,
+        TaskKind, TaskType,
     };
 
     static NEXT_CONFIG_ID: AtomicU64 = AtomicU64::new(0);
 
-    fn cdc_inline_check_config(parallel_type: &str, extra_checker: &str) -> String {
+    fn cdc_inline_check_config(
+        parallel_type: &str,
+        extra_checker: &str,
+        extra_cdc: &str,
+        extra_output: &str,
+    ) -> String {
         format!(
             r#"[extractor]
 db_type=mysql
@@ -1492,9 +1436,15 @@ sink_type=write
 url=mysql://127.0.0.1:3307
 
 [checker]
-enable=true
 batch_size=2
 {extra_checker}
+
+[checker_cdc]
+is_enabled=true
+{extra_cdc}
+
+[checker_output]
+{extra_output}
 
 [parallelizer]
 parallel_type={parallel_type}
@@ -1527,10 +1477,13 @@ db_type=mysql
 extract_type=snapshot
 url=mysql://127.0.0.1:3306
 
-[checker]
-enable=true
+[sinker]
 db_type=mysql
+sink_type=check
 url=mysql://127.0.0.1:3307
+max_connections=3
+
+[checker]
 {extra_checker}
 
 [parallelizer]
@@ -1615,11 +1568,25 @@ parallel_type=redis
 
     #[test]
     fn checker_accepts_supported_configs() {
-        let config = load_temp_task_config(&cdc_inline_check_config("rdb_merge", ""))
-            .expect("cdc inline checker config should be valid");
+        let config = load_temp_task_config(&cdc_inline_check_config(
+            "rdb_merge",
+            "",
+            "queue_size=16",
+            "",
+        ))
+        .expect("cdc inline checker config should be valid");
         assert_eq!(
             config.task_type(),
             Some(TaskType::new(TaskKind::Cdc, Some(CheckMode::Inline)))
+        );
+        assert_eq!(
+            config
+                .checker
+                .as_ref()
+                .and_then(|checker| checker.inline_check.as_ref())
+                .expect("cdc inline config should exist")
+                .queue_size,
+            16
         );
 
         let config = load_temp_task_config(
@@ -1628,10 +1595,13 @@ db_type=mongo
 extract_type=snapshot
 url=mongodb://127.0.0.1:27017
 
-[checker]
-enable=true
+[sinker]
 db_type=mongo
+sink_type=check
 url=mongodb://127.0.0.1:27018
+
+[checker]
+batch_size=20
 
 [parallelizer]
 parallel_type=mongo
@@ -1645,22 +1615,32 @@ parallel_type=mongo
                 Some(CheckMode::Standalone)
             ))
         );
+        assert_eq!(
+            config.checker_target().expect("checker target").url,
+            "mongodb://127.0.0.1:27018"
+        );
 
-        for (config, sample_rate) in [
-            (snapshot_check_config("sample_rate=25"), 25),
-            (cdc_inline_check_config("rdb_merge", "sample_rate=10"), 10),
+        for (config, sample_percent) in [
+            (snapshot_check_config("sample_percent=25"), 25),
+            (
+                cdc_inline_check_config("rdb_merge", "sample_percent=10", "", ""),
+                10,
+            ),
         ] {
             let checker = load_temp_task_config(&config)
                 .expect("sampled checker config should be valid")
                 .checker
                 .expect("checker should exist");
-            assert_eq!(checker.sample_rate, Some(sample_rate));
+            assert_eq!(checker.sample_percent, Some(sample_percent));
         }
 
         let checker = load_temp_task_config(&cdc_inline_check_config(
             "rdb_merge",
-            r#"
-check_log_s3=true
+            "",
+            "check_log_interval_secs=12",
+            r#"output_type=s3
+check_log_file_size=10mb
+check_log_max_rows=123
 s3_bucket=ape-dts
 s3_access_key_id=ak
 s3_secret_access_key=sk
@@ -1672,28 +1652,47 @@ s3_key_prefix=check/10001
         .expect("cdc checker s3 config should be valid")
         .checker
         .expect("checker should exist");
-        assert!(checker.check_log_s3);
-        assert_eq!(checker.s3_key_prefix, "check/10001");
         assert_eq!(
-            checker.s3_config.expect("s3 config should exist").bucket,
-            "ape-dts"
+            checker
+                .inline_check
+                .as_ref()
+                .expect("cdc inline config")
+                .check_log_interval_secs,
+            12
         );
+        assert_eq!(checker.log_file_size(), "10mb");
+        assert_eq!(checker.log_max_rows(), 123);
+        match checker.output.output_type {
+            CheckerOutputType::S3 { key_prefix, config } => {
+                assert_eq!(key_prefix, "check/10001");
+                assert_eq!(config.bucket, "ape-dts");
+            }
+            _ => panic!("expected s3 checker output"),
+        }
 
-        let checker = load_temp_task_config(&snapshot_check_config(
-            r#"
-check_log_s3=true
+        let checker = load_temp_task_config(&format!(
+            r#"{}
+
+[checker_output]
+output_type=s3
 s3_bucket=ape-dts
-s3_access_key_id=ak
-s3_secret_access_key=sk
-s3_region=us-east-1
-s3_endpoint=http://127.0.0.1:9000
 s3_key_prefix=check/10001
 "#,
+            snapshot_check_config(
+                "recheck_count=4\nrecheck_interval_secs=5\nrecheck_queue_size=123\nrecheck_queue_memory_mb=64",
+            )
         ))
         .expect("standalone snapshot checker s3 config should be valid")
         .checker
         .expect("checker should exist");
-        assert!(checker.check_log_s3);
+        assert!(matches!(
+            checker.output.output_type,
+            CheckerOutputType::S3 { .. }
+        ));
+        assert_eq!(checker.recheck_count, 4);
+        assert_eq!(checker.recheck_interval_secs, 5);
+        assert_eq!(checker.recheck_queue_size, 123);
+        assert_eq!(checker.recheck_queue_memory_mb, 64);
 
         let checker = load_temp_task_config(
             r#"[extractor]
@@ -1702,48 +1701,62 @@ extract_type=struct
 url=mysql://127.0.0.1:3306
 
 [sinker]
-sink_type=dummy
+db_type=mysql
+sink_type=check
+url=mysql://127.0.0.1:3307
 
 [checker]
-enable=true
-db_type=mysql
-url=mysql://127.0.0.1:3307
-sample_rate=
+sample_percent=
 "#,
         )
-        .expect("empty sample_rate should be ignored")
+        .expect("empty sample_percent should be ignored")
         .checker
         .expect("checker should exist");
-        assert_eq!(checker.sample_rate, None);
+        assert_eq!(checker.sample_percent, None);
+
+        let config = load_temp_task_config(&basic_snapshot_config(
+            r#"[checker]
+batch_size=10
+
+[checker_output]
+output_type=logs
+check_log_dir=/tmp/ape-dts-check
+output_full_row=true
+"#,
+        ))
+        .expect("inline snapshot checker config should be valid");
+        assert_eq!(
+            config.task_type(),
+            Some(TaskType::new(TaskKind::Snapshot, Some(CheckMode::Inline)))
+        );
+        let checker = config.checker.expect("checker should exist");
+        assert_eq!(checker.log_dir(), "/tmp/ape-dts-check");
+        assert!(checker.output.output_full_row);
     }
 
     #[test]
     fn checker_rejects_invalid_configs() {
         for (config, expected_err) in [
             (
-                cdc_inline_check_config("serial", ""),
-                "config error: config [checker].enable=true with [extractor] extract_type=cdc and [sinker] sink_type=write currently supports only [parallelizer] parallel_type=rdb_merge",
+                cdc_inline_check_config("serial", "", "", ""),
+                "config error: inline cdc check currently supports only [parallelizer] parallel_type=rdb_merge",
             ),
             (
                 r#"[extractor]
 db_type=mysql
-extract_type=cdc
+extract_type=snapshot
 url=mysql://127.0.0.1:3306
-server_id=1
 
 [sinker]
 db_type=mysql
 sink_type=write
 url=mysql://127.0.0.1:3307
 
-[checker]
-batch_size=2
-
-[parallelizer]
-parallel_type=rdb_merge
+[checker_cdc]
+is_enabled=true
 "#
                 .to_string(),
-                "config error: config [checker].enable is required when [checker] section is present",
+                "config error: config [checker_cdc].is_enabled=true requires [extractor] extract_type=cdc and [sinker] sink_type=write",
             ),
             (
                 r#"[extractor]
@@ -1752,10 +1765,38 @@ extract_type=snapshot
 url=mysql://127.0.0.1:3306
 
 [checker]
-enable=false
+batch_size=2
 "#
                 .to_string(),
-                "config error: config [sinker] is required unless [checker].enable=true",
+                "config error: config [sinker] is required",
+            ),
+            (
+                r#"[extractor]
+db_type=mysql
+extract_type=snapshot
+url=mysql://127.0.0.1:3306
+
+[sinker]
+db_type=mysql
+sink_type=write
+url=mysql://127.0.0.1:3307
+
+[checker]
+enable=true
+"#
+                .to_string(),
+                "config error: config [checker].enable is no longer supported; use [sinker].sink_type=check for standalone check, [checker] for snapshot inline check, or [checker_cdc].is_enabled=true for CDC inline check",
+            ),
+            (
+                format!(
+                    r#"{}
+
+[checker_output]
+output_type=s3
+"#,
+                    snapshot_check_config("")
+                ),
+                "config error: config [checker_output].s3_bucket is required when output_type=s3",
             ),
             (
                 r#"[extractor]
@@ -1764,18 +1805,22 @@ extract_type=check_log
 url=mysql://127.0.0.1:3306
 check_log_dir=/tmp/ape-dts-check-log
 
-[checker]
-enable=true
+[sinker]
 db_type=mysql
+sink_type=check
 url=mysql://127.0.0.1:3307
-check_log_s3=true
+
+[checker]
+
+[checker_output]
+output_type=s3
 s3_bucket=ape-dts
 
 [parallelizer]
 parallel_type=rdb_merge
 "#
                 .to_string(),
-                "config error: config [checker].check_log_s3 only supports standalone snapshot check or inline cdc check",
+                "config error: config [checker_output].output_type=s3 only supports standalone snapshot check or inline cdc check",
             ),
             (
                 r#"[extractor]
@@ -1789,23 +1834,28 @@ sink_type=write
 url=mysql://127.0.0.1:3307
 
 [checker]
-enable=true
-check_log_s3=true
+
+[checker_output]
+output_type=s3
 s3_bucket=ape-dts
 
 [parallelizer]
 parallel_type=rdb_merge
 "#
                 .to_string(),
-                "config error: config [checker].check_log_s3 only supports standalone snapshot check or inline cdc check",
+                "config error: config [checker_output].output_type=s3 only supports standalone snapshot check or inline cdc check",
             ),
             (
-                snapshot_check_config("check_log_s3=true"),
-                "config error: check_log_s3=true but checker s3 config is missing in [checker]",
+                snapshot_check_config("sample_percent=0"),
+                "config error: config [checker].sample_percent must be between 1 and 100, got 0",
             ),
             (
-                snapshot_check_config("sample_rate=0"),
-                "config error: config [checker].sample_rate must be between 1 and 100, got 0",
+                snapshot_check_config("recheck_queue_size=0"),
+                "config error: config [checker].recheck_queue_size must be greater than 0",
+            ),
+            (
+                snapshot_check_config("recheck_queue_memory_mb=0"),
+                "config error: config [checker].recheck_queue_memory_mb must be greater than 0",
             ),
             (
                 r#"[extractor]
@@ -1814,16 +1864,26 @@ extract_type=struct
 url=mysql://127.0.0.1:3306
 
 [sinker]
-sink_type=dummy
+db_type=mysql
+sink_type=check
+url=mysql://127.0.0.1:3307
 
 [checker]
-enable=true
-db_type=mysql
-url=mysql://127.0.0.1:3307
-sample_rate=10
+sample_percent=10
 "#
                 .to_string(),
-                "config error: config [checker].sample_rate only supports snapshot check or inline cdc check",
+                "config error: config [checker].sample_percent only supports snapshot check or inline cdc check",
+            ),
+            (
+                format!(
+                    r#"{}
+
+[checker_output]
+output_type=db
+"#,
+                    snapshot_check_config("")
+                ),
+                "config error: config [checker_output].output_type must be logs or s3, got db",
             ),
         ] {
             assert_eq!(

--- a/dt-common/src/config/task_config.rs
+++ b/dt-common/src/config/task_config.rs
@@ -26,8 +26,8 @@ use super::{
         DEFAULT_CHECK_LOG_FILE_SIZE,
     },
     config_enums::{
-        CheckMode, ConflictPolicyEnum, DbType, ExtractType, MetaCenterType, ParallelType,
-        PipelineType, SinkType, TaskKind, TaskType,
+        CheckMode, ConflictPolicyEnum, DbType, ExtractType, MetaCenterType, ParallelType, SinkType,
+        TaskKind, TaskType,
     },
     data_marker_config::DataMarkerConfig,
     extractor_config::{BasicExtractorConfig, ExtractorConfig},
@@ -91,18 +91,6 @@ const CHECKER_CDC: &str = "checker_cdc";
 const META_CENTER: &str = "metacenter";
 const TRACING: &str = "tracing";
 // keys
-const CHECK_LOG_DIR: &str = "check_log_dir";
-const CHECK_LOG_FILE_SIZE: &str = "check_log_file_size";
-const CHECK_LOG_MAX_ROWS: &str = "check_log_max_rows";
-const OUTPUT_FULL_ROW: &str = "output_full_row";
-const OUTPUT_REVISE_SQL: &str = "output_revise_sql";
-const REVISE_MATCH_FULL_ROW: &str = "revise_match_full_row";
-const RECHECK_INTERVAL_SECS: &str = "recheck_interval_secs";
-const RECHECK_COUNT: &str = "recheck_count";
-const RECHECK_QUEUE_SIZE: &str = "recheck_queue_size";
-const RECHECK_QUEUE_MEMORY_MB: &str = "recheck_queue_memory_mb";
-const IS_ENABLED: &str = "is_enabled";
-const LEGACY_CHECKER_ENABLE: &str = "enable";
 const DB_TYPE: &str = "db_type";
 const URL: &str = "url";
 const BATCH_SIZE: &str = "batch_size";
@@ -133,6 +121,19 @@ const IS_DIRECT_CONNECTION: &str = "is_direct_connection";
 const MONGO_REQUIRE_SHARD_KEY_FILTER: &str = "mongo_require_shard_key_filter";
 const TASK_SUMMARY_MODE: &str = "task_summary_mode";
 const OUTPUT_FORMAT: &str = "output_format";
+// keys, checker
+const CHECK_LOG_DIR: &str = "check_log_dir";
+const CHECK_LOG_FILE_SIZE: &str = "check_log_file_size";
+const CHECK_LOG_MAX_ROWS: &str = "check_log_max_rows";
+const OUTPUT_FULL_ROW: &str = "output_full_row";
+const OUTPUT_REVISE_SQL: &str = "output_revise_sql";
+const REVISE_MATCH_FULL_ROW: &str = "revise_match_full_row";
+const RECHECK_INTERVAL_SECS: &str = "recheck_interval_secs";
+const RECHECK_COUNT: &str = "recheck_count";
+const RECHECK_QUEUE_SIZE: &str = "recheck_queue_size";
+const RECHECK_QUEUE_MEMORY_MB: &str = "recheck_queue_memory_mb";
+const IS_ENABLED: &str = "is_enabled";
+const LEGACY_CHECKER_ENABLE: &str = "enable";
 
 // default values
 pub const APE_DTS: &str = "APE_DTS";
@@ -153,12 +154,6 @@ impl TaskConfig {
         let checker =
             Self::load_checker_config(&loader, &extractor_basic.extract_type, &sinker_basic)?;
         if let Some(checker_cfg) = checker.as_ref() {
-            if !matches!(pipeline.pipeline_type, PipelineType::Basic) {
-                bail!(Error::ConfigError(
-                    "config [checker] only supports [pipeline] pipeline_type=basic".into(),
-                ));
-            }
-
             let task_type = if matches!(extractor_basic.extract_type, ExtractType::CheckLog)
                 && matches!(sinker_basic.sink_type, SinkType::Check)
                 && matches!(
@@ -189,9 +184,10 @@ impl TaskConfig {
                 task_type.is_cdc_inline_check() || task_type.is_standalone_snapshot_check()
             });
             if is_s3_output && !s3_supported {
-                bail!(Error::ConfigError(format!(
+                bail!(Error::ConfigError(
                     "config [checker_output].output_type=s3 only supports standalone snapshot check or inline cdc check"
-                )));
+                        .to_string()
+                ));
             }
 
             if checker_cfg.sample_percent.is_some()
@@ -992,7 +988,6 @@ impl TaskConfig {
             batch_sink_interval_secs: loader.get_optional(PIPELINE, "batch_sink_interval_secs"),
             counter_time_window_secs: loader.get_optional(PIPELINE, "counter_time_window_secs"),
             counter_max_sub_count: loader.get_with_default(PIPELINE, "counter_max_sub_count", 1000),
-            pipeline_type: loader.get_with_default(PIPELINE, "pipeline_type", PipelineType::Basic),
         };
 
         if config.counter_time_window_secs == 0 {

--- a/dt-connector/src/checker/base_checker.rs
+++ b/dt-connector/src/checker/base_checker.rs
@@ -41,6 +41,10 @@ use dt_common::{
 mod cdc_state;
 #[path = "checker_engine.rs"]
 mod checker_engine;
+#[path = "retry_buffer.rs"]
+mod retry_buffer;
+
+use retry_buffer::RetryBuffer;
 
 pub const CHECKER_MAX_QUERY_BATCH: usize = 1000;
 
@@ -192,6 +196,8 @@ pub struct CheckContext {
     pub sample_rate: Option<u8>,
     pub retry_interval_secs: u64,
     pub max_retries: u32,
+    pub retry_buffer_max_rows: usize,
+    pub retry_buffer_max_bytes: usize,
     pub is_cdc: bool,
     pub check_log_dir: String,
     pub cdc_check_log_max_file_size: u64,
@@ -220,6 +226,8 @@ impl Default for CheckContext {
             sample_rate: None,
             retry_interval_secs: 0,
             max_retries: 0,
+            retry_buffer_max_rows: 10_000,
+            retry_buffer_max_bytes: 256 * 1024 * 1024,
             is_cdc: false,
             check_log_dir: String::new(),
             cdc_check_log_max_file_size: 1,
@@ -262,20 +270,30 @@ impl CheckContext {
     }
 
     fn record_row_table_counts(&mut self, row: &RowData, checked_count: usize, skip_count: usize) {
+        self.record_table_counts(&row.schema, &row.tb, checked_count, skip_count);
+    }
+
+    fn record_table_counts(
+        &mut self,
+        target_schema: &str,
+        target_tb: &str,
+        checked_count: usize,
+        skip_count: usize,
+    ) {
         if checked_count == 0 && skip_count == 0 {
             return;
         }
         self.summary.checked_count += checked_count;
         let (schema, tb) = match &self.router {
-            Some(router) => router.reverse_get_tb_map(&row.schema, &row.tb),
-            None => (row.schema.as_str(), row.tb.as_str()),
+            Some(router) => router.reverse_get_tb_map(target_schema, target_tb),
+            None => (target_schema, target_tb),
         };
-        let has_target = row.schema != schema || row.tb != tb;
+        let has_target = target_schema != schema || target_tb != tb;
         self.summary.merge_table(CheckTableSummaryLog {
             schema: schema.to_string(),
             tb: tb.to_string(),
-            target_schema: has_target.then(|| row.schema.clone()),
-            target_tb: has_target.then(|| row.tb.clone()),
+            target_schema: has_target.then(|| target_schema.to_string()),
+            target_tb: has_target.then(|| target_tb.to_string()),
             checked_count,
             skip_count,
             ..Default::default()
@@ -359,9 +377,32 @@ pub struct DataCheckerHandle {
     join_handle: Arc<Mutex<Option<JoinHandle<anyhow::Result<()>>>>>,
 }
 
-pub enum CheckerHandle {
-    Data(DataCheckerHandle),
+#[async_trait]
+trait DirectDataChecker: Send {
+    async fn check_batch(&mut self, data: Vec<RowData>, batch: bool) -> anyhow::Result<()>;
+    async fn refresh_meta(&mut self, data: &[DdlData]) -> anyhow::Result<()>;
+    async fn handle_control_item(&mut self, item: &DtItem) -> anyhow::Result<()>;
+    async fn close(&mut self) -> anyhow::Result<()>;
+}
+
+enum DirectChecker {
+    Data(Box<dyn DirectDataChecker>),
     Struct(StructCheckerHandle),
+}
+
+struct DirectCheckerState {
+    checker: Option<DirectChecker>,
+}
+
+#[derive(Clone)]
+pub struct DirectCheckerHandle {
+    state: Arc<Mutex<DirectCheckerState>>,
+}
+
+#[derive(Clone)]
+pub enum CheckerHandle {
+    Direct(DirectCheckerHandle),
+    Async(DataCheckerHandle),
 }
 
 impl DataCheckerHandle {
@@ -382,12 +423,12 @@ impl DataCheckerHandle {
             checker,
             task_id,
             ctx,
-            CheckerIo {
+            Some(CheckerIo {
                 batch_queue: batch_queue.clone(),
                 batch_notify: batch_notify.clone(),
                 dropped_items: dropped_items.clone(),
                 control_rx,
-            },
+            }),
             name,
         );
         let join_handle = tokio::spawn(async move { check_job.run().await });
@@ -430,7 +471,7 @@ impl DataCheckerHandle {
         Ok(())
     }
 
-    pub async fn close_with_position(&mut self, position: Option<&Position>) -> anyhow::Result<()> {
+    pub async fn close_with_position(&self, position: Option<&Position>) -> anyhow::Result<()> {
         if self
             .shared
             .control_tx
@@ -504,39 +545,115 @@ impl DataCheckerHandle {
     }
 }
 
+impl DirectCheckerHandle {
+    pub fn data<C: Checker>(checker: C, task_id: String, ctx: CheckContext, name: &str) -> Self {
+        let checker = DataChecker::new(checker, task_id, ctx, None, name);
+        Self {
+            state: Arc::new(Mutex::new(DirectCheckerState {
+                checker: Some(DirectChecker::Data(Box::new(checker))),
+            })),
+        }
+    }
+
+    pub fn structure(checker: StructCheckerHandle) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(DirectCheckerState {
+                checker: Some(DirectChecker::Struct(checker)),
+            })),
+        }
+    }
+
+    pub async fn check_dml(&self, data: Vec<RowData>, batch: bool) -> anyhow::Result<()> {
+        let mut state = self.state.lock().await;
+        match state.checker.as_mut() {
+            Some(DirectChecker::Data(checker)) => checker.check_batch(data, batch).await,
+            Some(DirectChecker::Struct(_)) => Ok(()),
+            None => Ok(()),
+        }
+    }
+
+    pub async fn check_struct(&self, data: Vec<StructData>) -> anyhow::Result<()> {
+        let mut state = self.state.lock().await;
+        match state.checker.as_mut() {
+            Some(DirectChecker::Struct(checker)) => checker.check_struct(data).await,
+            Some(DirectChecker::Data(_)) | None => Ok(()),
+        }
+    }
+
+    pub async fn refresh_meta(&self, data: Vec<DdlData>) -> anyhow::Result<()> {
+        let mut state = self.state.lock().await;
+        match state.checker.as_mut() {
+            Some(DirectChecker::Data(checker)) => checker.refresh_meta(&data).await,
+            Some(DirectChecker::Struct(_)) | None => Ok(()),
+        }
+    }
+
+    pub async fn handle_control_item(&self, item: &DtItem) -> anyhow::Result<()> {
+        let mut state = self.state.lock().await;
+        match state.checker.as_mut() {
+            Some(DirectChecker::Data(checker)) => checker.handle_control_item(item).await,
+            Some(DirectChecker::Struct(_)) | None => Ok(()),
+        }
+    }
+
+    pub async fn close(&self) -> anyhow::Result<()> {
+        let mut state = self.state.lock().await;
+        let Some(checker) = state.checker.as_mut() else {
+            return Ok(());
+        };
+        match checker {
+            DirectChecker::Data(checker) => checker.close().await?,
+            DirectChecker::Struct(checker) => checker.close().await?,
+        }
+        state.checker = None;
+        Ok(())
+    }
+}
+
 impl CheckerHandle {
-    pub async fn close_with_position(&mut self, position: Option<&Position>) -> anyhow::Result<()> {
+    pub fn is_async(&self) -> bool {
+        matches!(self, Self::Async(_))
+    }
+
+    pub async fn check_dml(&self, data: Vec<RowData>, batch: bool) -> anyhow::Result<()> {
         match self {
-            Self::Data(handle) => handle.close_with_position(position).await,
-            Self::Struct(handle) => handle.close().await,
+            Self::Direct(handle) => handle.check_dml(data, batch).await,
+            Self::Async(handle) => handle.enqueue_check(data).await,
+        }
+    }
+
+    pub async fn close_with_position(&self, position: Option<&Position>) -> anyhow::Result<()> {
+        match self {
+            Self::Direct(handle) => handle.close().await,
+            Self::Async(handle) => handle.close_with_position(position).await,
         }
     }
 
     pub async fn record_checkpoint(&self, position: &Position) -> anyhow::Result<()> {
         match self {
-            Self::Data(handle) => handle.record_checkpoint(position).await,
-            Self::Struct(_) => Ok(()),
+            Self::Async(handle) => handle.record_checkpoint(position).await,
+            Self::Direct(_) => Ok(()),
         }
     }
 
     pub async fn refresh_meta(&self, data: Vec<DdlData>) -> anyhow::Result<()> {
         match self {
-            Self::Data(handle) => handle.refresh_meta(data).await,
-            Self::Struct(_) => Ok(()),
+            Self::Direct(handle) => handle.refresh_meta(data).await,
+            Self::Async(handle) => handle.refresh_meta(data).await,
         }
     }
 
     pub async fn handle_control_item(&self, item: &DtItem) -> anyhow::Result<()> {
         match self {
-            CheckerHandle::Data(handle) => handle.handle_control_item(item).await,
-            CheckerHandle::Struct(_) => Ok(()),
+            Self::Direct(handle) => handle.handle_control_item(item).await,
+            Self::Async(handle) => handle.handle_control_item(item).await,
         }
     }
 
-    pub async fn check_struct(&mut self, data: Vec<StructData>) -> anyhow::Result<()> {
+    pub async fn check_struct(&self, data: Vec<StructData>) -> anyhow::Result<()> {
         match self {
-            Self::Data(_) => Ok(()),
-            Self::Struct(handle) => handle.check_struct(data).await,
+            Self::Direct(handle) => handle.check_struct(data).await,
+            Self::Async(_) => Ok(()),
         }
     }
 }
@@ -625,12 +742,6 @@ impl CheckEntry {
     }
 }
 
-struct RetryItem {
-    row: RowData,
-    retries_left: u32,
-    next_retry_at: Instant,
-}
-
 struct BoundedLineBuffer {
     size_limit: usize,
     row_limit: Option<usize>,
@@ -698,15 +809,15 @@ struct DataChecker<C: Checker> {
     checker: C,
     task_id: String,
     ctx: CheckContext,
-    retry_queue: VecDeque<RetryItem>,
+    retry_buffer: RetryBuffer,
     retry_next_at: Option<Instant>,
     store: IndexMap<CheckerStoreKey, CheckEntry>,
     dirty_upserts: IndexSet<CheckerStoreKey>,
     dirty_deletes: IndexMap<CheckerStoreKey, String>,
-    batch_queue: Arc<StdMutex<LimitedQueue<Vec<RowData>>>>,
-    batch_notify: Arc<Notify>,
+    batch_queue: Option<Arc<StdMutex<LimitedQueue<Vec<RowData>>>>>,
+    batch_notify: Option<Arc<Notify>>,
     dropped_items: Arc<AtomicU64>,
-    control_rx: mpsc::UnboundedReceiver<CheckerControlMsg>,
+    control_rx: Option<mpsc::UnboundedReceiver<CheckerControlMsg>>,
     pending_controls: VecDeque<CheckerControlMsg>,
     name: String,
     // Tracks store changes since the last DB checkpoint and is cleared by `record_checkpoint`.
@@ -728,30 +839,34 @@ struct CheckerIo {
 }
 
 impl<C: Checker> DataChecker<C> {
-    pub fn new(
+    fn new(
         checker: C,
         task_id: String,
         mut ctx: CheckContext,
-        io: CheckerIo,
+        io: Option<CheckerIo>,
         name: &str,
     ) -> Self {
         if ctx.summary.start_time.is_empty() {
             ctx.summary.start_time = Local::now().to_rfc3339();
         }
         let persisted_identity_keys = ctx.state_store.as_ref().map(|_| BTreeSet::new());
+        let retry_buffer = RetryBuffer::new(ctx.retry_buffer_max_rows, ctx.retry_buffer_max_bytes);
         Self {
             checker,
             task_id,
             ctx,
-            retry_queue: VecDeque::new(),
+            retry_buffer,
             retry_next_at: None,
             store: IndexMap::new(),
             dirty_upserts: IndexSet::new(),
             dirty_deletes: IndexMap::new(),
-            batch_queue: io.batch_queue,
-            batch_notify: io.batch_notify,
-            dropped_items: io.dropped_items,
-            control_rx: io.control_rx,
+            batch_queue: io.as_ref().map(|io| io.batch_queue.clone()),
+            batch_notify: io.as_ref().map(|io| io.batch_notify.clone()),
+            dropped_items: io
+                .as_ref()
+                .map(|io| io.dropped_items.clone())
+                .unwrap_or_else(|| Arc::new(AtomicU64::new(0))),
+            control_rx: io.map(|io| io.control_rx),
             pending_controls: VecDeque::new(),
             name: name.to_string(),
             store_dirty: false,
@@ -777,6 +892,9 @@ impl<C: Checker> DataChecker<C> {
 
     pub async fn run(mut self) -> anyhow::Result<()> {
         log_info!("Checker [{}] started.", self.name);
+        debug_assert!(self.batch_queue.is_some());
+        debug_assert!(self.batch_notify.is_some());
+        debug_assert!(self.control_rx.is_some());
         let mut interval = tokio::time::interval(Duration::from_secs(1));
         if let Err(err) = self.init_cdc_state().await {
             log_error!(
@@ -798,7 +916,7 @@ impl<C: Checker> DataChecker<C> {
 
             tokio::select! {
                 biased;
-                msg = self.control_rx.recv() => {
+                msg = self.control_rx.as_mut().expect("worker control channel").recv() => {
                     match msg {
                         Some(msg) => {
                             self.pending_controls.push_back(msg);
@@ -807,7 +925,7 @@ impl<C: Checker> DataChecker<C> {
                         None => self.close_requested = true,
                     }
                 }
-                _ = self.batch_notify.notified() => {
+                _ = self.batch_notify.as_ref().expect("worker batch notifier").notified() => {
                     self.drain_pending_batches().await;
                 }
                 _ = interval.tick() => {
@@ -883,7 +1001,8 @@ impl<C: Checker> DataChecker<C> {
     }
 
     fn collect_pending_controls(&mut self) {
-        while let Ok(msg) = self.control_rx.try_recv() {
+        let control_rx = self.control_rx.as_mut().expect("worker control channel");
+        while let Ok(msg) = control_rx.try_recv() {
             self.pending_controls.push_back(msg);
         }
     }
@@ -894,7 +1013,12 @@ impl<C: Checker> DataChecker<C> {
             self.collect_pending_controls();
 
             let batch = {
-                let mut queue = self.batch_queue.lock().unwrap();
+                let mut queue = self
+                    .batch_queue
+                    .as_ref()
+                    .expect("worker batch queue")
+                    .lock()
+                    .unwrap();
                 queue.pop()
             };
             let Some(batch) = batch else {
@@ -905,7 +1029,7 @@ impl<C: Checker> DataChecker<C> {
                 return;
             };
 
-            if let Err(err) = self.check_batch(&batch, true).await {
+            if let Err(err) = self.check_batch(batch, true).await {
                 log_error!("Checker [{}] batch failed: {}", self.name, err);
             }
         }
@@ -973,6 +1097,28 @@ impl<C: Checker> DataChecker<C> {
     }
 }
 
+#[async_trait]
+impl<C: Checker> DirectDataChecker for DataChecker<C> {
+    async fn check_batch(&mut self, data: Vec<RowData>, batch: bool) -> anyhow::Result<()> {
+        if let Err(err) = self.process_due_retries().await {
+            log_error!("Checker [{}] retry failed: {}", self.name, err);
+        }
+        DataChecker::check_batch(self, data, batch).await
+    }
+
+    async fn refresh_meta(&mut self, data: &[DdlData]) -> anyhow::Result<()> {
+        self.checker.refresh_meta(data).await
+    }
+
+    async fn handle_control_item(&mut self, item: &DtItem) -> anyhow::Result<()> {
+        DataChecker::handle_control_item(self, item).await
+    }
+
+    async fn close(&mut self) -> anyhow::Result<()> {
+        self.shutdown().await
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -993,6 +1139,10 @@ mod tests {
 
     struct CaptureInvalidateChecker {
         invalidated: Arc<StdMutex<Vec<(String, String)>>>,
+    }
+
+    struct RetryFailureChecker {
+        loaded_ids: Arc<StdMutex<Vec<i32>>>,
     }
 
     #[async_trait]
@@ -1043,6 +1193,37 @@ mod tests {
                 .unwrap()
                 .push((schema.to_string(), tb.to_string()));
             Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl Checker for RetryFailureChecker {
+        async fn load_table_meta(
+            &mut self,
+            lookup_row: &RowData,
+        ) -> anyhow::Result<Arc<CheckerTbMeta>> {
+            let id = match lookup_row.require_after()?.get("id") {
+                Some(ColValue::Long(id)) => *id,
+                value => anyhow::bail!("unexpected id value: {value:?}"),
+            };
+            self.loaded_ids.lock().unwrap().push(id);
+            if id == 1 {
+                anyhow::bail!("simulated retry failure");
+            }
+            Ok(Arc::new(CheckerTbMeta::Mongo(RdbTbMeta {
+                schema: "s1".to_string(),
+                tb: "t1".to_string(),
+                id_cols: vec!["id".to_string()],
+                ..Default::default()
+            })))
+        }
+
+        async fn fetch_rows_by_keys(
+            &mut self,
+            _table_meta: Arc<CheckerTbMeta>,
+            _lookup_rows: &[&RowData],
+        ) -> anyhow::Result<Vec<RowData>> {
+            Ok(Vec::new())
         }
     }
 
@@ -1104,7 +1285,7 @@ mod tests {
             4,
             "unit-test",
         );
-        let mut handle = handle;
+        let handle = handle;
 
         handle.enqueue_check(vec![build_row(1)]).await.unwrap();
         timeout(Duration::from_secs(1), fetch_started_rx.recv())
@@ -1152,12 +1333,12 @@ mod tests {
                 router: Some(router),
                 ..Default::default()
             },
-            CheckerIo {
+            Some(CheckerIo {
                 batch_queue: Arc::new(StdMutex::new(LimitedQueue::new(1))),
                 batch_notify: Arc::new(Notify::new()),
                 dropped_items: Arc::new(AtomicU64::new(0)),
                 control_rx,
-            },
+            }),
             "unit-test",
         );
 
@@ -1177,5 +1358,60 @@ mod tests {
             invalidated.lock().unwrap().as_slice(),
             &[("dst_schema".to_string(), "dst_tb".to_string())]
         );
+    }
+
+    #[tokio::test]
+    async fn direct_checker_retry_failure_does_not_skip_current_batch() {
+        let loaded_ids = Arc::new(StdMutex::new(Vec::new()));
+        let mut checker = DataChecker::new(
+            RetryFailureChecker {
+                loaded_ids: loaded_ids.clone(),
+            },
+            "task-1".to_string(),
+            build_ctx(),
+            None,
+            "unit-test",
+        );
+        checker
+            .retry_buffer
+            .try_push(retry_buffer::RetryItem {
+                row: build_row(1),
+                retries_left: 1,
+                next_retry_at: Instant::now(),
+            })
+            .unwrap();
+        checker.retry_next_at = Some(Instant::now());
+
+        DirectDataChecker::check_batch(&mut checker, vec![build_row(2)], true)
+            .await
+            .unwrap();
+
+        assert_eq!(loaded_ids.lock().unwrap().as_slice(), &[1, 2]);
+    }
+
+    #[tokio::test]
+    async fn retry_query_failure_keeps_item_until_attempts_are_exhausted() {
+        let mut checker = DataChecker::new(
+            RetryFailureChecker {
+                loaded_ids: Arc::new(StdMutex::new(Vec::new())),
+            },
+            "task-1".to_string(),
+            build_ctx(),
+            None,
+            "unit-test",
+        );
+        checker
+            .retry_buffer
+            .try_push(retry_buffer::RetryItem {
+                row: build_row(1),
+                retries_left: 2,
+                next_retry_at: Instant::now(),
+            })
+            .unwrap();
+        checker.retry_next_at = Some(Instant::now());
+
+        assert!(checker.process_due_retries().await.is_err());
+        assert_eq!(checker.retry_buffer.len(), 1);
+        assert_eq!(checker.retry_buffer.iter().next().unwrap().retries_left, 1);
     }
 }

--- a/dt-connector/src/checker/cdc_state.rs
+++ b/dt-connector/src/checker/cdc_state.rs
@@ -629,12 +629,12 @@ mod tests {
                 s3_output,
                 ..Default::default()
             },
-            CheckerIo {
+            Some(CheckerIo {
                 batch_queue: Arc::new(std::sync::Mutex::new(LimitedQueue::new(1))),
                 batch_notify: Arc::new(tokio::sync::Notify::new()),
                 dropped_items: Arc::new(std::sync::atomic::AtomicU64::new(0)),
                 control_rx,
-            },
+            }),
             "unit-test",
         )
     }

--- a/dt-connector/src/checker/checker_engine.rs
+++ b/dt-connector/src/checker/checker_engine.rs
@@ -1,22 +1,23 @@
+use std::{borrow::Cow, collections::{BTreeSet, HashMap}};
+
 use anyhow::Context;
 use mongodb::bson::Document;
-use std::borrow::Cow;
-use std::collections::{BTreeSet, HashMap};
 use tokio::time::{sleep, Duration, Instant};
 
-use super::cdc_state::build_identity_key;
 use super::{
-    CheckContext, CheckEntry, CheckInconsistency, Checker, CheckerStoreKey, CheckerTbMeta,
-    DataChecker, RecheckKey, RetryItem,
+    cdc_state::build_identity_key, retry_buffer::RetryItem, CheckContext, CheckEntry,
+    CheckInconsistency, Checker, CheckerStoreKey, CheckerTbMeta, DataChecker, RecheckKey,
 };
-use crate::checker::check_log::{to_json_line, CheckLog, DiffColValue};
-use crate::sinker::mongo::mongo_cmd;
-use dt_common::meta::{
-    col_value::ColValue, mongo::mongo_constant::MongoConstants, pg::pg_value_type::PgValueType,
-    rdb_tb_meta::RdbTbMeta, row_data::RowData, row_type::RowType,
+use crate::{
+    checker::check_log::{to_json_line, CheckLog, DiffColValue},
+    sinker::mongo::mongo_cmd,
 };
 use dt_common::{
     log_diff, log_miss, log_sql, log_warn,
+    meta::{
+        col_value::ColValue, mongo::mongo_constant::MongoConstants, pg::pg_value_type::PgValueType,
+        rdb_tb_meta::RdbTbMeta, row_data::RowData, row_type::RowType,
+    },
     monitor::{
         counter_type::CounterType, task_metrics::TaskMetricsType,
         task_monitor_handle::TaskMonitorHandle,
@@ -152,29 +153,63 @@ impl<C: Checker> DataChecker<C> {
 
     async fn check_rows(
         &mut self,
-        src_data: &[(&RowData, u128)],
+        src_data: Vec<(RowData, u128)>,
         mut dst_row_data_map: HashMap<u128, RowData>,
         tb_meta: &CheckerTbMeta,
-    ) -> anyhow::Result<(usize, Vec<RowData>)> {
+    ) -> anyhow::Result<usize> {
         let mut checked_count = 0;
-        let mut retry_rows = Vec::new();
 
         for (src_row_data, key) in src_data {
-            let src_row_data = *src_row_data;
-            let key = *key;
             checked_count += 1;
             let dst_row_data = dst_row_data_map.remove(&key);
 
             if self.ctx.is_cdc || self.ctx.max_retries == 0 {
-                self.reconcile_row_inconsistency(key, src_row_data, dst_row_data.as_ref(), tb_meta)
-                    .await?;
-            } else if Self::compare_src_dst(src_row_data, dst_row_data.as_ref(), tb_meta)?.is_some()
+                self.reconcile_row_inconsistency(
+                    key,
+                    &src_row_data,
+                    dst_row_data.as_ref(),
+                    tb_meta,
+                )
+                .await?;
+            } else if Self::compare_src_dst(&src_row_data, dst_row_data.as_ref(), tb_meta)?
+                .is_some()
             {
-                retry_rows.push((*src_row_data).clone());
+                let retry_at = Instant::now() + Duration::from_secs(self.ctx.retry_interval_secs);
+                let item = RetryItem {
+                    row: src_row_data,
+                    retries_left: self.ctx.max_retries,
+                    next_retry_at: retry_at,
+                };
+                match self.retry_buffer.try_push(item) {
+                    Ok(()) => {
+                        if self.retry_next_at.is_none_or(|current| retry_at < current) {
+                            self.retry_next_at = Some(retry_at);
+                        }
+                    }
+                    Err((item, reason)) => {
+                        let overflow_count = self.retry_buffer.overflow_count();
+                        if overflow_count == 1 || overflow_count % 100 == 0 {
+                            log_warn!(
+                                "checker retry buffer is full ({:?}); finalizing current inconsistency without retry, pending rows: {}, pending bytes: {}, total overflowed rows: {}",
+                                reason,
+                                self.retry_buffer.len(),
+                                self.retry_buffer.pending_bytes(),
+                                overflow_count
+                            );
+                        }
+                        self.reconcile_row_inconsistency(
+                            key,
+                            &item.row,
+                            dst_row_data.as_ref(),
+                            tb_meta,
+                        )
+                        .await?;
+                    }
+                }
             }
         }
 
-        Ok((checked_count, retry_rows))
+        Ok(checked_count)
     }
 
     pub fn compare_src_dst(
@@ -320,18 +355,17 @@ impl<C: Checker> DataChecker<C> {
         row_key % 100 < u128::from(sample_rate)
     }
 
-    fn prepare_rows_for_fetch<'a>(
+    fn prepare_rows_for_fetch(
         &mut self,
-        rows: &[&'a RowData],
+        rows: Vec<RowData>,
         tb_meta: &CheckerTbMeta,
-    ) -> Vec<(&'a RowData, u128)> {
+    ) -> Vec<(RowData, u128)> {
         let mut prepared_rows = Vec::with_capacity(rows.len());
         for row in rows {
-            let row = *row;
-            match Self::lookup_match_key(row, tb_meta.basic()) {
+            match Self::lookup_match_key(&row, tb_meta.basic()) {
                 Ok(Some(key)) => {
                     if self.ctx.is_cdc {
-                        self.cleanup_stale_update_key(row, tb_meta.basic(), Some(key));
+                        self.cleanup_stale_update_key(&row, tb_meta.basic(), Some(key));
                     }
                     if Self::should_sample_key(self.ctx.sample_rate, key) {
                         prepared_rows.push((row, key));
@@ -339,19 +373,19 @@ impl<C: Checker> DataChecker<C> {
                 }
                 Ok(None) => {
                     if self.ctx.is_cdc {
-                        self.cleanup_stale_update_key(row, tb_meta.basic(), None);
+                        self.cleanup_stale_update_key(&row, tb_meta.basic(), None);
                     }
                     log_warn!(
                         "Skipping row with NULL key component in {}.{}.",
                         row.schema,
                         row.tb
                     );
-                    self.ctx.record_row_table_counts(row, 0, 1);
+                    self.ctx.record_row_table_counts(&row, 0, 1);
                     self.ctx.summary.skip_count += 1;
                 }
                 Err(e) => {
                     if self.ctx.is_cdc {
-                        self.cleanup_stale_update_key(row, tb_meta.basic(), None);
+                        self.cleanup_stale_update_key(&row, tb_meta.basic(), None);
                     }
                     log_warn!(
                         "Skipping unhashable row in {}.{}: {}",
@@ -359,7 +393,7 @@ impl<C: Checker> DataChecker<C> {
                         row.tb,
                         e
                     );
-                    self.ctx.record_row_table_counts(row, 0, 1);
+                    self.ctx.record_row_table_counts(&row, 0, 1);
                     self.ctx.summary.skip_count += 1;
                 }
             }
@@ -711,25 +745,8 @@ impl<C: Checker> DataChecker<C> {
         diff_col_values
     }
 
-    fn enqueue_retry_rows(&mut self, rows: Vec<RowData>) {
-        if rows.is_empty() {
-            return;
-        }
-
-        let retry_at = Instant::now() + Duration::from_secs(self.ctx.retry_interval_secs);
-        if self.retry_next_at.is_none_or(|current| retry_at < current) {
-            self.retry_next_at = Some(retry_at);
-        }
-        self.retry_queue
-            .extend(rows.into_iter().map(|row| RetryItem {
-                row,
-                retries_left: self.ctx.max_retries,
-                next_retry_at: retry_at,
-            }));
-    }
-
     pub async fn process_due_retries(&mut self) -> anyhow::Result<()> {
-        if self.retry_queue.is_empty() {
+        if self.retry_buffer.is_empty() {
             return Ok(());
         }
         let now = Instant::now();
@@ -738,9 +755,10 @@ impl<C: Checker> DataChecker<C> {
         }
 
         let mut next_retry_at: Option<Instant> = None;
-        let pending_len = self.retry_queue.len();
+        let mut first_error = None;
+        let pending_len = self.retry_buffer.len();
         for _ in 0..pending_len {
-            let Some(item) = self.retry_queue.pop_front() else {
+            let Some(mut item) = self.retry_buffer.pop_front() else {
                 break;
             };
 
@@ -749,24 +767,50 @@ impl<C: Checker> DataChecker<C> {
                     next_retry_at
                         .map_or(item.next_retry_at, |c: Instant| c.min(item.next_retry_at)),
                 );
-                self.retry_queue.push_back(item);
+                self.retry_buffer.push_existing(item);
                 continue;
             }
 
-            if let Some(rescheduled) = self.retry_check_item(item).await? {
-                next_retry_at = Some(
-                    next_retry_at.map_or(rescheduled.next_retry_at, |c: Instant| {
-                        c.min(rescheduled.next_retry_at)
-                    }),
-                );
-                self.retry_queue.push_back(rescheduled);
+            match self.retry_check_item(&mut item).await {
+                Ok(true) => {
+                    next_retry_at = Some(next_retry_at.map_or(item.next_retry_at, |current| {
+                        current.min(item.next_retry_at)
+                    }));
+                    self.retry_buffer.push_existing(item);
+                }
+                Ok(false) => {}
+                Err(err) => {
+                    if first_error.is_none() {
+                        first_error = Some(err);
+                    }
+                    if item.retries_left > 1 {
+                        item.retries_left -= 1;
+                        item.next_retry_at =
+                            Instant::now() + Duration::from_secs(self.ctx.retry_interval_secs);
+                        next_retry_at = Some(next_retry_at.map_or(item.next_retry_at, |current| {
+                            current.min(item.next_retry_at)
+                        }));
+                        self.retry_buffer.push_existing(item);
+                    } else {
+                        log_warn!(
+                            "checker retry query failed after all attempts for {}.{}; recording the row as skipped",
+                            item.row.schema,
+                            item.row.tb
+                        );
+                        self.ctx.summary.skip_count += 1;
+                        self.ctx.record_row_table_counts(&item.row, 0, 1);
+                    }
+                }
             }
         }
         self.retry_next_at = next_retry_at;
-        Ok(())
+        match first_error {
+            Some(err) => Err(err),
+            None => Ok(()),
+        }
     }
 
-    async fn retry_check_item(&mut self, mut item: RetryItem) -> anyhow::Result<Option<RetryItem>> {
+    async fn retry_check_item(&mut self, item: &mut RetryItem) -> anyhow::Result<bool> {
         let row_ref = &item.row;
         let tb_meta = self.checker.load_table_meta(row_ref).await?;
         let Some(key) = Self::lookup_match_key(&item.row, tb_meta.basic())? else {
@@ -777,7 +821,7 @@ impl<C: Checker> DataChecker<C> {
             );
             self.ctx.summary.skip_count += 1;
             self.ctx.record_row_table_counts(&item.row, 0, 1);
-            return Ok(None);
+            return Ok(false);
         };
         let dst_rows = self
             .checker
@@ -787,23 +831,23 @@ impl<C: Checker> DataChecker<C> {
 
         if item.retries_left > 1 {
             if Self::compare_src_dst(&item.row, dst_row.as_ref(), tb_meta.as_ref())?.is_none() {
-                return Ok(None);
+                return Ok(false);
             }
             item.retries_left -= 1;
             item.next_retry_at = Instant::now() + Duration::from_secs(self.ctx.retry_interval_secs);
-            return Ok(Some(item));
+            return Ok(true);
         }
 
         self.cleanup_stale_update_key(&item.row, tb_meta.basic(), Some(key));
         self.reconcile_row_inconsistency(key, &item.row, dst_row.as_ref(), tb_meta.as_ref())
             .await?;
-        Ok(None)
+        Ok(false)
     }
 
     pub async fn drain_retries(&mut self) -> anyhow::Result<()> {
-        while !self.retry_queue.is_empty() {
+        while !self.retry_buffer.is_empty() {
             let next_retry_at = self
-                .retry_queue
+                .retry_buffer
                 .iter()
                 .map(|item| item.next_retry_at)
                 .min()
@@ -812,13 +856,15 @@ impl<C: Checker> DataChecker<C> {
             if next_retry_at > now {
                 sleep(next_retry_at.duration_since(now)).await;
             }
-            self.process_due_retries().await?;
+            if let Err(err) = self.process_due_retries().await {
+                log_warn!("checker retry drain attempt failed: {}", err);
+            }
         }
         self.retry_next_at = None;
         Ok(())
     }
 
-    pub async fn check_batch(&mut self, data: &[RowData], batch: bool) -> anyhow::Result<()> {
+    pub async fn check_batch(&mut self, data: Vec<RowData>, batch: bool) -> anyhow::Result<()> {
         if data.is_empty() {
             return Ok(());
         }
@@ -826,7 +872,12 @@ impl<C: Checker> DataChecker<C> {
             return self.process_batch(data, true).await;
         }
         let batch_size = self.ctx.batch_size.max(1);
-        for chunk in data.chunks(batch_size) {
+        let mut rows = data.into_iter();
+        loop {
+            let chunk = rows.by_ref().take(batch_size).collect::<Vec<_>>();
+            if chunk.is_empty() {
+                break;
+            }
             self.process_batch(chunk, false).await?;
         }
         Ok(())
@@ -834,7 +885,7 @@ impl<C: Checker> DataChecker<C> {
 
     pub async fn process_batch(
         &mut self,
-        data: &[RowData],
+        mut data: Vec<RowData>,
         is_serial_mode: bool,
     ) -> anyhow::Result<()> {
         if data.is_empty() {
@@ -842,31 +893,32 @@ impl<C: Checker> DataChecker<C> {
         }
 
         let start_time = tokio::time::Instant::now();
-        let mut grouped: HashMap<(&str, &str), Vec<&RowData>> = HashMap::new();
+        data.sort_by(|left, right| (&left.schema, &left.tb).cmp(&(&right.schema, &right.tb)));
+        let mut grouped: Vec<Vec<RowData>> = Vec::new();
         for row in data {
-            grouped
-                .entry((row.schema.as_str(), row.tb.as_str()))
-                .or_default()
-                .push(row);
+            if let Some(group) = grouped.last_mut() {
+                let first = &group[0];
+                if first.schema == row.schema && first.tb == row.tb {
+                    group.push(row);
+                    continue;
+                }
+            }
+            grouped.push(vec![row]);
         }
 
         let mut total_checked = 0usize;
-        let mut retry_rows = Vec::new();
         let mut monitor_task_id = None;
-        let mut groups = grouped.into_iter().collect::<Vec<_>>();
-        groups.sort_by(|(a, _), (b, _)| a.cmp(b));
-        for (_, rows) in groups {
+        for rows in grouped {
             let first_row = rows.first().context("checker group is empty")?;
             let tb_meta = self.checker.load_table_meta(first_row).await?;
-            let prepared_rows = self.prepare_rows_for_fetch(&rows, tb_meta.as_ref());
+            let prepared_rows = self.prepare_rows_for_fetch(rows, tb_meta.as_ref());
             if prepared_rows.is_empty() {
                 continue;
             }
-            let rows_to_fetch = prepared_rows
-                .iter()
-                .map(|(row, _)| *row)
-                .collect::<Vec<_>>();
+            let rows_to_fetch = prepared_rows.iter().map(|(row, _)| row).collect::<Vec<_>>();
             let first_row = rows_to_fetch.first().context("checker group is empty")?;
+            let table_schema = first_row.schema.clone();
+            let table_tb = first_row.tb.clone();
             if monitor_task_id.is_none() {
                 let (schema, tb) = match &self.ctx.router {
                     Some(router) => router.reverse_get_tb_map(&first_row.schema, &first_row.tb),
@@ -887,13 +939,12 @@ impl<C: Checker> DataChecker<C> {
                 }
             }
 
-            let (checked_count, table_retry_rows) = self
-                .check_rows(&prepared_rows, dst_row_data_map, tb_meta.as_ref())
+            let checked_count = self
+                .check_rows(prepared_rows, dst_row_data_map, tb_meta.as_ref())
                 .await?;
             self.ctx
-                .record_row_table_counts(first_row, checked_count, 0);
+                .record_table_counts(&table_schema, &table_tb, checked_count, 0);
             total_checked += checked_count;
-            retry_rows.extend(table_retry_rows);
         }
         if total_checked == 0 {
             return Ok(());
@@ -902,8 +953,6 @@ impl<C: Checker> DataChecker<C> {
         let mut rts = LimitedQueue::new(1);
         let elapsed_millis = u64::try_from(start_time.elapsed().as_millis()).unwrap_or(u64::MAX);
         rts.push((elapsed_millis, 1));
-        self.enqueue_retry_rows(retry_rows);
-
         let task_id =
             monitor_task_id.unwrap_or_else(|| self.ctx.monitor.default_task_id().to_string());
         self.ctx.monitor.ensure_monitor(&task_id);
@@ -986,6 +1035,10 @@ mod tests {
         tb_meta: Arc<CheckerTbMeta>,
     }
 
+    struct MissingChecker {
+        tb_meta: Arc<CheckerTbMeta>,
+    }
+
     #[async_trait]
     impl Checker for ConsistentChecker {
         async fn load_table_meta(
@@ -1001,6 +1054,24 @@ mod tests {
             lookup_rows: &[&RowData],
         ) -> anyhow::Result<Vec<RowData>> {
             Ok(lookup_rows.iter().map(|row| (*row).clone()).collect())
+        }
+    }
+
+    #[async_trait]
+    impl Checker for MissingChecker {
+        async fn load_table_meta(
+            &mut self,
+            _lookup_row: &RowData,
+        ) -> anyhow::Result<Arc<CheckerTbMeta>> {
+            Ok(self.tb_meta.clone())
+        }
+
+        async fn fetch_rows_by_keys(
+            &mut self,
+            _table_meta: Arc<CheckerTbMeta>,
+            _lookup_rows: &[&RowData],
+        ) -> anyhow::Result<Vec<RowData>> {
+            Ok(Vec::new())
         }
     }
 
@@ -1072,12 +1143,12 @@ mod tests {
             checker,
             "unit-test".to_string(),
             ctx,
-            CheckerIo {
+            Some(CheckerIo {
                 batch_queue: Arc::new(StdMutex::new(LimitedQueue::new(1))),
                 batch_notify: Arc::new(tokio::sync::Notify::new()),
                 dropped_items: Arc::new(AtomicU64::new(0)),
                 control_rx,
-            },
+            }),
             "unit-test",
         )
     }
@@ -1157,7 +1228,7 @@ mod tests {
         );
 
         checker
-            .process_batch(&[build_insert_row(1, "not-sampled")], false)
+            .process_batch(vec![build_insert_row(1, "not-sampled")], false)
             .await
             .unwrap();
 
@@ -1172,7 +1243,7 @@ mod tests {
         );
 
         checker
-            .process_batch(&[build_null_key_row()], false)
+            .process_batch(vec![build_null_key_row()], false)
             .await
             .unwrap();
 
@@ -1189,12 +1260,43 @@ mod tests {
         checker.optional_logs_dirty = false;
 
         checker
-            .process_batch(&[build_insert_row(1, "consistent")], false)
+            .process_batch(vec![build_insert_row(1, "consistent")], false)
             .await
             .unwrap();
 
         assert_eq!(checker.ctx.summary.checked_count, 1);
         assert_eq!(checker.ctx.summary.tables[0].checked_count, 1);
         assert!(!checker.optional_logs_dirty);
+    }
+
+    #[tokio::test]
+    async fn retry_buffer_overflow_finalizes_inconsistency_without_dropping_row() {
+        let mut ctx = build_ctx(false);
+        ctx.max_retries = 1;
+        ctx.retry_interval_secs = 60;
+        ctx.retry_buffer_max_rows = 1;
+        ctx.retry_buffer_max_bytes = usize::MAX;
+        let mut checker = build_checker_with(
+            MissingChecker {
+                tb_meta: Arc::new(build_mysql_tb_meta()),
+            },
+            ctx,
+        );
+
+        checker
+            .process_batch(
+                vec![
+                    build_insert_row(1, "queued"),
+                    build_insert_row(2, "overflow"),
+                ],
+                false,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(checker.retry_buffer.len(), 1);
+        assert_eq!(checker.retry_buffer.overflow_count(), 1);
+        assert_eq!(checker.ctx.summary.checked_count, 2);
+        assert_eq!(checker.ctx.summary.miss_count, 1);
     }
 }

--- a/dt-connector/src/checker/checker_engine.rs
+++ b/dt-connector/src/checker/checker_engine.rs
@@ -1,4 +1,7 @@
-use std::{borrow::Cow, collections::{BTreeSet, HashMap}};
+use std::{
+    borrow::Cow,
+    collections::{BTreeSet, HashMap},
+};
 
 use anyhow::Context;
 use mongodb::bson::Document;

--- a/dt-connector/src/checker/mod.rs
+++ b/dt-connector/src/checker/mod.rs
@@ -7,7 +7,9 @@ pub mod pg_checker;
 pub mod state_store;
 pub mod struct_checker;
 
-pub use base_checker::{CheckContext, Checker, CheckerHandle, CheckerTbMeta, DataCheckerHandle};
+pub use base_checker::{
+    CheckContext, Checker, CheckerHandle, CheckerTbMeta, DataCheckerHandle, DirectCheckerHandle,
+};
 pub use mongo_checker::MongoChecker;
 pub use mysql_checker::MysqlChecker;
 pub use pg_checker::PgChecker;

--- a/dt-connector/src/checker/retry_buffer.rs
+++ b/dt-connector/src/checker/retry_buffer.rs
@@ -36,6 +36,10 @@ impl RetryBuffer {
         }
     }
 
+    #[allow(
+        clippy::result_large_err,
+        reason = "the rejected RetryItem must be returned without cloning or allocating"
+    )]
     pub fn try_push(&mut self, item: RetryItem) -> Result<(), (RetryItem, RetryBufferFull)> {
         if self.queue.len() >= self.max_rows {
             self.overflow_count = self.overflow_count.saturating_add(1);

--- a/dt-connector/src/checker/retry_buffer.rs
+++ b/dt-connector/src/checker/retry_buffer.rs
@@ -1,0 +1,152 @@
+use std::{collections::VecDeque, mem::size_of};
+
+use tokio::time::Instant;
+
+use dt_common::meta::row_data::RowData;
+
+#[derive(Debug)]
+pub(super) struct RetryItem {
+    pub row: RowData,
+    pub retries_left: u32,
+    pub next_retry_at: Instant,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum RetryBufferFull {
+    Rows,
+    Bytes,
+}
+
+pub(super) struct RetryBuffer {
+    queue: VecDeque<RetryItem>,
+    pending_bytes: usize,
+    max_rows: usize,
+    max_bytes: usize,
+    overflow_count: u64,
+}
+
+impl RetryBuffer {
+    pub fn new(max_rows: usize, max_bytes: usize) -> Self {
+        Self {
+            queue: VecDeque::new(),
+            pending_bytes: 0,
+            max_rows: max_rows.max(1),
+            max_bytes: max_bytes.max(1),
+            overflow_count: 0,
+        }
+    }
+
+    pub fn try_push(&mut self, item: RetryItem) -> Result<(), (RetryItem, RetryBufferFull)> {
+        if self.queue.len() >= self.max_rows {
+            self.overflow_count = self.overflow_count.saturating_add(1);
+            return Err((item, RetryBufferFull::Rows));
+        }
+
+        let item_bytes = Self::item_bytes(&item);
+        if self.pending_bytes.saturating_add(item_bytes) > self.max_bytes {
+            self.overflow_count = self.overflow_count.saturating_add(1);
+            return Err((item, RetryBufferFull::Bytes));
+        }
+
+        self.pending_bytes = self.pending_bytes.saturating_add(item_bytes);
+        self.queue.push_back(item);
+        Ok(())
+    }
+
+    pub fn push_existing(&mut self, item: RetryItem) {
+        let item_bytes = Self::item_bytes(&item);
+        debug_assert!(self.queue.len() < self.max_rows);
+        debug_assert!(self.pending_bytes.saturating_add(item_bytes) <= self.max_bytes);
+        self.pending_bytes = self.pending_bytes.saturating_add(item_bytes);
+        self.queue.push_back(item);
+    }
+
+    pub fn pop_front(&mut self) -> Option<RetryItem> {
+        let item = self.queue.pop_front()?;
+        self.pending_bytes = self.pending_bytes.saturating_sub(Self::item_bytes(&item));
+        Some(item)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.queue.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.queue.len()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &RetryItem> {
+        self.queue.iter()
+    }
+
+    pub fn pending_bytes(&self) -> usize {
+        self.pending_bytes
+    }
+
+    pub fn overflow_count(&self) -> u64 {
+        self.overflow_count
+    }
+
+    fn item_bytes(item: &RetryItem) -> usize {
+        usize::try_from(item.row.get_data_size())
+            .unwrap_or(usize::MAX)
+            .saturating_add(size_of::<RetryItem>())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use dt_common::meta::{col_value::ColValue, row_data::RowData, row_type::RowType};
+
+    use super::*;
+
+    fn row(id: i32) -> RowData {
+        RowData::new(
+            "s1".to_string(),
+            "t1".to_string(),
+            0,
+            RowType::Insert,
+            None,
+            Some(HashMap::from([("id".to_string(), ColValue::Long(id))])),
+        )
+    }
+
+    fn item(id: i32) -> RetryItem {
+        RetryItem {
+            row: row(id),
+            retries_left: 1,
+            next_retry_at: Instant::now(),
+        }
+    }
+
+    #[test]
+    fn enforces_row_limit_and_releases_capacity_after_pop() {
+        let mut buffer = RetryBuffer::new(1, usize::MAX);
+        buffer.try_push(item(1)).unwrap();
+
+        let (_, reason) = buffer.try_push(item(2)).unwrap_err();
+        assert_eq!(reason, RetryBufferFull::Rows);
+        assert_eq!(buffer.overflow_count(), 1);
+
+        let popped = buffer.pop_front().unwrap();
+        buffer.try_push(item(2)).unwrap();
+        assert_eq!(
+            popped.row.after.unwrap().get("id"),
+            Some(&ColValue::Long(1))
+        );
+    }
+
+    #[test]
+    fn enforces_byte_limit() {
+        let first = item(1);
+        let max_bytes = RetryBuffer::item_bytes(&first);
+        let mut buffer = RetryBuffer::new(2, max_bytes);
+        buffer.try_push(first).unwrap();
+
+        let (_, reason) = buffer.try_push(item(2)).unwrap_err();
+        assert_eq!(reason, RetryBufferFull::Bytes);
+        assert!(buffer.pending_bytes() <= max_bytes);
+    }
+}

--- a/dt-connector/src/lib.rs
+++ b/dt-connector/src/lib.rs
@@ -15,8 +15,8 @@ pub mod sinker;
 use async_trait::async_trait;
 use checker::check_log::CheckLog;
 use dt_common::meta::{
-    dcl_meta::dcl_data::DclData, ddl_meta::ddl_data::DdlData, dt_data::DtItem, row_data::RowData,
-    struct_meta::struct_data::StructData,
+    dcl_meta::dcl_data::DclData, ddl_meta::ddl_data::DdlData, dt_data::DtItem, position::Position,
+    row_data::RowData, struct_meta::struct_data::StructData,
 };
 #[async_trait]
 pub trait Sinker {
@@ -33,6 +33,14 @@ pub trait Sinker {
     }
 
     async fn close(&mut self) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn close_with_position(&mut self, _position: Option<&Position>) -> anyhow::Result<()> {
+        self.close().await
+    }
+
+    async fn record_checkpoint(&mut self, _position: &Position) -> anyhow::Result<()> {
         Ok(())
     }
 

--- a/dt-connector/src/sinker/busy_tracking_sinker.rs
+++ b/dt-connector/src/sinker/busy_tracking_sinker.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use dt_common::{
     meta::{
         dcl_meta::dcl_data::DclData, ddl_meta::ddl_data::DdlData, dt_data::DtItem,
-        row_data::RowData, struct_meta::struct_data::StructData,
+        position::Position, row_data::RowData, struct_meta::struct_data::StructData,
     },
     monitor::sinker_worker_metrics::SinkerWorkerRecorder,
 };
@@ -61,6 +61,14 @@ impl Sinker for BusyTrackingSinker {
 
     async fn close(&mut self) -> anyhow::Result<()> {
         self.inner.close().await
+    }
+
+    async fn close_with_position(&mut self, position: Option<&Position>) -> anyhow::Result<()> {
+        self.inner.close_with_position(position).await
+    }
+
+    async fn record_checkpoint(&mut self, position: &Position) -> anyhow::Result<()> {
+        self.inner.record_checkpoint(position).await
     }
 
     fn get_id(&self) -> String {

--- a/dt-connector/src/sinker/checkable_sinker.rs
+++ b/dt-connector/src/sinker/checkable_sinker.rs
@@ -5,7 +5,9 @@ use dt_common::meta::{
     struct_meta::struct_data::StructData,
 };
 
-use crate::{checker::DataCheckerHandle, Sinker};
+use dt_common::meta::position::Position;
+
+use crate::{checker::CheckerHandle, Sinker};
 
 macro_rules! delegate_inner {
     ($self:ident, $method:ident($($arg:expr),*)) => {
@@ -24,21 +26,27 @@ pub trait CheckableSink: Sinker {
 
 pub struct SinkerWithChecker<S> {
     inner: S,
-    checker: DataCheckerHandle,
+    checker: CheckerHandle,
+    lifecycle_owner: bool,
 }
 
 impl<S> SinkerWithChecker<S> {
-    pub fn new(inner: S, checker: DataCheckerHandle) -> Self {
-        Self { inner, checker }
+    pub fn new(inner: S, checker: CheckerHandle, lifecycle_owner: bool) -> Self {
+        Self {
+            inner,
+            checker,
+            lifecycle_owner,
+        }
     }
 }
 
 pub fn wrap_sinker_with_checker<S: CheckableSink + Send + 'static>(
     sinker: S,
-    checker: Option<DataCheckerHandle>,
+    checker: Option<CheckerHandle>,
+    lifecycle_owner: bool,
 ) -> Box<dyn Sinker + Send> {
     if let Some(checker) = checker {
-        Box::new(SinkerWithChecker::new(sinker, checker))
+        Box::new(SinkerWithChecker::new(sinker, checker, lifecycle_owner))
     } else {
         Box::new(sinker)
     }
@@ -49,14 +57,19 @@ impl<S: CheckableSink + Send> Sinker for SinkerWithChecker<S> {
     async fn sink_dml(&mut self, mut data: Vec<RowData>, batch: bool) -> anyhow::Result<()> {
         self.inner.sink_dml_borrowed(&mut data, batch).await?;
         let data = self.inner.prepare_check_data(data);
-        if let Err(err) = self.checker.enqueue_check(data).await {
-            log_warn!("checker enqueue_check failed: {}", err);
+        if let Err(err) = self.checker.check_dml(data, batch).await {
+            log_warn!("checker check_dml failed: {}", err);
         }
         Ok(())
     }
 
     async fn sink_ddl(&mut self, data: Vec<DdlData>, batch: bool) -> anyhow::Result<()> {
-        delegate_inner!(self, sink_ddl(data, batch))
+        let checker_data = data.clone();
+        self.inner.sink_ddl(data, batch).await?;
+        if let Err(err) = self.checker.refresh_meta(checker_data).await {
+            log_warn!("checker refresh_meta failed: {}", err);
+        }
+        Ok(())
     }
 
     async fn sink_dcl(&mut self, data: Vec<DclData>, batch: bool) -> anyhow::Result<()> {
@@ -65,6 +78,24 @@ impl<S: CheckableSink + Send> Sinker for SinkerWithChecker<S> {
 
     async fn close(&mut self) -> anyhow::Result<()> {
         delegate_inner!(self, close())
+    }
+
+    async fn close_with_position(&mut self, position: Option<&Position>) -> anyhow::Result<()> {
+        self.inner.close_with_position(position).await?;
+        if self.lifecycle_owner {
+            if let Err(err) = self.checker.close_with_position(position).await {
+                log_warn!("checker close failed: {}", err);
+            }
+        }
+        Ok(())
+    }
+
+    async fn record_checkpoint(&mut self, position: &Position) -> anyhow::Result<()> {
+        self.inner.record_checkpoint(position).await?;
+        if self.lifecycle_owner {
+            self.checker.record_checkpoint(position).await?;
+        }
+        Ok(())
     }
 
     async fn sink_raw(&mut self, data: Vec<DtItem>, batch: bool) -> anyhow::Result<()> {
@@ -80,7 +111,11 @@ impl<S: CheckableSink + Send> Sinker for SinkerWithChecker<S> {
     }
 
     async fn handle_control_item(&mut self, item: &DtItem) -> anyhow::Result<()> {
-        delegate_inner!(self, handle_control_item(item))
+        self.inner.handle_control_item(item).await?;
+        if self.lifecycle_owner {
+            self.checker.handle_control_item(item).await?;
+        }
+        Ok(())
     }
 
     fn get_id(&self) -> String {

--- a/dt-parallelizer/src/merge_parallelizer.rs
+++ b/dt-parallelizer/src/merge_parallelizer.rs
@@ -176,6 +176,11 @@ impl MergeParallelizer {
         sinkers: &[Arc<async_mutex::Mutex<Box<dyn Sinker + Send>>>],
         merge_type: MergeType,
     ) -> anyhow::Result<(DataSize, usize)> {
+        let active_sinkers = self.parallel_size.min(sinkers.len());
+        if active_sinkers == 0 {
+            anyhow::bail!("parallel_size and sinkers must not be empty");
+        }
+
         let mut futures = Vec::new();
         let mut data_size = DataSize::default();
         for tb_merged_data in tb_merged_data_items.iter_mut() {
@@ -194,7 +199,7 @@ impl MergeParallelizer {
 
             // make sure NO too much threads generated
             let batch_size = cmp::max(
-                data.len() / self.parallel_size,
+                data.len() / active_sinkers,
                 cmp::max(self.sinker_basic_config.batch_size, 1),
             );
 
@@ -208,7 +213,7 @@ impl MergeParallelizer {
                             Vec::new()
                         };
                         let sub_data = std::mem::replace(&mut remaining, tail);
-                        let sinker = sinkers[futures.len() % self.parallel_size].clone();
+                        let sinker = sinkers[futures.len() % active_sinkers].clone();
                         let future = tokio::spawn(async move {
                             sinker.lock().await.sink_dml(sub_data, true).await
                         });
@@ -217,7 +222,7 @@ impl MergeParallelizer {
                 }
 
                 MergeType::Unmerged => {
-                    let sinker = sinkers[futures.len() % self.parallel_size].clone();
+                    let sinker = sinkers[futures.len() % active_sinkers].clone();
                     let future =
                         tokio::spawn(async move { Self::sink_unmerged_rows(sinker, data).await });
                     futures.push(future);
@@ -225,7 +230,7 @@ impl MergeParallelizer {
             }
         }
 
-        let workers_used = futures.len().min(self.parallel_size);
+        let workers_used = futures.len().min(active_sinkers);
         for future in futures {
             future.await??;
         }
@@ -252,5 +257,53 @@ impl MergeParallelizer {
                 .await?;
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use async_mutex::Mutex;
+    use dt_common::{
+        config::sinker_config::BasicSinkerConfig,
+        meta::{row_data::RowData, row_type::RowType},
+    };
+    use dt_connector::{sinker::dummy_sinker::DummySinker, Sinker};
+
+    use super::{MergeParallelizer, MergeType, TbMergedData};
+    use crate::base_parallelizer::BaseParallelizer;
+
+    #[tokio::test]
+    async fn sink_dml_adaptive_caps_parallelism_to_available_sinkers() {
+        let mut sinker_basic_config = BasicSinkerConfig::default();
+        sinker_basic_config.batch_size = 1;
+        let mut parallelizer =
+            MergeParallelizer::for_mongo(BaseParallelizer::default(), 2, sinker_basic_config);
+        let row = || {
+            RowData::new(
+                "schema".to_string(),
+                "table".to_string(),
+                0,
+                RowType::Insert,
+                None,
+                None,
+            )
+        };
+        let mut merged_data = vec![TbMergedData {
+            delete_rows: Vec::new(),
+            insert_rows: vec![row(), row()],
+            unmerged_rows: Vec::new(),
+        }];
+        let sinkers = vec![Arc::new(Mutex::new(
+            Box::new(DummySinker {}) as Box<dyn Sinker + Send>
+        ))];
+
+        let (_, workers_used) = parallelizer
+            .sink_dml_adaptive(&mut merged_data, &sinkers, MergeType::Insert)
+            .await
+            .unwrap();
+
+        assert_eq!(workers_used, 1);
     }
 }

--- a/dt-pipeline/src/base_pipeline.rs
+++ b/dt-pipeline/src/base_pipeline.rs
@@ -29,7 +29,6 @@ use dt_common::{
     runtime_trace,
 };
 use dt_connector::{
-    checker::CheckerHandle,
     data_marker::DataMarker,
     extractor::resumer::{recorder::Recorder, utils::ResumerUtil},
     Sinker,
@@ -50,7 +49,7 @@ pub struct BasePipeline {
     pub data_marker: Option<Arc<RwLock<DataMarker>>>,
     pub lua_processor: Option<LuaProcessor>,
     pub recorder: Option<Arc<dyn Recorder + Send + Sync>>,
-    pub checker: Option<CheckerHandle>,
+    pub propagate_checkpoint_to_sinker: bool,
 }
 
 enum SinkMethod {
@@ -64,17 +63,16 @@ enum SinkMethod {
 #[async_trait]
 impl Pipeline for BasePipeline {
     async fn stop(&mut self) -> anyhow::Result<()> {
-        for sinker in self.sinkers.iter_mut() {
-            sinker.lock().await.close().await?;
-        }
         let final_position = {
             let syncer = self.syncer.lock().await;
-            Self::checker_close_position(&syncer)
+            Self::final_commit_position(&syncer)
         };
-        if let Some(checker) = &mut self.checker {
-            if let Err(err) = checker.close_with_position(final_position.as_ref()).await {
-                log_warn!("checker close failed: {}", err);
-            }
+        for sinker in self.sinkers.iter_mut() {
+            sinker
+                .lock()
+                .await
+                .close_with_position(final_position.as_ref())
+                .await?;
         }
         self.parallelizer.close().await
     }
@@ -203,7 +201,7 @@ impl Pipeline for BasePipeline {
 }
 
 impl BasePipeline {
-    fn checker_close_position(syncer: &Syncer) -> Option<Position> {
+    fn final_commit_position(syncer: &Syncer) -> Option<Position> {
         (!matches!(syncer.committed_position, Position::None))
             .then_some(syncer.committed_position.clone())
     }
@@ -240,14 +238,7 @@ impl BasePipeline {
             return Ok((DataSize::default(), None, Vec::new()));
         }
 
-        let data_size = self
-            .parallelizer
-            .sink_struct(data.clone(), &self.sinkers)
-            .await?;
-
-        if let Some(checker) = &mut self.checker {
-            checker.check_struct(data).await?;
-        }
+        let data_size = self.parallelizer.sink_struct(data, &self.sinkers).await?;
 
         Ok((data_size, None, Vec::new()))
     }
@@ -291,12 +282,6 @@ impl BasePipeline {
             // only part of sinkers will execute sink_ddl, but all sinkers should refresh metadata
             for sinker in self.sinkers.iter_mut() {
                 sinker.lock().await.refresh_meta(data.clone()).await?;
-            }
-            // cdc+check also needs refreshed table metadata after sink ddl changes the target schema
-            if let Some(checker) = &self.checker {
-                if let Err(err) = checker.refresh_meta(data.clone()).await {
-                    log_warn!("checker refresh_meta failed: {}", err);
-                }
             }
             self.monitor
                 .add_counter(
@@ -561,11 +546,6 @@ impl BasePipeline {
                 position: finish_position.clone(),
                 data_origin_node: String::new(),
             };
-            if let Some(checker) = &self.checker {
-                if let Err(err) = checker.handle_control_item(&item).await {
-                    log_warn!("checker handle_control_item failed: {}", err);
-                }
-            }
             for sinker in self.sinkers.iter_mut() {
                 sinker.lock().await.handle_control_item(&item).await?;
             }
@@ -616,10 +596,17 @@ impl BasePipeline {
             .map(|(_, position)| *position)
             .unwrap_or(last_received_position);
 
-        if !matches!(checker_position, Position::None) {
-            if let Some(checker) = &self.checker {
-                if let Err(err) = checker.record_checkpoint(checker_position).await {
-                    log_warn!("checker checkpoint failed: {}", err);
+        if self.propagate_checkpoint_to_sinker && !matches!(checker_position, Position::None) {
+            // Lifecycle-aware decorators are attached to the last sinker so their close hook
+            // runs after every regular sinker has closed.
+            if let Some(sinker) = self.sinkers.last() {
+                if let Err(err) = sinker
+                    .lock()
+                    .await
+                    .record_checkpoint(checker_position)
+                    .await
+                {
+                    log_warn!("sinker checkpoint hook failed: {}", err);
                 }
             }
         }

--- a/dt-pipeline/src/checker_pipeline.rs
+++ b/dt-pipeline/src/checker_pipeline.rs
@@ -1,4 +1,6 @@
 use async_trait::async_trait;
+
+use crate::{base_pipeline::BasePipeline, Pipeline};
 use dt_common::{
     log_warn,
     meta::{position::Position, row_data::RowData, struct_meta::struct_data::StructData},
@@ -7,8 +9,6 @@ use dt_connector::{
     checker::CheckerHandle, sinker::busy_tracking_sinker::BusyTrackingSinker, Sinker,
 };
 
-use crate::{base_pipeline::BasePipeline, Pipeline};
-
 pub struct CheckerPipeline {
     inner: BasePipeline,
 }
@@ -16,10 +16,11 @@ pub struct CheckerPipeline {
 impl CheckerPipeline {
     pub fn new(mut inner: BasePipeline, checker: CheckerHandle) -> Self {
         let metrics = inner.monitor.sinker_worker_metrics();
-        let sinker = CheckerSinker { checker };
-        let sinker = BusyTrackingSinker::new(Box::new(sinker), metrics.register_worker());
+        let check_sinker = CheckerSinker { checker };
+        let sinker_with_wrap =
+            BusyTrackingSinker::new(Box::new(check_sinker), metrics.register_worker());
         inner.sinkers = vec![std::sync::Arc::new(async_mutex::Mutex::new(
-            Box::new(sinker) as Box<dyn Sinker + Send>,
+            Box::new(sinker_with_wrap) as Box<dyn Sinker + Send>,
         ))];
         Self { inner }
     }

--- a/dt-pipeline/src/checker_pipeline.rs
+++ b/dt-pipeline/src/checker_pipeline.rs
@@ -1,0 +1,69 @@
+use async_trait::async_trait;
+use dt_common::{
+    log_warn,
+    meta::{position::Position, row_data::RowData, struct_meta::struct_data::StructData},
+};
+use dt_connector::{
+    checker::CheckerHandle, sinker::busy_tracking_sinker::BusyTrackingSinker, Sinker,
+};
+
+use crate::{base_pipeline::BasePipeline, Pipeline};
+
+pub struct CheckerPipeline {
+    inner: BasePipeline,
+}
+
+impl CheckerPipeline {
+    pub fn new(mut inner: BasePipeline, checker: CheckerHandle) -> Self {
+        let metrics = inner.monitor.sinker_worker_metrics();
+        let sinker = CheckerSinker { checker };
+        let sinker = BusyTrackingSinker::new(Box::new(sinker), metrics.register_worker());
+        inner.sinkers = vec![std::sync::Arc::new(async_mutex::Mutex::new(
+            Box::new(sinker) as Box<dyn Sinker + Send>,
+        ))];
+        Self { inner }
+    }
+}
+
+#[async_trait]
+impl Pipeline for CheckerPipeline {
+    async fn start(&mut self) -> anyhow::Result<()> {
+        self.inner.start().await
+    }
+
+    async fn stop(&mut self) -> anyhow::Result<()> {
+        self.inner.stop().await
+    }
+}
+
+struct CheckerSinker {
+    checker: CheckerHandle,
+}
+
+#[async_trait]
+impl Sinker for CheckerSinker {
+    async fn sink_dml(&mut self, data: Vec<RowData>, batch: bool) -> anyhow::Result<()> {
+        if let Err(err) = self.checker.check_dml(data, batch).await {
+            log_warn!("standalone checker check_dml failed: {}", err);
+        }
+        Ok(())
+    }
+
+    async fn sink_struct(&mut self, data: Vec<StructData>) -> anyhow::Result<()> {
+        self.checker.check_struct(data).await
+    }
+
+    async fn handle_control_item(
+        &mut self,
+        item: &dt_common::meta::dt_data::DtItem,
+    ) -> anyhow::Result<()> {
+        self.checker.handle_control_item(item).await
+    }
+
+    async fn close_with_position(&mut self, position: Option<&Position>) -> anyhow::Result<()> {
+        if let Err(err) = self.checker.close_with_position(position).await {
+            log_warn!("standalone checker close failed: {}", err);
+        }
+        Ok(())
+    }
+}

--- a/dt-pipeline/src/lib.rs
+++ b/dt-pipeline/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod base_pipeline;
+pub mod checker_pipeline;
 pub mod lua_processor;
 
 use async_trait::async_trait;

--- a/dt-task/src/extractor_util.rs
+++ b/dt-task/src/extractor_util.rs
@@ -10,7 +10,7 @@ use tokio::sync::Mutex;
 
 use dt_common::{
     config::{
-        config_enums::{CheckMode, DbType, ExtractType, TaskKind},
+        config_enums::{CheckMode, DbType, ExtractType, SinkType, TaskKind},
         extractor_config::ExtractorConfig,
         sinker_config::SinkerConfig,
         task_config::TaskConfig,
@@ -73,6 +73,10 @@ const JSON_PREFIX: &str = "json:";
 pub struct ExtractorUtil {}
 
 impl ExtractorUtil {
+    fn use_mongo_raw_document(sinker: &SinkerConfig, sink_type: &SinkType) -> bool {
+        matches!(sinker, SinkerConfig::Mongo { .. }) && matches!(sink_type, SinkType::Write)
+    }
+
     fn sample_rate(config: &TaskConfig, extractor_config: &ExtractorConfig) -> Option<u8> {
         let standalone_snapshot_check = config.task_type().is_some_and(|task_type| {
             matches!(task_type.kind, TaskKind::Snapshot)
@@ -379,7 +383,10 @@ impl ExtractorUtil {
                     extract_state,
                     recovery,
                     filter: filter.clone(),
-                    use_raw_document: matches!(config.sinker, SinkerConfig::Mongo { .. }),
+                    use_raw_document: Self::use_mongo_raw_document(
+                        &config.sinker,
+                        &config.sinker_basic.sink_type,
+                    ),
                 };
                 Box::new(extractor)
             }
@@ -781,5 +788,39 @@ impl ExtractorUtil {
             results.insert((i.db, i.tb), i.partition_col);
         }
         Ok(results)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use dt_common::config::connection_auth_config::ConnectionAuthConfig;
+
+    use super::*;
+
+    fn mongo_sinker() -> SinkerConfig {
+        SinkerConfig::Mongo {
+            url: String::new(),
+            connection_auth: ConnectionAuthConfig::default(),
+            is_direct_connection: None,
+            app_name: String::new(),
+            batch_size: 1,
+            require_shard_key_filter: false,
+        }
+    }
+
+    #[test]
+    fn mongo_standalone_check_does_not_use_raw_documents() {
+        assert!(!ExtractorUtil::use_mongo_raw_document(
+            &mongo_sinker(),
+            &SinkType::Check,
+        ));
+    }
+
+    #[test]
+    fn mongo_write_sinker_keeps_using_raw_documents() {
+        assert!(ExtractorUtil::use_mongo_raw_document(
+            &mongo_sinker(),
+            &SinkType::Write,
+        ));
     }
 }

--- a/dt-task/src/extractor_util.rs
+++ b/dt-task/src/extractor_util.rs
@@ -89,7 +89,7 @@ impl ExtractorUtil {
             config
                 .checker
                 .as_ref()
-                .and_then(|checker| checker.sample_rate)
+                .and_then(|checker| checker.sample_percent)
         } else {
             None
         }

--- a/dt-task/src/sinker_util.rs
+++ b/dt-task/src/sinker_util.rs
@@ -26,7 +26,7 @@ use dt_common::{
 use super::task_util::TaskUtil;
 use crate::{extractor_util::ExtractorUtil, task_util::ConnClient};
 use dt_connector::{
-    checker::DataCheckerHandle,
+    checker::CheckerHandle,
     data_marker::DataMarker,
     rdb_router::RdbRouter,
     sinker::{
@@ -74,10 +74,11 @@ impl SinkerUtil {
     fn push_checkable_sinker<S: CheckableSink + Send + 'static>(
         sub_sinkers: &mut Sinkers,
         sinker: S,
-        checker: &Option<DataCheckerHandle>,
+        checker: &Option<CheckerHandle>,
+        lifecycle_owner: bool,
         metrics: &Arc<SinkerWorkerMetrics>,
     ) {
-        let sinker = wrap_sinker_with_checker(sinker, checker.clone());
+        let sinker = wrap_sinker_with_checker(sinker, checker.clone(), lifecycle_owner);
         let sinker = BusyTrackingSinker::new(sinker, metrics.register_worker());
         sub_sinkers.push(Arc::new(async_mutex::Mutex::new(Box::new(sinker))));
     }
@@ -87,7 +88,7 @@ impl SinkerUtil {
         client: ConnClient,
         monitor: TaskMonitorHandle,
         data_marker: Option<Arc<RwLock<DataMarker>>>,
-        checker: Option<DataCheckerHandle>,
+        checker: Option<CheckerHandle>,
     ) -> anyhow::Result<Sinkers> {
         let log_level = &config.runtime.log_level;
         let enable_sqlx_log = TaskUtil::check_enable_sqlx_log(log_level);
@@ -98,12 +99,13 @@ impl SinkerUtil {
         let mut sub_sinkers: Sinkers = Vec::new();
         match config.sinker.clone() {
             SinkerConfig::Dummy => {
-                for _ in 0..parallel_size {
+                for index in 0..parallel_size {
                     let sinker = DummySinker {};
                     Self::push_checkable_sinker(
                         &mut sub_sinkers,
                         sinker,
                         &checker,
+                        index + 1 == parallel_size,
                         &sinker_worker_metrics,
                     );
                 }
@@ -126,7 +128,7 @@ impl SinkerUtil {
                 };
                 let meta_manager = MysqlMetaManager::new(conn_pool.clone()).await?;
 
-                for _ in 0..parallel_size {
+                for index in 0..parallel_size {
                     let sinker = MysqlSinker {
                         url: url.to_string(),
                         connection_auth: connection_auth.clone(),
@@ -142,6 +144,7 @@ impl SinkerUtil {
                         &mut sub_sinkers,
                         sinker,
                         &checker,
+                        index + 1 == parallel_size,
                         &sinker_worker_metrics,
                     );
                 }
@@ -163,7 +166,7 @@ impl SinkerUtil {
                 };
                 let meta_manager = PgMetaManager::new(conn_pool.clone()).await?;
 
-                for _ in 0..parallel_size {
+                for index in 0..parallel_size {
                     let sinker = PgSinker {
                         url: url.to_string(),
                         connection_auth: connection_auth.clone(),
@@ -179,6 +182,7 @@ impl SinkerUtil {
                         &mut sub_sinkers,
                         sinker,
                         &checker,
+                        index + 1 == parallel_size,
                         &sinker_worker_metrics,
                     );
                 }
@@ -197,7 +201,7 @@ impl SinkerUtil {
                     }
                 };
                 let is_target_mongos = is_mongos(&mongo_client).await?;
-                for _ in 0..parallel_size {
+                for index in 0..parallel_size {
                     let sinker = MongoSinker {
                         batch_size,
                         router: router.clone(),
@@ -211,6 +215,7 @@ impl SinkerUtil {
                         &mut sub_sinkers,
                         sinker,
                         &checker,
+                        index + 1 == parallel_size,
                         &sinker_worker_metrics,
                     );
                 }
@@ -601,7 +606,7 @@ mod tests {
         let mut sinkers = Sinkers::new();
 
         SinkerUtil::push_sinker(&mut sinkers, DummySinker {}, &metrics);
-        SinkerUtil::push_checkable_sinker(&mut sinkers, DummySinker {}, &None, &metrics);
+        SinkerUtil::push_checkable_sinker(&mut sinkers, DummySinker {}, &None, true, &metrics);
 
         assert_eq!(sinkers.len(), 2);
         assert_eq!(metrics.snapshot().configured, 2);

--- a/dt-task/src/task_runner.rs
+++ b/dt-task/src/task_runner.rs
@@ -26,13 +26,13 @@ use tokio_util::sync::CancellationToken;
 
 use dt_common::{
     config::{
-        checker_config::CheckerConfig,
+        checker_config::{CheckerConfig, DEFAULT_CHECK_LOG_FILE_SIZE},
         config_enums::{DbType, ExtractType, PipelineType, SinkType, TaskKind, TaskType},
         config_token_parser::{ConfigTokenParser, TokenEscapePair},
         extractor_config::ExtractorConfig,
         limiter_config::CapacityLimiterConfig,
         sinker_config::SinkerConfig,
-        task_config::{TaskConfig, DEFAULT_CHECK_LOG_FILE_SIZE},
+        task_config::TaskConfig,
     },
     error::Error,
     limiter::buffer_limiter::BufferLimiter,
@@ -54,8 +54,8 @@ use dt_connector::{
     checker::base_checker::CheckContext,
     checker::check_log::{to_json_line, CheckSummaryLog},
     checker::{
-        Checker, CheckerHandle, CheckerStateStore, DataCheckerHandle, MongoChecker, MysqlChecker,
-        PgChecker, StructCheckerHandle,
+        Checker, CheckerHandle, CheckerStateStore, DataCheckerHandle, DirectCheckerHandle,
+        MongoChecker, MysqlChecker, PgChecker, StructCheckerHandle,
     },
     data_marker::DataMarker,
     extractor::resumer::{recorder::Recorder, recovery::Recovery},
@@ -63,7 +63,10 @@ use dt_connector::{
     sinker::base_sinker::BaseSinker,
     Extractor, Sinker,
 };
-use dt_pipeline::{base_pipeline::BasePipeline, lua_processor::LuaProcessor, Pipeline};
+use dt_pipeline::{
+    base_pipeline::BasePipeline, checker_pipeline::CheckerPipeline, lua_processor::LuaProcessor,
+    Pipeline,
+};
 
 use super::{
     extractor_util::ExtractorUtil, parallelizer_util::ParallelizerUtil, sinker_util::SinkerUtil,
@@ -416,14 +419,9 @@ impl TaskRunner {
         cfg: &CheckerConfig,
         task_id: &str,
     ) -> anyhow::Result<Option<(Operator, String)>> {
-        if !cfg.check_log_s3 {
+        let Some((s3_cfg, _)) = cfg.s3_output() else {
             return Ok(None);
-        }
-        let s3_cfg = cfg.s3_config.as_ref().ok_or_else(|| {
-            Error::ConfigError(
-                "check_log_s3=true but checker s3 config is missing in [checker]".into(),
-            )
-        })?;
+        };
         Ok(Some((
             TaskUtil::create_s3_client(s3_cfg)?,
             self.check_log_s3_key_prefix(cfg, task_id),
@@ -431,18 +429,22 @@ impl TaskRunner {
     }
 
     fn check_log_dir(&self, cfg: &CheckerConfig) -> String {
-        if cfg.check_log_dir.is_empty() {
+        if cfg.log_dir().is_empty() {
             format!("{}/check", self.config.runtime.log_dir)
         } else {
-            cfg.check_log_dir.clone()
+            cfg.log_dir().to_string()
         }
     }
 
     fn check_log_s3_key_prefix(&self, checker: &CheckerConfig, task_id: &str) -> String {
-        let base = if checker.s3_key_prefix.is_empty() {
+        let configured_prefix = checker
+            .s3_output()
+            .map(|(_, key_prefix)| key_prefix)
+            .unwrap_or("");
+        let base = if configured_prefix.is_empty() {
             format!("{}/check", self.config.global.task_id)
         } else {
-            checker.s3_key_prefix.clone()
+            configured_prefix.to_string()
         };
         let base = base.trim_end_matches('/');
         if task_id.is_empty() || task_id == self.config.global.task_id {
@@ -583,17 +585,19 @@ impl TaskRunner {
             monitor_count_window,
         );
         let sinker_monitor = sinker_monitor_handle.build_monitor("sinker", &task_id);
-        let sinkers = SinkerUtil::create_sinkers(
-            &self.config,
-            sinker_client.clone(),
-            sinker_monitor_handle,
-            rw_sinker_data_marker.clone(),
-            checker.as_ref().and_then(|handle| match handle {
-                CheckerHandle::Data(handle) => Some(handle.clone()),
-                CheckerHandle::Struct(_) => None,
-            }),
-        )
-        .await?;
+        let standalone_check = matches!(self.config.sinker_basic.sink_type, SinkType::Check);
+        let sinkers = if standalone_check {
+            Vec::new()
+        } else {
+            SinkerUtil::create_sinkers(
+                &self.config,
+                sinker_client.clone(),
+                sinker_monitor_handle,
+                rw_sinker_data_marker.clone(),
+                checker.clone(),
+            )
+            .await?
+        };
 
         let pipeline_monitor_handle = TaskMonitorHandle::new(
             self.task_monitor.clone(),
@@ -842,6 +846,7 @@ impl TaskRunner {
                 let parallelizer =
                     ParallelizerUtil::create_parallelizer(&self.config, monitor.clone()).await?;
 
+                let propagate_checkpoint_to_sinker = checker.is_some();
                 let pipeline = BasePipeline {
                     buffer,
                     parallelizer,
@@ -856,9 +861,22 @@ impl TaskRunner {
                     data_marker,
                     lua_processor,
                     recorder,
-                    checker,
+                    propagate_checkpoint_to_sinker,
                 };
-                Ok(Box::new(pipeline) as Box<dyn Pipeline + Send>)
+                if matches!(self.config.sinker_basic.sink_type, SinkType::Check) {
+                    let checker = checker.ok_or_else(|| {
+                        Error::ConfigError(
+                            "standalone check requires a direct checker runtime".into(),
+                        )
+                    })?;
+                    if checker.is_async() {
+                        bail!("standalone check must not use async checker runtime");
+                    }
+                    Ok(Box::new(CheckerPipeline::new(pipeline, checker))
+                        as Box<dyn Pipeline + Send>)
+                } else {
+                    Ok(Box::new(pipeline) as Box<dyn Pipeline + Send>)
+                }
             }
         }
     }
@@ -881,8 +899,6 @@ impl TaskRunner {
             Some(cfg) => cfg,
             None => return Ok(None),
         };
-        let max_connections = cfg.max_connections.max(1);
-        let queue_size = cfg.queue_size.max(1);
         let log_level = &self.config.runtime.log_level;
         let enable_sqlx_log = TaskUtil::check_enable_sqlx_log(log_level);
         let is_cdc_task = matches!(self.config.extractor_basic.extract_type, ExtractType::Cdc)
@@ -902,35 +918,42 @@ impl TaskRunner {
         }
         let check_log_dir_base = self.check_log_dir(cfg);
         let checker_task_id = task_id.to_string();
-        let cdc_check_log_max_file_size =
-            parse_size_limit(&cfg.check_log_file_size).map_err(|e| {
-                Error::ConfigError(format!(
-                    "invalid config [checker].check_log_file_size: {}, error: {}",
-                    cfg.check_log_file_size, e
-                ))
-            })?;
-        let cdc_check_log_max_rows = if cfg.check_log_max_rows == 0 {
-            log_warn!("checker.check_log_max_rows=0 is invalid. Using 1.");
+        let cdc_check_log_max_file_size = parse_size_limit(cfg.log_file_size()).map_err(|e| {
+            Error::ConfigError(format!(
+                "invalid config [checker_output].check_log_file_size: {}, error: {}",
+                cfg.log_file_size(),
+                e
+            ))
+        })?;
+        let cdc_check_log_max_rows = if cfg.log_max_rows() == 0 {
+            log_warn!("checker_output.check_log_max_rows=0 is invalid. Using 1.");
             1
         } else {
-            cfg.check_log_max_rows
+            cfg.log_max_rows()
         };
         let (max_retries, retry_interval_secs) = if is_cdc_task {
-            if cfg.max_retries > 0 || cfg.retry_interval_secs > 0 {
+            if cfg.recheck_count > 0 || cfg.recheck_interval_secs > 0 {
                 log_warn!(
-                    "CDC+check mode does not support retries. Ignoring max_retries={} and retry_interval_secs={} from config.",
-                    cfg.max_retries,
-                    cfg.retry_interval_secs
+                    "CDC+check mode does not support retries. Ignoring recheck_count={} and recheck_interval_secs={} from config.",
+                    cfg.recheck_count,
+                    cfg.recheck_interval_secs
                 );
             }
             (0, 0)
         } else {
-            (cfg.max_retries, cfg.retry_interval_secs)
+            (cfg.recheck_count, cfg.recheck_interval_secs)
         };
         let checker_target = self
             .config
             .checker_target()
             .ok_or_else(|| Error::ConfigError("config [checker] target is missing".into()))?;
+        let max_connections = checker_target.max_connections.max(1);
+        let queue_size = cfg
+            .inline_check
+            .as_ref()
+            .map(|inline| inline.queue_size)
+            .unwrap_or(1)
+            .max(1);
         let checker_db_type = checker_target.db_type.clone();
         let checker_url = checker_target.url.clone();
         let checker_auth = checker_target.connection_auth.clone();
@@ -940,7 +963,7 @@ impl TaskRunner {
         let checker_sample_rate = if standalone_snapshot_check {
             None
         } else {
-            cfg.sample_rate
+            cfg.sample_percent
         };
 
         let is_struct_task = matches!(
@@ -970,7 +993,7 @@ impl TaskRunner {
                         None,
                         filter,
                         router,
-                        cfg.output_revise_sql,
+                        cfg.output.output_revise_sql,
                         retry_interval_secs,
                         max_retries,
                         check_summary,
@@ -993,7 +1016,7 @@ impl TaskRunner {
                         Some(conn_pool),
                         filter,
                         router,
-                        cfg.output_revise_sql,
+                        cfg.output.output_revise_sql,
                         retry_interval_secs,
                         max_retries,
                         check_summary,
@@ -1006,7 +1029,9 @@ impl TaskRunner {
                     checker_db_type
                 ),
             };
-            return Ok(Some(CheckerHandle::Struct(checker)));
+            return Ok(Some(CheckerHandle::Direct(DirectCheckerHandle::structure(
+                checker,
+            ))));
         }
 
         let s3_output = if is_cdc_task {
@@ -1029,11 +1054,13 @@ impl TaskRunner {
                     monitor.clone(),
                     self.config.pipeline.checkpoint_interval_secs,
                 ),
-                output_full_row: cfg.output_full_row,
-                output_revise_sql: cfg.output_revise_sql,
+                output_full_row: cfg.output.output_full_row,
+                output_revise_sql: cfg.output.output_revise_sql,
                 revise_match_full_row,
                 retry_interval_secs,
                 max_retries,
+                retry_buffer_max_rows: cfg.recheck_queue_size,
+                retry_buffer_max_bytes: cfg.recheck_queue_memory_mb.saturating_mul(1024 * 1024),
                 is_cdc: is_cdc_task,
                 sample_rate: checker_sample_rate,
                 summary: CheckSummaryLog::default(),
@@ -1042,7 +1069,11 @@ impl TaskRunner {
                 cdc_check_log_max_file_size,
                 cdc_check_log_max_rows,
                 s3_output: s3_output.clone(),
-                cdc_check_log_interval_secs: cfg.cdc_check_log_interval_secs,
+                cdc_check_log_interval_secs: cfg
+                    .inline_check
+                    .as_ref()
+                    .map(|inline| inline.check_log_interval_secs)
+                    .unwrap_or(30),
                 state_store: state_store.clone(),
                 source_checker,
                 expected_resume_position: expected_resume_position.clone(),
@@ -1070,19 +1101,29 @@ impl TaskRunner {
                         conn_pool.clone(),
                     )
                     .await?;
-                let checker = DataCheckerHandle::spawn(
-                    MysqlChecker::new(conn_pool, meta_manager),
-                    checker_task_id.clone(),
-                    build_check_context(
-                        extractor_meta_manager,
-                        router,
-                        source_checker,
-                        cfg.revise_match_full_row,
-                    ),
-                    queue_size,
-                    "MysqlChecker",
+                let checker = MysqlChecker::new(conn_pool, meta_manager);
+                let ctx = build_check_context(
+                    extractor_meta_manager,
+                    router,
+                    source_checker,
+                    cfg.output.revise_match_full_row,
                 );
-                Ok(Some(CheckerHandle::Data(checker)))
+                if is_cdc_task {
+                    Ok(Some(CheckerHandle::Async(DataCheckerHandle::spawn(
+                        checker,
+                        checker_task_id.clone(),
+                        ctx,
+                        queue_size,
+                        "MysqlChecker",
+                    ))))
+                } else {
+                    Ok(Some(CheckerHandle::Direct(DirectCheckerHandle::data(
+                        checker,
+                        checker_task_id.clone(),
+                        ctx,
+                        "MysqlChecker",
+                    ))))
+                }
             }
             DbType::Pg => {
                 let router = RdbRouter::from_config(&self.config.router, &DbType::Pg)?;
@@ -1102,19 +1143,29 @@ impl TaskRunner {
                 let meta_manager =
                     dt_common::meta::pg::pg_meta_manager::PgMetaManager::new(conn_pool.clone())
                         .await?;
-                let checker = DataCheckerHandle::spawn(
-                    PgChecker::new(conn_pool, meta_manager),
-                    checker_task_id.clone(),
-                    build_check_context(
-                        extractor_meta_manager,
-                        router,
-                        source_checker,
-                        cfg.revise_match_full_row,
-                    ),
-                    queue_size,
-                    "PgChecker",
+                let checker = PgChecker::new(conn_pool, meta_manager);
+                let ctx = build_check_context(
+                    extractor_meta_manager,
+                    router,
+                    source_checker,
+                    cfg.output.revise_match_full_row,
                 );
-                Ok(Some(CheckerHandle::Data(checker)))
+                if is_cdc_task {
+                    Ok(Some(CheckerHandle::Async(DataCheckerHandle::spawn(
+                        checker,
+                        checker_task_id.clone(),
+                        ctx,
+                        queue_size,
+                        "PgChecker",
+                    ))))
+                } else {
+                    Ok(Some(CheckerHandle::Direct(DirectCheckerHandle::data(
+                        checker,
+                        checker_task_id.clone(),
+                        ctx,
+                        "PgChecker",
+                    ))))
+                }
             }
             DbType::Mongo => {
                 let router = RdbRouter::from_config(&self.config.router, &DbType::Mongo)?;
@@ -1129,14 +1180,24 @@ impl TaskRunner {
                     Some(max_connections),
                 )
                 .await?;
-                let checker = DataCheckerHandle::spawn(
-                    MongoChecker::new(mongo_client),
-                    checker_task_id.clone(),
-                    build_check_context(None, router, source_checker, false),
-                    queue_size,
-                    "MongoChecker",
-                );
-                Ok(Some(CheckerHandle::Data(checker)))
+                let checker = MongoChecker::new(mongo_client);
+                let ctx = build_check_context(None, router, source_checker, false);
+                if is_cdc_task {
+                    Ok(Some(CheckerHandle::Async(DataCheckerHandle::spawn(
+                        checker,
+                        checker_task_id.clone(),
+                        ctx,
+                        queue_size,
+                        "MongoChecker",
+                    ))))
+                } else {
+                    Ok(Some(CheckerHandle::Direct(DirectCheckerHandle::data(
+                        checker,
+                        checker_task_id.clone(),
+                        ctx,
+                        "MongoChecker",
+                    ))))
+                }
             }
             _ => bail!("checker not supported for db_type: {}", checker_db_type),
         }
@@ -1219,8 +1280,8 @@ impl TaskRunner {
 
             _ => {
                 if let Some(cfg) = self.config.checker.as_ref() {
-                    let check_log_dir = &cfg.check_log_dir;
-                    let check_log_file_size = &cfg.check_log_file_size;
+                    let check_log_dir = cfg.log_dir();
+                    let check_log_file_size = cfg.log_file_size();
                     if !check_log_dir.is_empty() {
                         config_str = config_str.replace(CHECK_LOG_DIR_PLACEHOLDER, check_log_dir);
                     }

--- a/dt-task/src/task_runner.rs
+++ b/dt-task/src/task_runner.rs
@@ -4,17 +4,15 @@ use std::{
     path::{Component, Path},
     sync::{
         atomic::{AtomicBool, Ordering},
-        Arc,
+        Arc, Mutex as StdMutex,
     },
 };
 
-use crate::task_util::{ConnClient, TaskUtil};
 use anyhow::{bail, Context};
 use async_mutex::Mutex as AsyncMutex;
 use chrono::Local;
 use log4rs::config::{Config, Deserializers, RawConfig};
 use opendal::Operator;
-use std::sync::Mutex as StdMutex;
 use tokio::{
     fs::{self as tokio_fs, metadata, File},
     io::AsyncReadExt,
@@ -27,7 +25,7 @@ use tokio_util::sync::CancellationToken;
 use dt_common::{
     config::{
         checker_config::{CheckerConfig, DEFAULT_CHECK_LOG_FILE_SIZE},
-        config_enums::{DbType, ExtractType, PipelineType, SinkType, TaskKind, TaskType},
+        config_enums::{DbType, ExtractType, SinkType, TaskKind, TaskType},
         config_token_parser::{ConfigTokenParser, TokenEscapePair},
         extractor_config::ExtractorConfig,
         limiter_config::CapacityLimiterConfig,
@@ -71,6 +69,7 @@ use dt_pipeline::{
 use super::{
     extractor_util::ExtractorUtil, parallelizer_util::ParallelizerUtil, sinker_util::SinkerUtil,
 };
+use crate::task_util::{ConnClient, TaskUtil};
 
 #[cfg(feature = "metrics")]
 use dt_common::monitor::prometheus_metrics::PrometheusMetrics;
@@ -833,51 +832,44 @@ impl TaskRunner {
         recorder: Option<Arc<dyn Recorder + Send + Sync>>,
         checker: Option<CheckerHandle>,
     ) -> anyhow::Result<Box<dyn Pipeline + Send>> {
-        match self.config.pipeline.pipeline_type {
-            PipelineType::Basic => {
-                let lua_processor =
-                    self.config
-                        .processor
-                        .as_ref()
-                        .map(|processor_config| LuaProcessor {
-                            lua_code: processor_config.lua_code.clone(),
-                        });
+        let lua_processor = self
+            .config
+            .processor
+            .as_ref()
+            .map(|processor_config| LuaProcessor {
+                lua_code: processor_config.lua_code.clone(),
+            });
 
-                let parallelizer =
-                    ParallelizerUtil::create_parallelizer(&self.config, monitor.clone()).await?;
+        let parallelizer =
+            ParallelizerUtil::create_parallelizer(&self.config, monitor.clone()).await?;
 
-                let propagate_checkpoint_to_sinker = checker.is_some();
-                let pipeline = BasePipeline {
-                    buffer,
-                    parallelizer,
-                    sinker_config: self.config.sinker.clone(),
-                    sinkers,
-                    shut_down,
-                    checkpoint_interval_secs: self.config.pipeline.checkpoint_interval_secs,
-                    batch_sink_interval_secs: self.config.pipeline.batch_sink_interval_secs,
-                    syncer,
-                    monitor,
-                    pending_snapshot_finished: HashMap::new(),
-                    data_marker,
-                    lua_processor,
-                    recorder,
-                    propagate_checkpoint_to_sinker,
-                };
-                if matches!(self.config.sinker_basic.sink_type, SinkType::Check) {
-                    let checker = checker.ok_or_else(|| {
-                        Error::ConfigError(
-                            "standalone check requires a direct checker runtime".into(),
-                        )
-                    })?;
-                    if checker.is_async() {
-                        bail!("standalone check must not use async checker runtime");
-                    }
-                    Ok(Box::new(CheckerPipeline::new(pipeline, checker))
-                        as Box<dyn Pipeline + Send>)
-                } else {
-                    Ok(Box::new(pipeline) as Box<dyn Pipeline + Send>)
-                }
+        let propagate_checkpoint_to_sinker = checker.is_some();
+        let pipeline = BasePipeline {
+            buffer,
+            parallelizer,
+            sinker_config: self.config.sinker.clone(),
+            sinkers,
+            shut_down,
+            checkpoint_interval_secs: self.config.pipeline.checkpoint_interval_secs,
+            batch_sink_interval_secs: self.config.pipeline.batch_sink_interval_secs,
+            syncer,
+            monitor,
+            pending_snapshot_finished: HashMap::new(),
+            data_marker,
+            lua_processor,
+            recorder,
+            propagate_checkpoint_to_sinker,
+        };
+        if matches!(self.config.sinker_basic.sink_type, SinkType::Check) {
+            let checker = checker.ok_or_else(|| {
+                Error::ConfigError("standalone check requires a direct checker runtime".into())
+            })?;
+            if checker.is_async() {
+                bail!("standalone check must not use async checker runtime");
             }
+            Ok(Box::new(CheckerPipeline::new(pipeline, checker)) as Box<dyn Pipeline + Send>)
+        } else {
+            Ok(Box::new(pipeline) as Box<dyn Pipeline + Send>)
         }
     }
 
@@ -891,10 +883,6 @@ impl TaskRunner {
         recovery: Option<&Arc<dyn Recovery + Send + Sync>>,
         checker_state_store: Option<Arc<CheckerStateStore>>,
     ) -> anyhow::Result<Option<CheckerHandle>> {
-        if !matches!(self.config.pipeline.pipeline_type, PipelineType::Basic) {
-            return Ok(None);
-        }
-
         let cfg = match checker_config {
             Some(cfg) => cfg,
             None => return Ok(None),

--- a/dt-task/src/task_util.rs
+++ b/dt-task/src/task_util.rs
@@ -12,7 +12,7 @@ use sqlx::{
 
 use dt_common::{
     config::{
-        config_enums::{DbType, RdbTransactionIsolation, TaskKind, TaskType},
+        config_enums::{DbType, RdbTransactionIsolation, SinkType, TaskKind, TaskType},
         connection_auth_config::ConnectionAuthConfig,
         extractor_config::ExtractorConfig,
         global_config::GlobalConfig,
@@ -932,98 +932,102 @@ impl ConnClient {
             ),
             _ => ConnClient::None,
         };
-        let sinker_client = match &task_config.sinker {
-            SinkerConfig::Mysql {
-                url,
-                connection_auth,
-                disable_foreign_key_checks,
-                transaction_isolation,
-                ..
-            } => {
-                let conn_settings = TaskUtil::build_mysql_conn_settings(
-                    *disable_foreign_key_checks,
+        let sinker_client = if matches!(task_config.sinker_basic.sink_type, SinkType::Check) {
+            ConnClient::None
+        } else {
+            match &task_config.sinker {
+                SinkerConfig::Mysql {
+                    url,
+                    connection_auth,
+                    disable_foreign_key_checks,
                     transaction_isolation,
-                );
-                ConnClient::MySQL(
+                    ..
+                } => {
+                    let conn_settings = TaskUtil::build_mysql_conn_settings(
+                        *disable_foreign_key_checks,
+                        transaction_isolation,
+                    );
+                    ConnClient::MySQL(
+                        TaskUtil::create_mysql_conn_pool(
+                            url,
+                            &DbType::Mysql,
+                            connection_auth,
+                            sinker_max_connections,
+                            enable_sqlx_log,
+                            conn_settings,
+                        )
+                        .await?,
+                    )
+                }
+                SinkerConfig::MysqlStruct {
+                    url,
+                    connection_auth,
+                    ..
+                } => ConnClient::MySQL(
                     TaskUtil::create_mysql_conn_pool(
                         url,
                         &DbType::Mysql,
                         connection_auth,
                         sinker_max_connections,
                         enable_sqlx_log,
-                        conn_settings,
+                        None,
                     )
                     .await?,
-                )
+                ),
+                SinkerConfig::Pg {
+                    url,
+                    connection_auth,
+                    disable_foreign_key_checks,
+                    ..
+                } => ConnClient::PostgreSQL(
+                    TaskUtil::create_pg_conn_pool(
+                        url,
+                        connection_auth,
+                        sinker_max_connections,
+                        enable_sqlx_log,
+                        *disable_foreign_key_checks,
+                    )
+                    .await?,
+                ),
+                SinkerConfig::PgStruct {
+                    url,
+                    connection_auth,
+                    ..
+                } => ConnClient::PostgreSQL(
+                    TaskUtil::create_pg_conn_pool(
+                        url,
+                        connection_auth,
+                        sinker_max_connections,
+                        enable_sqlx_log,
+                        false,
+                    )
+                    .await?,
+                ),
+                SinkerConfig::Mongo {
+                    url,
+                    connection_auth,
+                    is_direct_connection,
+                    app_name,
+                    ..
+                }
+                | SinkerConfig::MongoStruct {
+                    url,
+                    connection_auth,
+                    is_direct_connection,
+                    app_name,
+                    ..
+                } => ConnClient::MongoDB(
+                    TaskUtil::create_mongo_client(
+                        url,
+                        connection_auth,
+                        *is_direct_connection,
+                        Some(app_name.to_string()),
+                        Some(sinker_max_connections),
+                    )
+                    .await?,
+                ),
+                _ => ConnClient::None,
             }
-            SinkerConfig::MysqlStruct {
-                url,
-                connection_auth,
-                ..
-            } => ConnClient::MySQL(
-                TaskUtil::create_mysql_conn_pool(
-                    url,
-                    &DbType::Mysql,
-                    connection_auth,
-                    sinker_max_connections,
-                    enable_sqlx_log,
-                    None,
-                )
-                .await?,
-            ),
-            SinkerConfig::Pg {
-                url,
-                connection_auth,
-                disable_foreign_key_checks,
-                ..
-            } => ConnClient::PostgreSQL(
-                TaskUtil::create_pg_conn_pool(
-                    url,
-                    connection_auth,
-                    sinker_max_connections,
-                    enable_sqlx_log,
-                    *disable_foreign_key_checks,
-                )
-                .await?,
-            ),
-            SinkerConfig::PgStruct {
-                url,
-                connection_auth,
-                ..
-            } => ConnClient::PostgreSQL(
-                TaskUtil::create_pg_conn_pool(
-                    url,
-                    connection_auth,
-                    sinker_max_connections,
-                    enable_sqlx_log,
-                    false,
-                )
-                .await?,
-            ),
-            SinkerConfig::Mongo {
-                url,
-                connection_auth,
-                is_direct_connection,
-                app_name,
-                ..
-            }
-            | SinkerConfig::MongoStruct {
-                url,
-                connection_auth,
-                is_direct_connection,
-                app_name,
-                ..
-            } => ConnClient::MongoDB(
-                TaskUtil::create_mongo_client(
-                    url,
-                    connection_auth,
-                    *is_direct_connection,
-                    Some(app_name.to_string()),
-                    Some(sinker_max_connections),
-                )
-                .await?,
-            ),
-            _ => ConnClient::None,
         };
         Ok((extractor_client, sinker_client))
     }

--- a/dt-tests/tests/mongo_to_mongo/check/basic_test/task_config.ini
+++ b/dt-tests/tests/mongo_to_mongo/check/basic_test/task_config.ini
@@ -3,12 +3,14 @@ db_type=mongo
 extract_type=snapshot
 url={mongo_extractor_url}
 
-[checker]
-enable=true
+[sinker]
 db_type=mongo
+sink_type=check
 url={mongo_sinker_without_auth_url}
 username={mongo_sinker_username}
 password={mongo_sinker_password}
+
+[checker]
 batch_size=2
 
 [filter]

--- a/dt-tests/tests/mongo_to_mongo/check/output_full_row_test/task_config.ini
+++ b/dt-tests/tests/mongo_to_mongo/check/output_full_row_test/task_config.ini
@@ -3,13 +3,18 @@ db_type=mongo
 extract_type=snapshot
 url={mongo_extractor_url}
 
-[checker]
-enable=true
+[sinker]
 db_type=mongo
+sink_type=check
 url={mongo_sinker_without_auth_url}
 username={mongo_sinker_username}
 password={mongo_sinker_password}
+
+[checker]
 batch_size=2
+
+[checker_output]
+output_type=logs
 output_full_row=true
 
 [filter]

--- a/dt-tests/tests/mongo_to_mongo/check/output_revise_sql_test/task_config.ini
+++ b/dt-tests/tests/mongo_to_mongo/check/output_revise_sql_test/task_config.ini
@@ -3,13 +3,18 @@ db_type=mongo
 extract_type=snapshot
 url={mongo_extractor_url}
 
-[checker]
-enable=true
+[sinker]
 db_type=mongo
+sink_type=check
 url={mongo_sinker_without_auth_url}
 username={mongo_sinker_username}
 password={mongo_sinker_password}
+
+[checker]
 batch_size=2
+
+[checker_output]
+output_type=logs
 output_full_row=false
 output_revise_sql=true
 

--- a/dt-tests/tests/mongo_to_mongo/check/recheck_basic/task_config.ini
+++ b/dt-tests/tests/mongo_to_mongo/check/recheck_basic/task_config.ini
@@ -4,14 +4,16 @@ extract_type=snapshot
 url={mongo_extractor_url}
 app_name=APE_DTS
 
-[checker]
-enable=true
+[sinker]
 db_type=mongo
+sink_type=check
 url={mongo_sinker_without_auth_url}
 username={mongo_sinker_username}
 password={mongo_sinker_password}
-retry_interval_secs=7
-max_retries=2
+
+[checker]
+recheck_interval_secs=7
+recheck_count=2
 batch_size=10
 
 [filter]

--- a/dt-tests/tests/mongo_to_mongo/check/recheck_recover/task_config.ini
+++ b/dt-tests/tests/mongo_to_mongo/check/recheck_recover/task_config.ini
@@ -4,14 +4,16 @@ extract_type=snapshot
 url={mongo_extractor_url}
 app_name=APE_DTS
 
-[checker]
-enable=true
+[sinker]
 db_type=mongo
+sink_type=check
 url={mongo_sinker_without_auth_url}
 username={mongo_sinker_username}
 password={mongo_sinker_password}
-retry_interval_secs=5
-max_retries=4
+
+[checker]
+recheck_interval_secs=5
+recheck_count=4
 batch_size=10
 
 [filter]

--- a/dt-tests/tests/mongo_to_mongo/check/route_test/task_config.ini
+++ b/dt-tests/tests/mongo_to_mongo/check/route_test/task_config.ini
@@ -3,12 +3,14 @@ db_type=mongo
 extract_type=snapshot
 url={mongo_extractor_url}
 
-[checker]
-enable=true
+[sinker]
 db_type=mongo
+sink_type=check
 url={mongo_sinker_without_auth_url}
 username={mongo_sinker_username}
 password={mongo_sinker_password}
+
+[checker]
 batch_size=2
 
 [filter]

--- a/dt-tests/tests/mongo_to_mongo/check/sample_test/task_config.ini
+++ b/dt-tests/tests/mongo_to_mongo/check/sample_test/task_config.ini
@@ -3,14 +3,16 @@ db_type=mongo
 extract_type=snapshot
 url={mongo_extractor_url}
 
-[checker]
-enable=true
+[sinker]
 db_type=mongo
+sink_type=check
 url={mongo_sinker_without_auth_url}
 username={mongo_sinker_username}
 password={mongo_sinker_password}
+
+[checker]
 batch_size=2
-sample_rate=50
+sample_percent=50
 
 [filter]
 do_dbs=

--- a/dt-tests/tests/mongo_to_mongo/check/snapshot_inline_basic_test/task_config.ini
+++ b/dt-tests/tests/mongo_to_mongo/check/snapshot_inline_basic_test/task_config.ini
@@ -14,7 +14,6 @@ password={mongo_sinker_password}
 batch_size=2
 
 [checker]
-enable=true
 batch_size=2
 
 [filter]

--- a/dt-tests/tests/mongo_to_mongo/review/basic_test/task_config.ini
+++ b/dt-tests/tests/mongo_to_mongo/review/basic_test/task_config.ini
@@ -5,14 +5,16 @@ url={mongo_extractor_url}
 check_log_dir=./dt-tests/tests/mongo_to_mongo/review/basic_test/check_log
 batch_size=200
 
-[checker]
-enable=true
+[sinker]
 db_type=mongo
+sink_type=check
 url={mongo_sinker_without_auth_url}
 username={mongo_sinker_username}
 password={mongo_sinker_password}
 
+[checker]
 batch_size=2
+
 [filter]
 do_dbs=
 ignore_dbs=

--- a/dt-tests/tests/mongo_to_mongo/review/route_test/task_config.ini
+++ b/dt-tests/tests/mongo_to_mongo/review/route_test/task_config.ini
@@ -5,14 +5,16 @@ url={mongo_extractor_url}
 check_log_dir=./dt-tests/tests/mongo_to_mongo/review/route_test/check_log
 batch_size=200
 
-[checker]
-enable=true
+[sinker]
 db_type=mongo
+sink_type=check
 url={mongo_sinker_without_auth_url}
 username={mongo_sinker_username}
 password={mongo_sinker_password}
 
+[checker]
 batch_size=2
+
 [filter]
 do_dbs=
 ignore_dbs=

--- a/dt-tests/tests/mongo_to_mongo/snapshot/utf8_error_test/task_config.ini
+++ b/dt-tests/tests/mongo_to_mongo/snapshot/utf8_error_test/task_config.ini
@@ -15,7 +15,6 @@ password={mongo_sinker_password}
 batch_size=2
 
 [checker]
-enable=true
 batch_size=2
 
 [filter]

--- a/dt-tests/tests/mysql_to_mysql/check/all_cols_pk_test/task_config.ini
+++ b/dt-tests/tests/mysql_to_mysql/check/all_cols_pk_test/task_config.ini
@@ -3,10 +3,12 @@ db_type=mysql
 extract_type=snapshot
 url={mysql_extractor_url}
 
-[checker]
-enable=true
+[sinker]
 db_type=mysql
+sink_type=check
 url={mysql_sinker_url}
+
+[checker]
 batch_size=2
 
 [filter]

--- a/dt-tests/tests/mysql_to_mysql/check/basic_struct_test/task_config.ini
+++ b/dt-tests/tests/mysql_to_mysql/check/basic_struct_test/task_config.ini
@@ -3,11 +3,16 @@ db_type=mysql
 extract_type=struct
 url={mysql_extractor_url}
 
-[checker]
-enable=true
+[sinker]
 db_type=mysql
+sink_type=check
 url={mysql_sinker_url}
+
+[checker]
 batch_size=2
+
+[checker_output]
+output_type=logs
 output_revise_sql=true
 
 [filter]

--- a/dt-tests/tests/mysql_to_mysql/check/basic_test/task_config.ini
+++ b/dt-tests/tests/mysql_to_mysql/check/basic_test/task_config.ini
@@ -3,10 +3,12 @@ db_type=mysql
 extract_type=snapshot
 url={mysql_extractor_url}
 
-[checker]
-enable=true
+[sinker]
 db_type=mysql
+sink_type=check
 url={mysql_sinker_url}
+
+[checker]
 batch_size=2
 
 [filter]

--- a/dt-tests/tests/mysql_to_mysql/check/cdc_check_basic_test/task_config.ini
+++ b/dt-tests/tests/mysql_to_mysql/check/cdc_check_basic_test/task_config.ini
@@ -27,8 +27,10 @@ password={mysql_sinker_password}
 replace=true
 
 [checker]
-enable=true
 batch_size=2
+
+[checker_cdc]
+is_enabled=true
 
 [resumer]
 resume_type=from_target

--- a/dt-tests/tests/mysql_to_mysql/check/cdc_check_large_data_test/task_config.ini
+++ b/dt-tests/tests/mysql_to_mysql/check/cdc_check_large_data_test/task_config.ini
@@ -27,8 +27,10 @@ password={mysql_sinker_password}
 replace=true
 
 [checker]
-enable=true
 batch_size=100
+
+[checker_cdc]
+is_enabled=true
 
 [resumer]
 resume_type=from_target

--- a/dt-tests/tests/mysql_to_mysql/check/cdc_check_resume_test/task_config.ini
+++ b/dt-tests/tests/mysql_to_mysql/check/cdc_check_resume_test/task_config.ini
@@ -27,8 +27,10 @@ password={mysql_sinker_password}
 replace=true
 
 [checker]
-enable=true
 batch_size=2
+
+[checker_cdc]
+is_enabled=true
 
 [resumer]
 resume_type=from_target

--- a/dt-tests/tests/mysql_to_mysql/check/cdc_check_update_delete_test/task_config.ini
+++ b/dt-tests/tests/mysql_to_mysql/check/cdc_check_update_delete_test/task_config.ini
@@ -27,8 +27,10 @@ password={mysql_sinker_password}
 replace=true
 
 [checker]
-enable=true
 batch_size=2
+
+[checker_cdc]
+is_enabled=true
 
 [resumer]
 resume_type=from_target

--- a/dt-tests/tests/mysql_to_mysql/check/cdc_checker_state_resume_test/task_config.ini
+++ b/dt-tests/tests/mysql_to_mysql/check/cdc_checker_state_resume_test/task_config.ini
@@ -27,8 +27,10 @@ password={mysql_sinker_password}
 replace=true
 
 [checker]
-enable=true
 batch_size=2
+
+[checker_cdc]
+is_enabled=true
 
 [resumer]
 resume_type=from_target

--- a/dt-tests/tests/mysql_to_mysql/check/cdc_position_resume_test/task_config.ini
+++ b/dt-tests/tests/mysql_to_mysql/check/cdc_position_resume_test/task_config.ini
@@ -27,8 +27,10 @@ password={mysql_sinker_password}
 replace=true
 
 [checker]
-enable=true
 batch_size=2
+
+[checker_cdc]
+is_enabled=true
 
 [resumer]
 resume_type=from_target

--- a/dt-tests/tests/mysql_to_mysql/check/log_size_limit_test/task_config.ini
+++ b/dt-tests/tests/mysql_to_mysql/check/log_size_limit_test/task_config.ini
@@ -3,11 +3,16 @@ db_type=mysql
 extract_type=snapshot
 url={mysql_extractor_url}
 
-[checker]
-enable=true
+[sinker]
 db_type=mysql
+sink_type=check
 url={mysql_sinker_url}
+
+[checker]
 batch_size=2
+
+[checker_output]
+output_type=logs
 check_log_file_size=100b
 
 [filter]

--- a/dt-tests/tests/mysql_to_mysql/check/output_full_row_test/task_config.ini
+++ b/dt-tests/tests/mysql_to_mysql/check/output_full_row_test/task_config.ini
@@ -3,11 +3,16 @@ db_type=mysql
 extract_type=snapshot
 url={mysql_extractor_url}
 
-[checker]
-enable=true
+[sinker]
 db_type=mysql
+sink_type=check
 url={mysql_sinker_url}
+
+[checker]
 batch_size=2
+
+[checker_output]
+output_type=logs
 output_full_row=true
 output_revise_sql=false
 

--- a/dt-tests/tests/mysql_to_mysql/check/output_revise_sql_test/task_config.ini
+++ b/dt-tests/tests/mysql_to_mysql/check/output_revise_sql_test/task_config.ini
@@ -3,11 +3,16 @@ db_type=mysql
 extract_type=snapshot
 url={mysql_extractor_url}
 
-[checker]
-enable=true
+[sinker]
 db_type=mysql
+sink_type=check
 url={mysql_sinker_url}
+
+[checker]
 batch_size=2
+
+[checker_output]
+output_type=logs
 output_full_row=false
 output_revise_sql=true
 revise_match_full_row=false

--- a/dt-tests/tests/mysql_to_mysql/check/recheck_basic/task_config.ini
+++ b/dt-tests/tests/mysql_to_mysql/check/recheck_basic/task_config.ini
@@ -3,12 +3,14 @@ db_type=mysql
 extract_type=snapshot
 url={mysql_extractor_url}
 
-[checker]
-enable=true
+[sinker]
 db_type=mysql
+sink_type=check
 url={mysql_sinker_url}
-retry_interval_secs=5
-max_retries=4
+
+[checker]
+recheck_interval_secs=5
+recheck_count=4
 batch_size=2
 
 [filter]

--- a/dt-tests/tests/mysql_to_mysql/check/recheck_recover/task_config.ini
+++ b/dt-tests/tests/mysql_to_mysql/check/recheck_recover/task_config.ini
@@ -3,12 +3,14 @@ db_type=mysql
 extract_type=snapshot
 url={mysql_extractor_url}
 
-[checker]
-enable=true
+[sinker]
 db_type=mysql
+sink_type=check
 url={mysql_sinker_url}
-retry_interval_secs=5
-max_retries=4
+
+[checker]
+recheck_interval_secs=5
+recheck_count=4
 batch_size=2
 
 [filter]

--- a/dt-tests/tests/mysql_to_mysql/check/recheck_struct_recover/task_config.ini
+++ b/dt-tests/tests/mysql_to_mysql/check/recheck_struct_recover/task_config.ini
@@ -4,14 +4,16 @@ extract_type=struct
 url={mysql_extractor_url}
 max_connections=5
 
-[checker]
-enable=true
+[sinker]
 db_type=mysql
+sink_type=check
 url={mysql_sinker_url}
-retry_interval_secs=3
-max_retries=4
-batch_size=2
 max_connections=5
+
+[checker]
+recheck_interval_secs=3
+recheck_count=4
+batch_size=2
 
 [filter]
 do_dbs=test_db_ddl_recheck

--- a/dt-tests/tests/mysql_to_mysql/check/revise_match_full_row_test/task_config.ini
+++ b/dt-tests/tests/mysql_to_mysql/check/revise_match_full_row_test/task_config.ini
@@ -3,11 +3,16 @@ db_type=mysql
 extract_type=snapshot
 url={mysql_extractor_url}
 
-[checker]
-enable=true
+[sinker]
 db_type=mysql
+sink_type=check
 url={mysql_sinker_url}
+
+[checker]
 batch_size=2
+
+[checker_output]
+output_type=logs
 output_full_row=false
 output_revise_sql=true
 revise_match_full_row=true

--- a/dt-tests/tests/mysql_to_mysql/check/revise_struct_test/task_config.ini
+++ b/dt-tests/tests/mysql_to_mysql/check/revise_struct_test/task_config.ini
@@ -3,12 +3,17 @@ db_type=mysql
 extract_type=struct
 url={mysql_extractor_url}
 
-[checker]
-enable=true
+[sinker]
 db_type=mysql
+sink_type=check
 url={mysql_sinker_url}
-output_revise_sql=true
+
+[checker]
 batch_size=2
+
+[checker_output]
+output_type=logs
+output_revise_sql=true
 
 [filter]
 do_dbs=

--- a/dt-tests/tests/mysql_to_mysql/check/route_test/task_config.ini
+++ b/dt-tests/tests/mysql_to_mysql/check/route_test/task_config.ini
@@ -3,10 +3,12 @@ db_type=mysql
 extract_type=snapshot
 url={mysql_extractor_url}
 
-[checker]
-enable=true
+[sinker]
 db_type=mysql
+sink_type=check
 url={mysql_sinker_url}
+
+[checker]
 batch_size=2
 
 [filter]

--- a/dt-tests/tests/mysql_to_mysql/check/sample_filter_test/task_config.ini
+++ b/dt-tests/tests/mysql_to_mysql/check/sample_filter_test/task_config.ini
@@ -3,12 +3,14 @@ db_type=mysql
 extract_type=snapshot
 url={mysql_extractor_url}
 
-[checker]
-enable=true
+[sinker]
 db_type=mysql
+sink_type=check
 url={mysql_sinker_url}
+
+[checker]
 batch_size=2
-sample_rate=50
+sample_percent=50
 
 [filter]
 do_dbs=

--- a/dt-tests/tests/mysql_to_mysql/check/sample_test/task_config.ini
+++ b/dt-tests/tests/mysql_to_mysql/check/sample_test/task_config.ini
@@ -3,12 +3,14 @@ db_type=mysql
 extract_type=snapshot
 url={mysql_extractor_url}
 
-[checker]
-enable=true
+[sinker]
 db_type=mysql
+sink_type=check
 url={mysql_sinker_url}
+
+[checker]
 batch_size=2
-sample_rate=34
+sample_percent=34
 
 [filter]
 do_dbs=

--- a/dt-tests/tests/mysql_to_mysql/check/set_check_log_dir_test/task_config.ini
+++ b/dt-tests/tests/mysql_to_mysql/check/set_check_log_dir_test/task_config.ini
@@ -3,11 +3,16 @@ db_type=mysql
 extract_type=snapshot
 url={mysql_extractor_url}
 
-[checker]
-enable=true
+[sinker]
 db_type=mysql
+sink_type=check
 url={mysql_sinker_url}
+
+[checker]
 batch_size=2
+
+[checker_output]
+output_type=logs
 check_log_dir=./logs/check_set_check_log_dir_test
 
 [filter]

--- a/dt-tests/tests/mysql_to_mysql/check/snapshot_inline_basic_test/task_config.ini
+++ b/dt-tests/tests/mysql_to_mysql/check/snapshot_inline_basic_test/task_config.ini
@@ -14,7 +14,6 @@ password={mysql_sinker_password}
 batch_size=2
 
 [checker]
-enable=true
 batch_size=2
 
 [filter]

--- a/dt-tests/tests/mysql_to_mysql/review/basic_test/task_config.ini
+++ b/dt-tests/tests/mysql_to_mysql/review/basic_test/task_config.ini
@@ -5,12 +5,14 @@ url={mysql_extractor_url}
 check_log_dir=./dt-tests/tests/mysql_to_mysql/review/basic_test/check_log
 batch_size=200
 
-[checker]
-enable=true
+[sinker]
 db_type=mysql
+sink_type=check
 url={mysql_sinker_url}
 
+[checker]
 batch_size=2
+
 [filter]
 do_dbs=
 ignore_dbs=

--- a/dt-tests/tests/mysql_to_mysql/review/route_test/task_config.ini
+++ b/dt-tests/tests/mysql_to_mysql/review/route_test/task_config.ini
@@ -5,12 +5,14 @@ url={mysql_extractor_url}
 check_log_dir=./dt-tests/tests/mysql_to_mysql/review/route_test/check_log
 batch_size=200
 
-[checker]
-enable=true
+[sinker]
 db_type=mysql
+sink_type=check
 url={mysql_sinker_url}
 
+[checker]
 batch_size=2
+
 [filter]
 do_dbs=
 ignore_dbs=

--- a/dt-tests/tests/mysql_to_mysql/struct/batch_test/bench_test_1/check/task_config.ini
+++ b/dt-tests/tests/mysql_to_mysql/struct/batch_test/bench_test_1/check/task_config.ini
@@ -4,10 +4,12 @@ db_type=mysql
 url={mysql_extractor_url_8_0}
 db_batch_size=1
 
-[checker]
-enable=true
+[sinker]
 db_type=mysql
+sink_type=check
 url={mysql_sinker_url_8_0}
+
+[checker]
 batch_size=1
 
 [filter]

--- a/dt-tests/tests/mysql_to_mysql/struct/filter_test_1/check/task_config.ini
+++ b/dt-tests/tests/mysql_to_mysql/struct/filter_test_1/check/task_config.ini
@@ -3,10 +3,12 @@ db_type=mysql
 extract_type=struct
 url={mysql_extractor_url}
 
-[checker]
-enable=true
+[sinker]
 db_type=mysql
+sink_type=check
 url={mysql_sinker_url}
+
+[checker]
 batch_size=2
 
 [filter]

--- a/dt-tests/tests/mysql_to_mysql_case_sensitive/check/basic_struct_test/task_config.ini
+++ b/dt-tests/tests/mysql_to_mysql_case_sensitive/check/basic_struct_test/task_config.ini
@@ -3,10 +3,12 @@ db_type=mysql
 extract_type=struct
 url={case_sensitive_mysql_extractor_url}
 
-[checker]
-enable=true
+[sinker]
 db_type=mysql
+sink_type=check
 url={case_sensitive_mysql_sinker_url}
+
+[checker]
 batch_size=2
 
 [filter]

--- a/dt-tests/tests/mysql_to_mysql_case_sensitive/check/basic_test/task_config.ini
+++ b/dt-tests/tests/mysql_to_mysql_case_sensitive/check/basic_test/task_config.ini
@@ -3,10 +3,12 @@ db_type=mysql
 extract_type=snapshot
 url={case_sensitive_mysql_extractor_url}
 
-[checker]
-enable=true
+[sinker]
 db_type=mysql
+sink_type=check
 url={case_sensitive_mysql_sinker_url}
+
+[checker]
 batch_size=2
 
 [filter]

--- a/dt-tests/tests/pg_to_pg/check/basic_struct_test/task_config.ini
+++ b/dt-tests/tests/pg_to_pg/check/basic_struct_test/task_config.ini
@@ -3,10 +3,12 @@ db_type=pg
 extract_type=struct
 url={pg_extractor_url}
 
-[checker]
-enable=true
+[sinker]
 db_type=pg
+sink_type=check
 url={pg_sinker_url}
+
+[checker]
 batch_size=2
 
 [filter]

--- a/dt-tests/tests/pg_to_pg/check/basic_test/task_config.ini
+++ b/dt-tests/tests/pg_to_pg/check/basic_test/task_config.ini
@@ -3,10 +3,12 @@ db_type=pg
 extract_type=snapshot
 url={pg_extractor_url}
 
-[checker]
-enable=true
+[sinker]
 db_type=pg
+sink_type=check
 url={pg_sinker_url}
+
+[checker]
 batch_size=2
 
 [filter]

--- a/dt-tests/tests/pg_to_pg/check/cdc_check_basic_test/task_config.ini
+++ b/dt-tests/tests/pg_to_pg/check/cdc_check_basic_test/task_config.ini
@@ -11,8 +11,10 @@ heartbeat_interval_secs=1
 heartbeat_tb=heartbeat_db.ape_dts_heartbeat
 
 [checker]
-enable=true
 batch_size=2
+
+[checker_cdc]
+is_enabled=true
 
 [resumer]
 resume_type=from_target

--- a/dt-tests/tests/pg_to_pg/check/cdc_check_large_data_test/task_config.ini
+++ b/dt-tests/tests/pg_to_pg/check/cdc_check_large_data_test/task_config.ini
@@ -11,8 +11,10 @@ heartbeat_interval_secs=1
 heartbeat_tb=heartbeat_db.ape_dts_heartbeat
 
 [checker]
-enable=true
 batch_size=100
+
+[checker_cdc]
+is_enabled=true
 
 [resumer]
 resume_type=from_target

--- a/dt-tests/tests/pg_to_pg/check/cdc_check_update_delete_test/task_config.ini
+++ b/dt-tests/tests/pg_to_pg/check/cdc_check_update_delete_test/task_config.ini
@@ -11,8 +11,10 @@ heartbeat_interval_secs=1
 heartbeat_tb=heartbeat_db.ape_dts_heartbeat
 
 [checker]
-enable=true
 batch_size=2
+
+[checker_cdc]
+is_enabled=true
 
 [resumer]
 resume_type=from_target

--- a/dt-tests/tests/pg_to_pg/check/output_full_row_test/task_config.ini
+++ b/dt-tests/tests/pg_to_pg/check/output_full_row_test/task_config.ini
@@ -3,11 +3,16 @@ db_type=pg
 extract_type=snapshot
 url={pg_extractor_url}
 
-[checker]
-enable=true
+[sinker]
 db_type=pg
+sink_type=check
 url={pg_sinker_url}
+
+[checker]
 batch_size=2
+
+[checker_output]
+output_type=logs
 output_full_row=true
 output_revise_sql=false
 

--- a/dt-tests/tests/pg_to_pg/check/output_revise_sql_test/task_config.ini
+++ b/dt-tests/tests/pg_to_pg/check/output_revise_sql_test/task_config.ini
@@ -3,11 +3,16 @@ db_type=pg
 extract_type=snapshot
 url={pg_extractor_url}
 
-[checker]
-enable=true
+[sinker]
 db_type=pg
+sink_type=check
 url={pg_sinker_url}
+
+[checker]
 batch_size=2
+
+[checker_output]
+output_type=logs
 output_full_row=false
 output_revise_sql=true
 revise_match_full_row=false

--- a/dt-tests/tests/pg_to_pg/check/recheck_basic/task_config.ini
+++ b/dt-tests/tests/pg_to_pg/check/recheck_basic/task_config.ini
@@ -3,12 +3,14 @@ db_type=pg
 extract_type=snapshot
 url={pg_extractor_url}
 
-[checker]
-enable=true
+[sinker]
 db_type=pg
+sink_type=check
 url={pg_sinker_url}
-retry_interval_secs=2
-max_retries=3
+
+[checker]
+recheck_interval_secs=2
+recheck_count=3
 batch_size=10
 
 [filter]
@@ -17,7 +19,6 @@ ignore_dbs=
 do_tbs=public.recheck_table
 ignore_tbs=
 do_events=insert,update,delete,ddl,dcl
-
 
 [router]
 db_map=

--- a/dt-tests/tests/pg_to_pg/check/recheck_recover/task_config.ini
+++ b/dt-tests/tests/pg_to_pg/check/recheck_recover/task_config.ini
@@ -3,12 +3,14 @@ db_type=pg
 extract_type=snapshot
 url={pg_extractor_url}
 
-[checker]
-enable=true
+[sinker]
 db_type=pg
+sink_type=check
 url={pg_sinker_url}
-retry_interval_secs=5
-max_retries=4
+
+[checker]
+recheck_interval_secs=5
+recheck_count=4
 batch_size=2
 
 [filter]

--- a/dt-tests/tests/pg_to_pg/check/recheck_struct_recover/task_config.ini
+++ b/dt-tests/tests/pg_to_pg/check/recheck_struct_recover/task_config.ini
@@ -4,14 +4,16 @@ extract_type=struct
 url={pg_extractor_url}
 max_connections=5
 
-[checker]
-enable=true
+[sinker]
 db_type=pg
+sink_type=check
 url={pg_sinker_url}
-retry_interval_secs=3
-max_retries=4
-batch_size=2
 max_connections=5
+
+[checker]
+recheck_interval_secs=3
+recheck_count=4
+batch_size=2
 
 [filter]
 do_dbs=

--- a/dt-tests/tests/pg_to_pg/check/revise_match_full_row_test/task_config.ini
+++ b/dt-tests/tests/pg_to_pg/check/revise_match_full_row_test/task_config.ini
@@ -3,11 +3,16 @@ db_type=pg
 extract_type=snapshot
 url={pg_extractor_url}
 
-[checker]
-enable=true
+[sinker]
 db_type=pg
+sink_type=check
 url={pg_sinker_url}
+
+[checker]
 batch_size=2
+
+[checker_output]
+output_type=logs
 output_full_row=false
 output_revise_sql=true
 revise_match_full_row=true

--- a/dt-tests/tests/pg_to_pg/check/revise_struct_test/task_config.ini
+++ b/dt-tests/tests/pg_to_pg/check/revise_struct_test/task_config.ini
@@ -3,12 +3,17 @@ db_type=pg
 extract_type=struct
 url={pg_extractor_url}
 
-[checker]
-enable=true
+[sinker]
 db_type=pg
+sink_type=check
 url={pg_sinker_url}
-output_revise_sql=true
+
+[checker]
 batch_size=2
+
+[checker_output]
+output_type=logs
+output_revise_sql=true
 
 [filter]
 do_dbs=

--- a/dt-tests/tests/pg_to_pg/check/route_test/task_config.ini
+++ b/dt-tests/tests/pg_to_pg/check/route_test/task_config.ini
@@ -3,10 +3,12 @@ db_type=pg
 extract_type=snapshot
 url={pg_extractor_url}
 
-[checker]
-enable=true
+[sinker]
 db_type=pg
+sink_type=check
 url={pg_sinker_url}
+
+[checker]
 batch_size=2
 
 [filter]

--- a/dt-tests/tests/pg_to_pg/check/sample_filter_test/task_config.ini
+++ b/dt-tests/tests/pg_to_pg/check/sample_filter_test/task_config.ini
@@ -3,12 +3,14 @@ db_type=pg
 extract_type=snapshot
 url={pg_extractor_url}
 
-[checker]
-enable=true
+[sinker]
 db_type=pg
+sink_type=check
 url={pg_sinker_url}
+
+[checker]
 batch_size=2
-sample_rate=50
+sample_percent=50
 
 [filter]
 do_dbs=

--- a/dt-tests/tests/pg_to_pg/check/sample_test/task_config.ini
+++ b/dt-tests/tests/pg_to_pg/check/sample_test/task_config.ini
@@ -3,12 +3,14 @@ db_type=pg
 extract_type=snapshot
 url={pg_extractor_url}
 
-[checker]
-enable=true
+[sinker]
 db_type=pg
+sink_type=check
 url={pg_sinker_url}
+
+[checker]
 batch_size=2
-sample_rate=34
+sample_percent=34
 
 [filter]
 do_dbs=

--- a/dt-tests/tests/pg_to_pg/check/snapshot_inline_basic_test/task_config.ini
+++ b/dt-tests/tests/pg_to_pg/check/snapshot_inline_basic_test/task_config.ini
@@ -14,7 +14,6 @@ password={pg_sinker_password}
 batch_size=2
 
 [checker]
-enable=true
 batch_size=2
 
 [filter]

--- a/dt-tests/tests/pg_to_pg/review/basic_test/task_config.ini
+++ b/dt-tests/tests/pg_to_pg/review/basic_test/task_config.ini
@@ -6,12 +6,14 @@ check_log_dir=./dt-tests/tests/pg_to_pg/review/basic_test/check_log
 batch_size=200
 start_after=[]
 
-[checker]
-enable=true
+[sinker]
 db_type=pg
+sink_type=check
 url={pg_sinker_url}
 
+[checker]
 batch_size=2
+
 [filter]
 do_dbs=
 ignore_dbs=

--- a/dt-tests/tests/pg_to_pg/review/route_test/task_config.ini
+++ b/dt-tests/tests/pg_to_pg/review/route_test/task_config.ini
@@ -6,12 +6,14 @@ check_log_dir=./dt-tests/tests/pg_to_pg/review/route_test/check_log
 batch_size=200
 start_after=[]
 
-[checker]
-enable=true
+[sinker]
 db_type=pg
+sink_type=check
 url={pg_sinker_url}
 
+[checker]
 batch_size=2
+
 [filter]
 do_dbs=
 ignore_dbs=

--- a/dt-tests/tests/pg_to_pg/struct/batch_test/bench_test_1/check/task_config.ini
+++ b/dt-tests/tests/pg_to_pg/struct/batch_test/bench_test_1/check/task_config.ini
@@ -4,10 +4,12 @@ extract_type=struct
 url={pg_extractor_url}
 db_batch_size=1
 
-[checker]
-enable=true
+[sinker]
 db_type=pg
+sink_type=check
 url={pg_sinker_url}
+
+[checker]
 batch_size=2
 
 [filter]

--- a/dt-tests/tests/pg_to_pg/struct/batch_test/bench_test_2/check/task_config.ini
+++ b/dt-tests/tests/pg_to_pg/struct/batch_test/bench_test_2/check/task_config.ini
@@ -4,10 +4,12 @@ extract_type=struct
 url={pg_extractor_url}
 db_batch_size=1
 
-[checker]
-enable=true
+[sinker]
 db_type=pg
+sink_type=check
 url={pg_sinker_url}
+
+[checker]
 batch_size=2
 
 [filter]

--- a/dt-tests/tests/pg_to_pg/struct/filter_test_1/check/task_config.ini
+++ b/dt-tests/tests/pg_to_pg/struct/filter_test_1/check/task_config.ini
@@ -3,10 +3,12 @@ db_type=pg
 extract_type=struct
 url={pg_extractor_url}
 
-[checker]
-enable=true
+[sinker]
 db_type=pg
+sink_type=check
 url={pg_sinker_url}
+
+[checker]
 batch_size=2
 
 [filter]

--- a/dt-tests/tests/test_config_util.rs
+++ b/dt-tests/tests/test_config_util.rs
@@ -13,7 +13,7 @@ pub struct TestConfigUtil {}
 
 const EXTRACTOR: &str = "extractor";
 const SINKER: &str = "sinker";
-const CHECKER: &str = "checker";
+const CHECKER_OUTPUT: &str = "checker_output";
 const RUNTIME: &str = "runtime";
 const RESUMER: &str = "resumer";
 const TEST_PROJECT: &str = "dt-tests";
@@ -143,13 +143,13 @@ impl TestConfigUtil {
         }
 
         if let Some(checker) = &config.checker {
-            let checker_check_log_dir = if !checker.check_log_dir.is_empty() {
-                format!("{}/{}", project_root, checker.check_log_dir)
+            let checker_check_log_dir = if !checker.log_dir().is_empty() {
+                format!("{}/{}", project_root, checker.log_dir())
             } else {
                 format!("{}/check", log_dir)
             };
             update_configs.push((
-                CHECKER.to_string(),
+                CHECKER_OUTPUT.to_string(),
                 "check_log_dir".to_string(),
                 checker_check_log_dir,
             ));

--- a/dt-tests/tests/test_runner/check_test_runner.rs
+++ b/dt-tests/tests/test_runner/check_test_runner.rs
@@ -338,13 +338,14 @@ impl CheckTestRunner {
         // start task
         self.base.base.start_task().await?;
 
-        let default_check_log_file_size = CheckerConfig::default().check_log_file_size;
+        let default_checker = CheckerConfig::default();
+        let default_check_log_file_size = default_checker.log_file_size().to_string();
         let check_log_file_size = self
             .base
             .config
             .checker
             .as_ref()
-            .map(|cfg| cfg.check_log_file_size.clone())
+            .map(|cfg| cfg.log_file_size().to_string())
             .unwrap_or(default_check_log_file_size.clone());
         if check_log_file_size == default_check_log_file_size {
             CheckUtil::validate_check_log(&self.expect_check_log_dir, &self.dst_check_log_dir)?;
@@ -487,7 +488,7 @@ impl CheckTestRunner {
             .get_config()
             .checker
             .as_ref()
-            .map(|checker| checker.retry_interval_secs)
+            .map(|checker| checker.recheck_interval_secs)
             .unwrap_or(0);
         let delay_secs = std::cmp::max(1, retry_interval_secs / 2);
 

--- a/dt-tests/tests/test_runner/check_util.rs
+++ b/dt-tests/tests/test_runner/check_util.rs
@@ -273,10 +273,10 @@ impl CheckUtil {
             .checker
             .as_ref()
             .map(|checker| {
-                if checker.check_log_dir.is_empty() {
+                if checker.log_dir().is_empty() {
                     format!("{}/check", config.runtime.log_dir)
                 } else {
-                    checker.check_log_dir.clone()
+                    checker.log_dir().to_string()
                 }
             })
             .unwrap_or_default();

--- a/dt-tests/tests/test_runner/mongo_check_test_runner.rs
+++ b/dt-tests/tests/test_runner/mongo_check_test_runner.rs
@@ -44,7 +44,7 @@ impl MongoCheckTestRunner {
             .get_config()
             .checker
             .as_ref()
-            .map(|checker| checker.retry_interval_secs)
+            .map(|checker| checker.recheck_interval_secs)
             .unwrap_or(0);
         let delay_secs = std::cmp::max(1, retry_interval_secs / 2);
 


### PR DESCRIPTION
## Checker refactor summary

This PR simplifies checker configuration and separates standalone checking from the normal replication pipeline.

### 1. More intuitive checker configuration

Previously, `[checker]` mixed several unrelated concerns:

- Enabling checker
- Target database connection
- Common check behavior
- CDC queue settings
- Log/S3 output settings

The new configuration separates these responsibilities:

- `[sinker]`: checker target database
- `[checker]`: common check behavior
- `[checker_cdc]`: CDC inline-check switch and queue settings
- `[checker_output]`: output medium and formatting

#### Standalone snapshot check

Before:

```ini
[extractor]
extract_type=snapshot
url=mysql://source:3306

[sinker]
sink_type=dummy

[checker]
enable=true
db_type=mysql
url=mysql://target:3306
username=root
password=***
batch_size=200
check_log_s3=false
```

After:

```ini
[extractor]
extract_type=snapshot
url=mysql://source:3306

[sinker]
db_type=mysql
sink_type=check
url=mysql://target:3306
username=root
password=***

[checker]
batch_size=200

[checker_output]
output_type=logs
```

The checker target now uses the normal sinker database configuration, avoiding a second database configuration model under `[checker]`.

#### CDC inline check

Before:

```ini
[sinker]
sink_type=write
url=mysql://target:3306

[checker]
enable=true
batch_size=200
queue_size=200
cdc_check_log_interval_secs=30
check_log_s3=false
```

After:

```ini
[sinker]
sink_type=write
url=mysql://target:3306

[checker]
batch_size=200

[checker_cdc]
is_enabled=true
queue_size=200
check_log_interval_secs=30

[checker_output]
output_type=logs
```

This makes it explicit that the queue belongs only to CDC inline check, while output configuration is independent of checker execution mode.

### 2. Introduce `CheckerPipeline`

Previously, `BasePipeline` directly contained checker-specific logic, including checker input forwarding, control events, checkpoint handling, DDL metadata refresh, and checker shutdown.

This mixed two different responsibilities:

- Normal replication: extract → parallelize → sink
- Data checking: extract → parallelize → check

This PR introduces a dedicated `CheckerPipeline` for standalone check tasks:

```text
Standalone check:
Extractor → BasePipeline dispatch → CheckerSinker → Direct checker

Normal replication:
Extractor → BasePipeline dispatch → Database sinker
```

`BasePipeline` now focuses on queue draining, parallelization, and sinker dispatch. Standalone check is modeled as a specialized sink stage instead of an optional side path inside the base pipeline.

Inline check remains attached to the real sinker through `CheckableSinker`, so normal write semantics are preserved. DDL-related metadata refresh is also handled by the checkable sinker rather than leaking checker-specific behavior into `BasePipeline`.

### 3. Introduce `CheckerHandle::Direct`

`CheckerHandle` now distinguishes two execution models:

```rust
enum CheckerHandle {
    Direct(DirectCheckerHandle),
    Async(DataCheckerHandle),
}
```

- `Direct` is used by standalone snapshot, struct, and check-log tasks.
- `Async` is retained for CDC inline check.

Standalone check no longer creates resources that it does not need:

- No checker input queue
- No `Notify`
- No checker control channel
- No background Tokio checker worker
- No queue overflow/drop accounting

The extracted `Vec<RowData>` is moved directly into the checker without cloning DML data.

CDC inline check still uses the asynchronous queue because checking must not block the original replication sink path. Its existing bounded-queue and overflow behavior remains unchanged.

Overall, this keeps the two modes aligned with their actual requirements:

```text
Standalone check: correctness-first, direct and awaited
CDC inline check: replication-first, asynchronous and decoupled
```