### PR TITLE
fix: adjustment to the behavior of Checker when metadata is missing

### DIFF
--- a/docs/en/config.md
+++ b/docs/en/config.md
@@ -182,7 +182,7 @@ under `runtime.log_dir/check`.
 | revise_match_full_row| use the complete row in generated repair predicates                 | false         | false   |
 | check_log_dir        | local check-log directory                                           | /tmp/check    | empty (use `runtime.log_dir/check`) |
 | check_log_file_size  | per-file size limit for `diff.log`, `miss.log`, and `sql.log` | 100mb         | 100mb   |
-| check_log_max_rows   | maximum rows in CDC `diff.log`/`miss.log` snapshots             | 1000          | 1000    |
+| check_log_max_rows   | maximum rows in `diff.log`/`miss.log`                            | 1000          | 1000    |
 | s3_bucket            | S3 bucket; required for `output_type=s3`                           | my-bucket     | -       |
 | s3_access_key_id     | S3 access key                                                       | AKIA...       | empty   |
 | s3_secret_access_key | S3 secret key                                                       | ****          | empty   |

--- a/docs/zh/config.md
+++ b/docs/zh/config.md
@@ -173,7 +173,7 @@ recheck_queue_memory_mb=256
 | revise_match_full_row| 生成修复语句时是否用完整行作为匹配条件                       | false         | false |
 | check_log_dir        | 本地校验日志目录                                             | /tmp/check    | 空（使用 `runtime.log_dir/check`） |
 | check_log_file_size  | `diff.log`、`miss.log`、`sql.log` 单文件大小上限       | 100mb         | 100mb |
-| check_log_max_rows   | CDC `diff.log`/`miss.log` 快照最大行数                   | 1000          | 1000 |
+| check_log_max_rows   | `diff.log`/`miss.log` 最大行数                           | 1000          | 1000 |
 | s3_bucket            | S3 bucket，`output_type=s3` 时必填                          | my-bucket     | - |
 | s3_access_key_id     | S3 access key                                                | AKIA...       | 空 |
 | s3_secret_access_key | S3 secret key                                                | ****          | 空 |

--- a/dt-common/src/log_filter.rs
+++ b/dt-common/src/log_filter.rs
@@ -1,7 +1,8 @@
 use std::{
-    fs,
+    fs::{self, File},
+    io::{BufRead, BufReader},
     path::Path,
-    sync::atomic::{AtomicU64, Ordering},
+    sync::atomic::{AtomicU64, AtomicUsize, Ordering},
 };
 
 use anyhow::anyhow;
@@ -46,6 +47,62 @@ impl Filter for SizeLimitFilter {
         } else {
             Response::Reject
         }
+    }
+}
+
+#[derive(Debug)]
+pub struct RowLimitFilter {
+    limit: usize,
+    written: AtomicUsize,
+}
+
+impl RowLimitFilter {
+    pub fn new(path: impl AsRef<Path>, limit: usize) -> Self {
+        let written = File::open(path)
+            .map(|file| BufReader::new(file).lines().count())
+            .unwrap_or(0);
+        Self {
+            limit,
+            written: AtomicUsize::new(written),
+        }
+    }
+}
+
+impl Filter for RowLimitFilter {
+    fn filter(&self, _record: &Record) -> Response {
+        if self
+            .written
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+                (current < self.limit).then_some(current + 1)
+            })
+            .is_ok()
+        {
+            Response::Neutral
+        } else {
+            Response::Reject
+        }
+    }
+}
+
+#[derive(Clone, Debug, SerdeDeserialize)]
+pub struct RowLimitFilterConfig {
+    pub path: String,
+    pub limit: usize,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct RowLimitFilterDeserializer;
+
+impl Deserialize for RowLimitFilterDeserializer {
+    type Trait = dyn Filter;
+    type Config = RowLimitFilterConfig;
+
+    fn deserialize(
+        &self,
+        config: RowLimitFilterConfig,
+        _deserializers: &Deserializers,
+    ) -> anyhow::Result<Box<dyn Filter>> {
+        Ok(Box::new(RowLimitFilter::new(config.path, config.limit)))
     }
 }
 
@@ -152,4 +209,45 @@ where
     }
 
     d.deserialize_any(V)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs, path::PathBuf};
