### PR TITLE
fix(redis): support RDB stream type 26 (IDMP) and fail fast on unknown RDB types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Added
+
+#### Redis
+
+- support RDB type byte 26 (`RDB_TYPE_STREAM_LISTPACKS_4`), including the trailing IDMP (Idempotent Message Producer) section, when extracting streams from an RDB snapshot
+
+### Fixed
+
+#### General and Platform
+
+- exit with a non-zero status code when the task panics, instead of leaving the process hanging
+
+#### Redis
+
+- fail the task on unsupported RDB type bytes; the entry length of an unknown type can not be determined, so the parser previously desynchronized and silently produced partial data
+
+---
+
 ## [2.0.26] - 2026-08-03
 
 Data replication involves inherently complex and diverse workloads. Over the past several releases, we have continued to strengthen the foundation of Ape-DTS across three key areas: observability, through clearer metrics, error reporting, and runtime logs; controllability, through explicit resource configuration and the elimination of black-box behaviors that can unexpectedly amplify resource consumption; and usability, through streamlined configuration and CLI-based tooling. Alongside these foundational improvements, we have focused on making replication for four widely adopted open-source database engines—MySQL, PostgreSQL, MongoDB, and Redis—more stable and reliable across real-world workloads:

--- a/dt-connector/src/extractor/redis/rdb/entry_parser/entry_parser.rs
+++ b/dt-connector/src/extractor/redis/rdb/entry_parser/entry_parser.rs
@@ -1,4 +1,8 @@
-use dt_common::meta::redis::redis_object::{RedisObject, RedisString};
+use anyhow::bail;
+use dt_common::{
+    error::DtError,
+    meta::redis::redis_object::{RedisObject, RedisString},
+};
 
 use crate::extractor::redis::rdb::reader::rdb_reader::RdbReader;
 
@@ -52,7 +56,8 @@ impl EntryParser {
 
             super::RDB_TYPE_STREAM_LISTPACKS
             | super::RDB_TYPE_STREAM_LISTPACKS_2
-            | super::RDB_TYPE_STREAM_LISTPACKS_3 => {
+            | super::RDB_TYPE_STREAM_LISTPACKS_3
+            | super::RDB_TYPE_STREAM_LISTPACKS_4 => {
                 RedisObject::Stream(StreamParser::load_from_buffer(reader, key, type_byte).await?)
             }
 
@@ -61,8 +66,13 @@ impl EntryParser {
             }
 
             _ => {
-                log::error!("unknown type byte: {}, key: {}", type_byte, key);
-                RedisObject::Unknown
+                // The length of an entry can only be determined by parsing it, so an unknown
+                // type byte leaves the reader desynchronized. Continuing would silently yield
+                // corrupted data for every following entry, so abort the task instead.
+                bail! {DtError::redis_rdb(format!(
+                    "unsupported RDB type byte: {}, key: {}",
+                    type_byte, key
+                ))}
             }
         };
 

--- a/dt-connector/src/extractor/redis/rdb/entry_parser/mod.rs
+++ b/dt-connector/src/extractor/redis/rdb/entry_parser/mod.rs
@@ -36,3 +36,6 @@ const RDB_TYPE_HASH_METADATA_PRE_GA: u8 = 22;
 const RDB_TYPE_HASH_LISTPACK_EX_PRE_GA: u8 = 23;
 const RDB_TYPE_HASH_METADATA: u8 = 24;
 const RDB_TYPE_HASH_LISTPACK_EX: u8 = 25;
+
+// Stream with IDMP (Idempotent Message Producer) support.
+const RDB_TYPE_STREAM_LISTPACKS_4: u8 = 26;

--- a/dt-connector/src/extractor/redis/rdb/entry_parser/stream_parser.rs
+++ b/dt-connector/src/extractor/redis/rdb/entry_parser/stream_parser.rs
@@ -248,6 +248,37 @@ impl StreamParser {
             }
         }
 
+        // 3. IDMP (Idempotent Message Producer) config and entries.
+        // refer: https://github.com/redis/redis/blob/unstable/src/rdb.c, rdbLoadStreamIdmpEntries
+        if type_byte >= super::RDB_TYPE_STREAM_LISTPACKS_4 {
+            let _ = reader.read_length().await?; // idmp_duration
+            let _ = reader.read_length().await?; // idmp_max_entries
+
+            // IDMP dedup state can not be expressed as redis commands,
+            // so entries are only consumed to keep the reader in sync.
+            let n_producer = reader.read_length().await?;
+            if n_producer > 0 {
+                log::warn!(
+                    "stream [{}] has {} IDMP producers, their deduplication state will NOT be migrated",
+                    master_key,
+                    n_producer
+                );
+            }
+
+            for _ in 0..n_producer {
+                let _ = reader.read_string().await?; // producer id
+                let n_entry = reader.read_length().await?;
+                for _ in 0..n_entry {
+                    let _ = reader.read_string().await?; // iid
+                    let _ = reader.read_length().await?; // entry id ms
+                    let _ = reader.read_length().await?; // entry id seq
+                }
+            }
+
+            let _ = reader.read_length().await?; // iids_added
+            let _ = reader.read_length().await?; // iids_duplicates
+        }
+
         Ok(obj)
     }
 

--- a/dt-main/src/main.rs
+++ b/dt-main/src/main.rs
@@ -130,6 +130,9 @@ fn install_panic_hook() {
         let backtrace = Backtrace::capture();
         log_error!("panic: {}\nbacktrace:\n{}", panic_info, backtrace);
         log::logger().flush();
+        // A panic in a spawned task or worker thread would otherwise leave the process
+        // hanging, and the task would never be reported as failed.
+        exit(1);
     }));
 }
 


### PR DESCRIPTION
fix #563 

## What

Three related fixes to the Redis RDB extractor and the task exit path.

### 1. Support RDB type byte 26 (`RDB_TYPE_STREAM_LISTPACKS_4`)

Redis added `RDB_TYPE_STREAM_LISTPACKS_4 = 26` ("Stream with IDMP support"). Any
RDB containing a stream written by such a server was previously unparseable.

The listpack/entry layout is identical to `RDB_TYPE_STREAM_LISTPACKS_3`, but the
object is followed by an extra IDMP (Idempotent Message Producer) trailer:

```
idmp_duration, idmp_max_entries,
num_producers × [ pid, count × [ iid, id.ms, id.seq ] ],
iids_added, iids_duplicates
```

The constant is added, routed to `StreamParser`, and the trailer is consumed so
the reader stays in sync. The IDMP dedup state itself is not migrated — a warning
is logged when a stream carries producer entries.

### 2. Unknown RDB type bytes are now fatal

Previously the parser returned `RedisObject::Unknown` and kept going. Because the
length of an entry of an unknown type cannot be determined, the reader is already
desynchronized at that point, so the task would silently sink partial/garbage data
and report success. It now aborts the task with a descriptive error.

The error message formats the key via `RedisString`'s lossy `Display`, so a binary
(non-UTF8) key cannot panic while reporting the failure.

### 3. Non-zero exit on panic

The panic hook flushed the logger but did not terminate. A panic on a spawned task
or worker thread left the process hanging, so a failing restore/migration job never
actually failed. The hook now `exit(1)`s after flushing.