+
+    use log::{Level, Record};
+    use log4rs::filter::{Filter, Response};
+
+    use super::RowLimitFilter;
+
+    #[test]
+    fn row_limit_filter_rejects_records_after_limit() {
+        let filter = RowLimitFilter::new("/path/that/does/not/exist", 2);
+        let record = Record::builder()
+            .args(format_args!("test"))
+            .level(Level::Info)
+            .build();
+
+        assert!(matches!(filter.filter(&record), Response::Neutral));
+        assert!(matches!(filter.filter(&record), Response::Neutral));
+        assert!(matches!(filter.filter(&record), Response::Reject));
+    }
+
+    #[test]
+    fn row_limit_filter_counts_existing_newline_terminated_rows() {
+        let path = PathBuf::from(format!(
+            "/tmp/ape-dts-row-limit-filter-{}.log",
+            std::process::id()
+        ));
+        fs::write(&path, "first\nsecond\n").unwrap();
+        let filter = RowLimitFilter::new(&path, 3);
+        fs::remove_file(path).unwrap();
+        let record = Record::builder()
+            .args(format_args!("third"))
+            .level(Level::Info)
+            .build();
+
+        assert!(matches!(filter.filter(&record), Response::Neutral));
+        assert!(matches!(filter.filter(&record), Response::Reject));
+    }
 }

--- a/dt-common/src/logger/task_logger.rs
+++ b/dt-common/src/logger/task_logger.rs
@@ -18,7 +18,7 @@ use crate::{
         extractor_config::ExtractorConfig, sinker_config::SinkerConfig, task_config::TaskConfig,
     },
     error::DtError,
-    log_filter::SizeLimitFilterDeserializer,
+    log_filter::{RowLimitFilterDeserializer, SizeLimitFilterDeserializer},
 };
 
 static LOG_HANDLE: Mutex<Option<log4rs::Handle>> = Mutex::new(None);
@@ -28,10 +28,18 @@ const STATISTIC_LOG_DIR_PLACEHOLDER: &str = "STATISTIC_LOG_DIR_PLACEHOLDER";
 const LOG_LEVEL_PLACEHOLDER: &str = "LOG_LEVEL_PLACEHOLDER";
 const LOG_DIR_PLACEHOLDER: &str = "LOG_DIR_PLACEHOLDER";
 const CHECK_LOG_FILE_SIZE_PLACEHOLDER: &str = "CHECK_LOG_FILE_SIZE_PLACEHOLDER";
+const CHECK_LOG_MAX_ROWS_PLACEHOLDER: &str = "CHECK_LOG_MAX_ROWS_PLACEHOLDER";
 const RUNTIME_STDOUT_APPENDER_PLACEHOLDER: &str = "RUNTIME_STDOUT_APPENDER_PLACEHOLDER";
 const CHECK_RESULT_STDOUT_APPENDER_PLACEHOLDER: &str = "CHECK_RESULT_STDOUT_APPENDER_PLACEHOLDER";
 const DEFAULT_CHECK_LOG_DIR_PLACEHOLDER: &str = "LOG_DIR_PLACEHOLDER/check";
 const DEFAULT_STATISTIC_LOG_DIR_PLACEHOLDER: &str = "LOG_DIR_PLACEHOLDER/statistic";
+
+fn log_deserializers() -> Deserializers {
+    let mut deserializers = Deserializers::default();
+    deserializers.insert("size_limit", SizeLimitFilterDeserializer);
+    deserializers.insert("row_limit", RowLimitFilterDeserializer);
+    deserializers
+}
 
 pub struct TaskLogger<'a> {
     task_config: &'a TaskConfig,
@@ -144,6 +152,10 @@ impl<'a> TaskLogger<'a> {
                     }
                     config_str =
                         config_str.replace(CHECK_LOG_FILE_SIZE_PLACEHOLDER, cfg.log_file_size());
+                    config_str = config_str.replace(
+                        CHECK_LOG_MAX_ROWS_PLACEHOLDER,
+                        &cfg.log_max_rows().max(1).to_string(),
+                    );
                 }
             }
         }
@@ -155,6 +167,10 @@ impl<'a> TaskLogger<'a> {
                 DEFAULT_STATISTIC_LOG_DIR_PLACEHOLDER,
             )
             .replace(CHECK_LOG_FILE_SIZE_PLACEHOLDER, DEFAULT_CHECK_LOG_FILE_SIZE)
+            .replace(
+                CHECK_LOG_MAX_ROWS_PLACEHOLDER,
+                &crate::config::checker_config::DEFAULT_CHECK_LOG_MAX_ROWS.to_string(),
+            )
             .replace(LOG_DIR_PLACEHOLDER, &self.task_config.runtime.log_dir)
             .replace(LOG_LEVEL_PLACEHOLDER, &self.task_config.runtime.log_level);
 
@@ -178,8 +194,7 @@ impl<'a> TaskLogger<'a> {
         }
 
         let raw: RawConfig = serde_yaml::from_str(&config_str)?;
-        let mut deserializers = Deserializers::default();
-        deserializers.insert("size_limit", SizeLimitFilterDeserializer);
+        let deserializers = log_deserializers();
         let (appenders, errors) = raw.appenders_lossy(&deserializers);
         if !errors.is_empty() {
             log::error!(target: "default_logger", "errors deserializing log appenders: {errors:?}");
@@ -210,7 +225,9 @@ impl<'a> TaskLogger<'a> {
 mod tests {
     use std::env::current_dir;
 
-    use super::TaskLogger;
+    use log4rs::config::RawConfig;
+
+    use super::{log_deserializers, TaskLogger};
     use crate::config::{
         config_enums::{CheckMode, TaskKind, TaskType},
         connection_auth_config::ConnectionAuthConfig,
@@ -250,5 +267,35 @@ mod tests {
             &extractor,
             "/tmp/ape-dts/other"
         ));
+    }
+
+    #[test]
+    fn bundled_log4rs_config_accepts_check_log_limits() {
+        let bundled_config = include_str!("../../../log4rs.yaml");
+        let yaml: serde_yaml::Value = serde_yaml::from_str(bundled_config).unwrap();
+        for appender in ["miss_appender", "diff_appender"] {
+            let filters = yaml["appenders"][appender]["filters"]
+                .as_sequence()
+                .unwrap();
+            assert_eq!(filters[0]["kind"].as_str(), Some("size_limit"));
+            assert_eq!(filters[1]["kind"].as_str(), Some("row_limit"));
+        }
+
+        let config = bundled_config
+            .replace("CHECK_LOG_DIR_PLACEHOLDER", "/tmp/ape-dts/check")
+            .replace("STATISTIC_LOG_DIR_PLACEHOLDER", "/tmp/ape-dts/statistic")
+            .replace("CHECK_LOG_FILE_SIZE_PLACEHOLDER", "100mb")
+            .replace("CHECK_LOG_MAX_ROWS_PLACEHOLDER", "1000")
+            .replace("LOG_DIR_PLACEHOLDER", "/tmp/ape-dts")
+            .replace("LOG_LEVEL_PLACEHOLDER", "info")
+            .replace("RUNTIME_STDOUT_APPENDER_PLACEHOLDER", "stdout")
+            .replace(
+                "CHECK_RESULT_STDOUT_APPENDER_PLACEHOLDER",
+                "silent_stdout_appender",
+            );
+        let raw: RawConfig = serde_yaml::from_str(&config).unwrap();
+        let (_, errors) = raw.appenders_lossy(&log_deserializers());
+
+        assert!(errors.is_empty(), "{errors:?}");
     }
 }

--- a/dt-connector/src/checker/checker_engine.rs
+++ b/dt-connector/src/checker/checker_engine.rs
@@ -16,6 +16,7 @@ use crate::{
     sinker::mongo::mongo_cmd,
 };
 use dt_common::{
+    error::{ErrorCode, ErrorReport},
     log_diff, log_miss, log_sql, log_warn,
     meta::{
         col_value::ColValue, mongo::mongo_constant::MongoConstants, pg::pg_value_type::PgValueType,
@@ -30,6 +31,110 @@ use dt_common::{
 
 impl<C: Checker> DataChecker<C> {
     const MAX_DIFF_COLS: usize = 8;
+
+    fn is_missing_target(error: &anyhow::Error) -> bool {
+        matches!(
+            ErrorReport::from_anyhow(error).code,
+            ErrorCode::ObjectNotFound | ErrorCode::DatabaseNotFound
+        )
+    }
+
+    async fn load_source_table_meta(&mut self, source_row: &RowData) -> anyhow::Result<RdbTbMeta> {
+        let meta_manager = self
+            .ctx
+            .extractor_meta_manager
+            .as_mut()
+            .context("source table metadata manager is not initialized")?;
+        Ok(meta_manager
+            .get_tb_meta(&source_row.schema, &source_row.tb)
+            .await?
+            .clone())
+    }
+
+    fn build_missing_target_entry(
+        target_row: &RowData,
+        source_row: &RowData,
+        source_meta: &RdbTbMeta,
+        output_full_row: bool,
+    ) -> anyhow::Result<(u128, CheckEntry)> {
+        let row_key = Self::lookup_match_key(source_row, source_meta)?
+            .context("source row has a NULL key component")?;
+        let key = RecheckKey::from_row_data(source_row, &source_meta.id_cols)?;
+        let target_changed =
+            source_row.schema != target_row.schema || source_row.tb != target_row.tb;
+        let id_col_values = Self::build_id_col_values(source_row, source_meta).unwrap_or_default();
+        let src_row = output_full_row
+            .then(|| Self::clone_row_values(source_row))
+            .flatten();
+        let entry = CheckEntry {
+            key,
+            log: CheckLog {
+                schema: source_row.schema.clone(),
+                tb: source_row.tb.clone(),
+                target_schema: target_changed.then(|| target_row.schema.clone()),
+                target_tb: target_changed.then(|| target_row.tb.clone()),
+                id_col_values,
+                diff_col_values: HashMap::new(),
+                src_row,
+                dst_row: None,
+            },
+            revise_sql: None,
+            diff_cols: None,
+        };
+        Ok((row_key, entry))
+    }
+
+    async fn record_missing_target_rows(
+        &mut self,
+        target_rows: Vec<RowData>,
+    ) -> anyhow::Result<usize> {
+        let first_target_row = target_rows.first().context("checker group is empty")?;
+        let first_source_row = self
+            .ctx
+            .router
+            .as_ref()
+            .map(|router| router.reverse_route_row(first_target_row.clone()))
+            .unwrap_or_else(|| first_target_row.clone());
+        let source_meta = self.load_source_table_meta(&first_source_row).await?;
+        let target_schema = first_target_row.schema.clone();
+        let target_tb = first_target_row.tb.clone();
+        let mut checked_count = 0;
+
+        for target_row in target_rows {
+            let source_row = self
+                .ctx
+                .router
+                .as_ref()
+                .map(|router| router.reverse_route_row(target_row.clone()))
+                .unwrap_or_else(|| target_row.clone());
+            match Self::build_missing_target_entry(
+                &target_row,
+                &source_row,
+                &source_meta,
+                self.ctx.output_full_row,
+            ) {
+                Ok((row_key, entry)) if Self::should_sample_key(self.ctx.sample_rate, row_key) => {
+                    self.store_entry(&target_row, row_key, entry).await;
+                    checked_count += 1;
+                }
+                Ok(_) => {}
+                Err(error) => {
+                    log_warn!(
+                        "Skipping row in missing target table {}.{}: {}",
+                        target_row.schema,
+                        target_row.tb,
+                        error
+                    );
+                    self.ctx.record_row_table_counts(&target_row, 0, 1);
+                    self.ctx.summary.skip_count += 1;
+                }
+            }
+        }
+
+        self.ctx
+            .record_table_counts(&target_schema, &target_tb, checked_count, 0);
+        Ok(checked_count)
+    }
 
     fn build_revise_sql(
         output_revise_sql: bool,
@@ -907,15 +1012,6 @@ impl<C: Checker> DataChecker<C> {
         let mut monitor_task_id = None;
         for rows in grouped {
             let first_row = rows.first().context("checker group is empty")?;
-            let tb_meta = self.checker.load_table_meta(first_row).await?;
-            let prepared_rows = self.prepare_rows_for_fetch(rows, tb_meta.as_ref())?;
-            if prepared_rows.is_empty() {
-                continue;
-            }
-            let rows_to_fetch = prepared_rows.iter().map(|(row, _)| row).collect::<Vec<_>>();
-            let first_row = rows_to_fetch.first().context("checker group is empty")?;
-            let table_schema = first_row.schema.clone();
-            let table_tb = first_row.tb.clone();
             if monitor_task_id.is_none() {
                 let (schema, tb) = match &self.ctx.router {
                     Some(router) => router.reverse_get_tb_map(&first_row.schema, &first_row.tb),
@@ -924,6 +1020,22 @@ impl<C: Checker> DataChecker<C> {
                 monitor_task_id = Some(TaskMonitorHandle::task_id_from_schema_tb(schema, tb))
                     .filter(|id| !id.is_empty());
             }
+            let tb_meta = match self.checker.load_table_meta(first_row).await {
+                Ok(tb_meta) => tb_meta,
+                Err(error) if !self.ctx.is_cdc && Self::is_missing_target(&error) => {
+                    total_checked += self.record_missing_target_rows(rows).await?;
+                    continue;
+                }
+                Err(error) => return Err(error),
+            };
+            let prepared_rows = self.prepare_rows_for_fetch(rows, tb_meta.as_ref())?;
+            if prepared_rows.is_empty() {
+                continue;
+            }
+            let rows_to_fetch = prepared_rows.iter().map(|(row, _)| row).collect::<Vec<_>>();
+            let first_row = rows_to_fetch.first().context("checker group is empty")?;
+            let table_schema = first_row.schema.clone();
+            let table_tb = first_row.tb.clone();
             let dst_rows = self
                 .checker
                 .fetch_rows_by_keys(tb_meta.clone(), &rows_to_fetch)
@@ -983,6 +1095,70 @@ mod tests {
     };
 
     struct NoopChecker;
+
+    #[test]
+    fn missing_target_error_codes_are_recognized() {
+        let database_error = anyhow::Error::new(dt_common::error::DtError::DatabaseNotFound(
+            dt_common::config::config_enums::DbType::Mysql,
+            "test_db".to_string(),
+        ));
+        let table_error = anyhow::Error::new(dt_common::error::DtError::DatabaseObjectNotFound(
+            dt_common::config::config_enums::DbType::Mysql,
+            "test_db.test_tb".to_string(),
+        ));
+
+        assert!(DataChecker::<NoopChecker>::is_missing_target(
+            &database_error
+        ));
+        assert!(DataChecker::<NoopChecker>::is_missing_target(&table_error));
+        assert!(!DataChecker::<NoopChecker>::is_missing_target(
+            &anyhow::anyhow!("network failure")
+        ));
+    }
+
+    #[test]
+    fn missing_target_row_builds_data_miss_from_source_metadata() {
+        let source_row = RowData::new(
+            "source_db".to_string(),
+            "source_tb".to_string(),
+            0,
+            RowType::Insert,
+            None,
+            Some(HashMap::from([
+                ("id".to_string(), ColValue::Long(7)),
+                ("value".to_string(), ColValue::String("src".to_string())),
+            ])),
+        );
+        let mut target_row = source_row.clone();
+        target_row.schema = "target_db".to_string();
+        target_row.tb = "target_tb".to_string();
+        let source_meta = RdbTbMeta {
+            schema: source_row.schema.clone(),
+            tb: source_row.tb.clone(),
+            id_cols: vec!["id".to_string()],
+            ..Default::default()
+        };
+
+        let (_, entry) = DataChecker::<NoopChecker>::build_missing_target_entry(
+            &target_row,
+            &source_row,
+            &source_meta,
+            true,
+        )
+        .unwrap();
+
+        assert!(entry.is_miss());
+        assert_eq!(entry.log.schema, "source_db");
+        assert_eq!(entry.log.tb, "source_tb");
+        assert_eq!(entry.log.target_schema.as_deref(), Some("target_db"));
+        assert_eq!(entry.log.target_tb.as_deref(), Some("target_tb"));
+        assert_eq!(
+            entry.log.id_col_values.get("id"),
+            Some(&Some("7".to_string()))
+        );
+        assert!(entry.log.src_row.is_some());
+        assert!(entry.revise_sql.is_none());
+    }
 
     #[async_trait]
     impl Checker for NoopChecker {

--- a/dt-connector/src/checker/struct_checker.rs
+++ b/dt-connector/src/checker/struct_checker.rs
@@ -1,6 +1,8 @@
-use std::collections::{BTreeMap, HashSet};
-use std::sync::Arc;
-use std::time::Duration;
+use std::{
+    collections::{BTreeMap, HashSet},
+    sync::Arc,
+    time::Duration,
+};
 
 use anyhow::{bail, Context};
 use async_mutex::Mutex;
@@ -169,6 +171,7 @@ impl StructCheckerHandle {
                     dbs: dbs.clone(),
                     filter: Some(self.filter.clone()),
                     meta_manager,
+                    allow_missing_databases: true,
                 };
                 for stmt in fetcher.get_create_database_statements("").await? {
                     dst_map.extend(stmt.to_sqls(&self.filter)?);
@@ -187,6 +190,7 @@ impl StructCheckerHandle {
                     conn_pool,
                     schemas: dbs.clone(),
                     filter: Some(self.filter.clone()),
+                    allow_missing_schemas: true,
                 };
                 if !self.filter.filter_structure(&StructureType::Udt) {
                     for stmt in fetcher.get_udt_statements().await? {
@@ -367,5 +371,41 @@ impl StructCheckerHandle {
             log_summary!("{}", log);
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_target_database_and_table_are_reported_as_miss() {
+        let src_sql_map = BTreeMap::from([
+            (
+                "database.test_db".to_string(),
+                "CREATE DATABASE IF NOT EXISTS `test_db`".to_string(),
+            ),
+            (
+                "table.test_db.test_tb".to_string(),
+                "CREATE TABLE IF NOT EXISTS `test_db`.`test_tb` (`id` int)".to_string(),
+            ),
+        ]);
+
+        let summary = StructCheckerHandle::compare_sql_maps(
+            &src_sql_map,
+            BTreeMap::new(),
+            "start",
+            false,
+            false,
+        );
+
+        assert!(!summary.is_consistent);
+        assert_eq!(summary.checked_count, 2);
+        assert_eq!(summary.miss_count, 2);
+        assert_eq!(summary.diff_count, 0);
+        assert_eq!(summary.tables.len(), 1);
+        assert_eq!(summary.tables[0].schema, "test_db");
+        assert_eq!(summary.tables[0].tb, "test_tb");
+        assert_eq!(summary.tables[0].miss_count, 1);
     }
 }

--- a/dt-connector/src/extractor/mysql/mysql_struct_extractor.rs
+++ b/dt-connector/src/extractor/mysql/mysql_struct_extractor.rs
@@ -59,6 +59,7 @@ impl MysqlStructExtractor {
             dbs,
             filter: Some(self.filter.to_owned()),
             meta_manager,
+            allow_missing_databases: false,
         };
 
         // database

--- a/dt-connector/src/extractor/pg/pg_struct_extractor.rs
+++ b/dt-connector/src/extractor/pg/pg_struct_extractor.rs
@@ -67,6 +67,7 @@ impl PgStructExtractor {
             conn_pool: self.conn_pool.to_owned(),
             schemas,
             filter: Some(self.filter.to_owned()),
+            allow_missing_schemas: false,
         };
 
         // User-Defined Type

--- a/dt-connector/src/meta_fetcher/mysql/mysql_struct_fetcher.rs
+++ b/dt-connector/src/meta_fetcher/mysql/mysql_struct_fetcher.rs
@@ -35,6 +35,7 @@ pub struct MysqlStructFetcher {
     pub dbs: HashSet<String>,
     pub filter: Option<RdbFilter>,
     pub meta_manager: MysqlMetaManager,
+    pub allow_missing_databases: bool,
 }
 
 impl MysqlStructFetcher {
@@ -123,7 +124,7 @@ impl MysqlStructFetcher {
             .filter(|&s| !dbs.contains_key(s))
             .cloned()
             .collect();
-        if !filtered_dbs.is_empty() {
+        if !self.allow_missing_databases && !filtered_dbs.is_empty() {
             bail! {DtError::DatabaseNotFound(DbType::Mysql, format!(
                 "dbs: {} not found",
                 filtered_dbs.join(",")

--- a/dt-connector/src/meta_fetcher/pg/pg_struct_fetcher.rs
+++ b/dt-connector/src/meta_fetcher/pg/pg_struct_fetcher.rs
@@ -38,6 +38,7 @@ pub struct PgStructFetcher {
     pub conn_pool: Pool<Postgres>,
     pub schemas: HashSet<String>,
     pub filter: Option<RdbFilter>,
+    pub allow_missing_schemas: bool,
 }
 
 enum ColType {
@@ -196,7 +197,7 @@ impl PgStructFetcher {
             .filter(|&s| !schemas.contains(s))
             .cloned()
             .collect();
-        if !filtered_schemas.is_empty() {
+        if !self.allow_missing_schemas && !filtered_schemas.is_empty() {
             bail! {DtError::DatabaseObjectNotFound(DbType::Pg, format!(
                 "schemas: {} not found",
                 filtered_schemas.join(",")

--- a/dt-parallelizer/src/rdb_merger.rs
+++ b/dt-parallelizer/src/rdb_merger.rs
@@ -5,7 +5,7 @@ use dt_common::meta::{
     rdb_meta_manager::RdbMetaManager, rdb_tb_meta::RdbTbMeta, row_data::RowData, row_type::RowType,
 };
 use dt_common::{
-    error::{DtResultExt, ErrorCode},
+    error::{DtResultExt, ErrorCode, ErrorReport},
     log_debug,
 };
 
@@ -13,6 +13,7 @@ use crate::{merge_parallelizer::TbMergedData, Merger};
 
 pub struct RdbMerger {
     pub rdb_meta_manager: RdbMetaManager,
+    pub allow_missing_meta: bool,
 }
 
 #[async_trait]
@@ -60,10 +61,24 @@ impl RdbMerger {
             return Ok(());
         }
 
-        let tb_meta = self
+        let tb_meta = match self
             .rdb_meta_manager
             .get_tb_meta(&row_data.schema, &row_data.tb)
-            .await?;
+            .await
+        {
+            Ok(tb_meta) => tb_meta,
+            Err(error)
+                if self.allow_missing_meta
+                    && matches!(
+                        ErrorReport::from_anyhow(&error).code,
+                        ErrorCode::ObjectNotFound | ErrorCode::DatabaseNotFound
+                    ) =>
+            {
+                merged.unmerged_rows.push(row_data);
+                return Ok(());
+            }
+            Err(error) => return Err(error),
+        };
 
         if row_data.contains_unchanged_toast() {
             merged.unmerged_rows.push(row_data);

--- a/dt-task/src/parallelizer_util.rs
+++ b/dt-task/src/parallelizer_util.rs
@@ -104,7 +104,13 @@ impl ParallelizerUtil {
                 )
             })?;
 
-        let rdb_merger = RdbMerger { rdb_meta_manager };
+        let allow_missing_meta = config
+            .task_type()
+            .is_some_and(|task_type| task_type.is_standalone_snapshot_check());
+        let rdb_merger = RdbMerger {
+            rdb_meta_manager,
+            allow_missing_meta,
+        };
         Ok(Box::new(rdb_merger))
     }
 

--- a/log4rs.yaml
+++ b/log4rs.yaml
@@ -106,6 +106,9 @@ appenders:
       - kind: size_limit
         path: "CHECK_LOG_DIR_PLACEHOLDER/miss.log"
         limit: CHECK_LOG_FILE_SIZE_PLACEHOLDER
+      - kind: row_limit
+        path: "CHECK_LOG_DIR_PLACEHOLDER/miss.log"
+        limit: CHECK_LOG_MAX_ROWS_PLACEHOLDER
     encoder:
       pattern: "{m}{n}"
 
@@ -117,6 +120,9 @@ appenders:
       - kind: size_limit
         path: "CHECK_LOG_DIR_PLACEHOLDER/diff.log"
         limit: CHECK_LOG_FILE_SIZE_PLACEHOLDER
+      - kind: row_limit
+        path: "CHECK_LOG_DIR_PLACEHOLDER/diff.log"
+        limit: CHECK_LOG_MAX_ROWS_PLACEHOLDER
     encoder:
       pattern: "{m}{n}"
 


### PR DESCRIPTION
- Previously:
  - Struct check stopped when the target database/schema did not exist, so missing structures were not reported correctly.
  - Snapshot check failed when the target database/schema/table did not exist, instead of reporting the source rows as missing.
- Now:
  - Struct check reports the missing database/schema and all related structures in miss.log.
  - Snapshot check reports all source rows from the missing target table in miss.log.
Both checks complete normally without being interrupted by missing target objects.