### PR TITLE
chore: add rustfmt.toml for import format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,10 +40,15 @@ jobs:
         with:
           submodules: true
 
+      - name: Setup nightly rustfmt
+        uses: dtolnay/rust-toolchain@nightly-2025-10-30
+        with:
+          components: rustfmt
+
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          components: rustfmt, clippy
+          components: clippy
 
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
@@ -56,7 +61,7 @@ jobs:
         run: |
           cargo metadata --format-version 1 --no-deps \
             | jq -r '.packages[] | select(.name != "dt-tests") | "--package", .name' \
-            | xargs -r cargo fmt --check
+            | xargs -r cargo +nightly-2025-10-30 fmt --check
 
       - name: Run lint checks (clippy)
         id: lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,9 +59,14 @@ jobs:
       - name: Check formatting (rustfmt)
         id: fmt
         run: |
-          cargo metadata --format-version 1 --no-deps \
-            | jq -r '.packages[] | select(.name != "dt-tests") | "--package", .name' \
-            | xargs -r cargo +nightly-2025-10-30 fmt --check
+          if cargo metadata --format-version 1 --no-deps \
+              | jq -r '.packages[] | select(.name != "dt-tests") | "--package", .name' \
+              | xargs -r cargo +nightly-2025-10-30 fmt --check; then
+            echo "has_issues=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_issues=true" >> "$GITHUB_OUTPUT"
+            echo "::warning title=rustfmt::Code formatting issues detected. Run 'make format' locally."
+          fi
 
       - name: Run lint checks (clippy)
         id: lint
@@ -82,19 +87,18 @@ jobs:
           echo "## 🔍 Lint & Static Check Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
-          # Overall status check
-          if [ "${{ steps.fmt.outcome }}" == "success" ] && \
-             [ "${{ steps.lint.outcome }}" == "success" ] && \
+          # Overall status check (formatting is advisory)
+          if [ "${{ steps.lint.outcome }}" == "success" ] && \
              [ "${{ steps.check.outcome }}" == "success" ]; then
-            echo "✅ **All checks passed!**" >> $GITHUB_STEP_SUMMARY
-            exit 0
+            echo "✅ **All required checks passed!**" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "❌ **One or more required checks failed.**" >> $GITHUB_STEP_SUMMARY
           fi
 
-          echo "❌ **One or more checks failed.**" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
           # Individual check results
-          [ "${{ steps.fmt.outcome }}" == "failure" ] && echo "❌ **rustfmt:** Code formatting issues detected." >> $GITHUB_STEP_SUMMARY
+          [ "${{ steps.fmt.outputs.has_issues }}" == "true" ] && echo "⚠️ **rustfmt:** Code formatting issues detected; run \`make format\` locally." >> $GITHUB_STEP_SUMMARY
           [ "${{ steps.lint.outcome }}" == "failure" ] && echo "❌ **Clippy:** Code quality issues detected." >> $GITHUB_STEP_SUMMARY
           [ "${{ steps.check.outcome }}" == "failure" ] && echo "❌ **cargo check:** Compilation errors detected." >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,9 @@ jobs:
           submodules: true
 
       - name: Setup nightly rustfmt
-        uses: dtolnay/rust-toolchain@nightly-2025-10-30
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: nightly-2025-10-30
           components: rustfmt
 
       - name: Setup Rust toolchain

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,14 +60,9 @@ jobs:
       - name: Check formatting (rustfmt)
         id: fmt
         run: |
-          if cargo metadata --format-version 1 --no-deps \
-              | jq -r '.packages[] | select(.name != "dt-tests") | "--package", .name' \
-              | xargs -r cargo +nightly-2025-10-30 fmt --check; then
-            echo "has_issues=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_issues=true" >> "$GITHUB_OUTPUT"
-            echo "::warning title=rustfmt::Code formatting issues detected. Run 'make format' locally."
-          fi
+          cargo metadata --format-version 1 --no-deps \
+            | jq -r '.packages[] | select(.name != "dt-tests") | "--package", .name' \
+            | xargs -r cargo +nightly-2025-10-30 fmt --check
 
       - name: Run lint checks (clippy)
         id: lint
@@ -88,18 +83,19 @@ jobs:
           echo "## 🔍 Lint & Static Check Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
-          # Overall status check (formatting is advisory)
-          if [ "${{ steps.lint.outcome }}" == "success" ] && \
+          # Overall status check
+          if [ "${{ steps.fmt.outcome }}" == "success" ] && \
+             [ "${{ steps.lint.outcome }}" == "success" ] && \
              [ "${{ steps.check.outcome }}" == "success" ]; then
-            echo "✅ **All required checks passed!**" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "❌ **One or more required checks failed.**" >> $GITHUB_STEP_SUMMARY
+            echo "✅ **All checks passed!**" >> $GITHUB_STEP_SUMMARY
+            exit 0
           fi
 
+          echo "❌ **One or more checks failed.**" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
           # Individual check results
-          [ "${{ steps.fmt.outputs.has_issues }}" == "true" ] && echo "⚠️ **rustfmt:** Code formatting issues detected; run \`make format\` locally." >> $GITHUB_STEP_SUMMARY
+          [ "${{ steps.fmt.outcome }}" == "failure" ] && echo "❌ **rustfmt:** Code formatting issues detected." >> $GITHUB_STEP_SUMMARY
           [ "${{ steps.lint.outcome }}" == "failure" ] && echo "❌ **Clippy:** Code quality issues detected." >> $GITHUB_STEP_SUMMARY
           [ "${{ steps.check.outcome }}" == "failure" ] && echo "❌ **cargo check:** Compilation errors detected." >> $GITHUB_STEP_SUMMARY
 

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,7 @@ help: ## Display this help.
 ##@ Development
 
 CARGO_BUILD_ARGS ?=
+RUSTFMT_TOOLCHAIN ?= nightly-2025-10-30
 
 .PHONY: init
 init: ## Build
@@ -92,8 +93,16 @@ build-release: ## Build release
 clean: ## Clean
 	cargo clean
 
+.PHONY: format
+format: ## Format Rust code
+	cargo +$(RUSTFMT_TOOLCHAIN) fmt --all
+
+.PHONY: format-check
+format-check: ## Check Rust code formatting
+	cargo +$(RUSTFMT_TOOLCHAIN) fmt --all --check
+
 .PHONY: lint
-lint: ## Run code linting
+lint: format-check ## Run code linting
 	cargo clippy --workspace
 
 .PHONY: test 

--- a/dt-cli/src/config.rs
+++ b/dt-cli/src/config.rs
@@ -498,8 +498,9 @@ fn randomish_u64() -> u64 {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use dt_common::config::task_config::TaskConfig;
+
+    use super::*;
 
     fn paths() -> (&'static Path, &'static Path) {
         (

--- a/dt-common/src/config/config_token_parser.rs
+++ b/dt-common/src/config/config_token_parser.rs
@@ -1,8 +1,7 @@
 use anyhow::bail;
 
-use crate::{error::DtError, utils::sql_util::SqlUtil};
-
 use super::config_enums::DbType;
+use crate::{error::DtError, utils::sql_util::SqlUtil};
 
 #[derive(Debug, Clone)]
 pub enum TokenEscapePair {

--- a/dt-common/src/config/connection_auth_config.rs
+++ b/dt-common/src/config/connection_auth_config.rs
@@ -2,9 +2,8 @@ use anyhow::{Context, Result};
 use url::Url;
 use urlencoding::encode;
 
-use crate::{config::ini_loader::IniLoader, error::DtError};
-
 use super::ssl_config::SslConfig;
+use crate::{config::ini_loader::IniLoader, error::DtError};
 
 const BASIC_AUTH_USERNAME_KEY: &str = "username";
 const BASIC_AUTH_PASSWORD_KEY: &str = "password";

--- a/dt-common/src/config/extractor_config.rs
+++ b/dt-common/src/config/extractor_config.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use super::config_enums::{DbType, ExtractType};
 use crate::{
     config::{
         config_enums::RdbParallelType, connection_auth_config::ConnectionAuthConfig,
@@ -7,8 +8,6 @@ use crate::{
     },
     meta::mongo::mongo_cdc_source::MongoCdcSource,
 };
-
-use super::config_enums::{DbType, ExtractType};
 
 #[derive(Clone, Debug)]
 pub enum ExtractorConfig {

--- a/dt-common/src/config/meta_center_config.rs
+++ b/dt-common/src/config/meta_center_config.rs
@@ -1,6 +1,5 @@
-use crate::config::connection_auth_config::ConnectionAuthConfig;
-
 use super::config_enums::ConflictPolicyEnum;
+use crate::config::connection_auth_config::ConnectionAuthConfig;
 
 #[derive(Clone, Debug, Default)]
 pub enum MetaCenterConfig {

--- a/dt-common/src/config/task_config.rs
+++ b/dt-common/src/config/task_config.rs
@@ -2,22 +2,6 @@ use std::{collections::HashMap, fs, io::ErrorKind};
 
 use anyhow::{bail, Error, Ok};
 
-#[cfg(feature = "metrics")]
-use crate::config::metrics_config::MetricsConfig;
-use crate::{
-    config::{
-        config_enums::{RdbParallelType, ResumeType},
-        connection_auth_config::ConnectionAuthConfig,
-        global_config::GlobalConfig,
-        limiter_config::{CapacityLimiterConfig, RateLimiterConfig},
-    },
-    error::{DtError, DtOptionExt, DtResultExt},
-    meta::{
-        mongo::mongo_cdc_source::MongoCdcSource, mssql::mssql_connection_pool::MssqlConnectionPool,
-    },
-    utils::task_util::TaskUtil,
-};
-
 use super::{
     checker_config::{
         CheckerConfig, CheckerOutputConfig, CheckerOutputType, InlineCheckConfig,
@@ -43,6 +27,21 @@ use super::{
     runtime_config::RuntimeConfig,
     sinker_config::{BasicSinkerConfig, SinkerConfig},
     tracing_config::TracingConfig,
+};
+#[cfg(feature = "metrics")]
+use crate::config::metrics_config::MetricsConfig;
+use crate::{
+    config::{
+        config_enums::{RdbParallelType, ResumeType},
+        connection_auth_config::ConnectionAuthConfig,
+        global_config::GlobalConfig,
+        limiter_config::{CapacityLimiterConfig, RateLimiterConfig},
+    },
+    error::{DtError, DtOptionExt, DtResultExt},
+    meta::{
+        mongo::mongo_cdc_source::MongoCdcSource, mssql::mssql_connection_pool::MssqlConnectionPool,
+    },
+    utils::task_util::TaskUtil,
 };
 
 #[derive(Clone)]
@@ -1480,16 +1479,15 @@ mod tests {
         sync::atomic::{AtomicU64, Ordering},
     };
 
+    use super::{
+        CheckMode, DbType, ExtractorConfig, ParallelType, RdbParallelType, SinkerConfig,
+        TaskConfig, TaskKind, TaskType,
+    };
     use crate::config::parallelizer_config::{
         ChunkPartitionerRebalanceCost, ChunkPartitionerRebalanceStrategy,
     };
     use crate::error::{ErrorCode, ErrorReport};
     use crate::runtime_trace::{TaskSummaryMode, TraceOutputFormat};
-
-    use super::{
-        CheckMode, DbType, ExtractorConfig, ParallelType, RdbParallelType, SinkerConfig,
-        TaskConfig, TaskKind, TaskType,
-    };
 
     static NEXT_CONFIG_ID: AtomicU64 = AtomicU64::new(0);
 

--- a/dt-common/src/config/task_config.rs
+++ b/dt-common/src/config/task_config.rs
@@ -1,6 +1,5 @@
-use std::{collections::HashMap, fs, io::ErrorKind};
-
 use anyhow::{bail, Error, Ok};
+use std::{collections::HashMap, fs, io::ErrorKind};
 
 use super::{
     checker_config::{

--- a/dt-common/src/config/task_config.rs
+++ b/dt-common/src/config/task_config.rs
@@ -1,5 +1,6 @@
-use anyhow::{bail, Error, Ok};
 use std::{collections::HashMap, fs, io::ErrorKind};
+
+use anyhow::{bail, Error, Ok};
 
 use super::{
     checker_config::{

--- a/dt-common/src/error/dt_error.rs
+++ b/dt-common/src/error/dt_error.rs
@@ -1,6 +1,5 @@
-use crate::config::config_enums::DbType;
-
 use super::{ClassifyError, DtErrorContext, ErrorCode, Stage};
+use crate::config::config_enums::DbType;
 
 #[derive(Clone, Debug, thiserror::Error)]
 pub enum DtError {

--- a/dt-common/src/error/error_context.rs
+++ b/dt-common/src/error/error_context.rs
@@ -210,10 +210,12 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::io::{Error, ErrorKind};
+
+    use anyhow::Context;
+
     use super::*;
     use crate::error::ErrorReport;
-    use anyhow::Context;
-    use std::io::{Error, ErrorKind};
 
     #[test]
     fn option_or_dt_error_returns_value() {

--- a/dt-common/src/error/report.rs
+++ b/dt-common/src/error/report.rs
@@ -177,9 +177,8 @@ mod tests {
     use chrono::DateTime;
     use url::Url;
 
-    use crate::error::{DtError, DtErrorContext, DtErrorContextExt};
-
     use super::*;
+    use crate::error::{DtError, DtErrorContext, DtErrorContextExt};
 
     #[test]
     fn preserves_structured_error_through_anyhow_context() {

--- a/dt-common/src/meta/adaptor/mysql_col_value_convertor.rs
+++ b/dt-common/src/meta/adaptor/mysql_col_value_convertor.rs
@@ -3,11 +3,10 @@ use std::io::Cursor;
 use anyhow::bail;
 use byteorder::{LittleEndian, ReadBytesExt};
 use chrono::{TimeZone, Utc};
-use sqlx::{mysql::MySqlRow, types::BigDecimal, Row};
-
 use mysql_binlog_connector_rust::column::{
     column_value::ColumnValue, json::json_binary::JsonBinary,
 };
+use sqlx::{mysql::MySqlRow, types::BigDecimal, Row};
 
 use crate::{
     config::config_enums::DbType,

--- a/dt-common/src/meta/avro/avro_converter.rs
+++ b/dt-common/src/meta/avro/avro_converter.rs
@@ -3,6 +3,7 @@ use std::{collections::HashMap, str::FromStr};
 use anyhow::Context;
 use apache_avro::{from_avro_datum, to_avro_datum, types::Value, Schema};
 
+use super::avro_converter_schema::{AvroConverterSchema, AvroFieldDef};
 use crate::{
     config::config_enums::DbType,
     error::DtError,
@@ -16,8 +17,6 @@ use crate::{
         row_type::RowType,
     },
 };
-
-use super::avro_converter_schema::{AvroConverterSchema, AvroFieldDef};
 
 #[derive(Clone)]
 pub struct AvroConverter {

--- a/dt-common/src/meta/col_value.rs
+++ b/dt-common/src/meta/col_value.rs
@@ -454,10 +454,11 @@ impl From<Bson> for ColValue {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use super::*;
     use crate::meta::tagged_col_value_map;
     use crate::meta::tagged_col_value_map::TaggedColValueDef as MetaTaggedColValueDef;
-    use std::collections::BTreeMap;
 
     #[test]
     fn test_is_same_value() {

--- a/dt-common/src/meta/dcl_meta/dcl_parser.rs
+++ b/dt-common/src/meta/dcl_meta/dcl_parser.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use anyhow::bail;
 use nom::branch::alt;
 use nom::bytes::complete::tag_no_case;
@@ -5,7 +7,6 @@ use nom::character::complete::{multispace0, multispace1};
 use nom::sequence::tuple;
 use nom::IResult;
 use regex::Regex;
-use std::borrow::Cow;
 
 use crate::{
     config::config_enums::DbType,

--- a/dt-common/src/meta/ddl_meta/ddl_data.rs
+++ b/dt-common/src/meta/ddl_meta/ddl_data.rs
@@ -1,9 +1,8 @@
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
-use crate::config::config_enums::DbType;
-
 use super::{ddl_statement::DdlStatement, ddl_type::DdlType};
+use crate::config::config_enums::DbType;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
 pub struct DdlData {

--- a/dt-common/src/meta/ddl_meta/ddl_parser.rs
+++ b/dt-common/src/meta/ddl_meta/ddl_parser.rs
@@ -18,8 +18,6 @@ use nom::{
 };
 use regex::Regex;
 
-use crate::error::DtError;
-
 use super::{
     ddl_data::DdlData,
     ddl_statement::{
@@ -37,6 +35,7 @@ use super::{
         keyword_s_to_z,
     },
 };
+use crate::error::DtError;
 use crate::{config::config_enums::DbType, utils::sql_util::SqlUtil};
 
 type SchemaTable = (Option<Vec<u8>>, Vec<u8>);
@@ -1043,9 +1042,8 @@ fn to_string(i: &[u8]) -> String {
 #[cfg(test)]
 mod test_mysql {
 
-    use crate::{config::config_enums::DbType, meta::ddl_meta::ddl_parser::DdlParser};
-
     use super::*;
+    use crate::{config::config_enums::DbType, meta::ddl_meta::ddl_parser::DdlParser};
 
     #[test]
     fn test_create_table_with_schema_mysql() {

--- a/dt-common/src/meta/mongo/mongo_cdc_source.rs
+++ b/dt-common/src/meta/mongo/mongo_cdc_source.rs
@@ -1,5 +1,6 @@
-use crate::error::{DtError, DtErrorContextExt, Stage};
 use strum::IntoStaticStr;
+
+use crate::error::{DtError, DtErrorContextExt, Stage};
 
 #[derive(Clone, IntoStaticStr, Debug)]
 pub enum MongoCdcSource {

--- a/dt-common/src/meta/mongo/mongo_ddl.rs
+++ b/dt-common/src/meta/mongo/mongo_ddl.rs
@@ -265,8 +265,9 @@ fn index_name_from_bson(index: &Bson) -> Option<Bson> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use mongodb::bson::{doc, raw::RawDocumentBuf};
+
+    use super::*;
 
     #[test]
     fn shard_collection_ddl_round_trips_command() {

--- a/dt-common/src/meta/mysql/mysql_dbengine_meta_center.rs
+++ b/dt-common/src/meta/mysql/mysql_dbengine_meta_center.rs
@@ -6,13 +6,12 @@ use sqlx::{
     MySql, Pool,
 };
 
+use super::mysql_meta_fetcher::MysqlMetaFetcher;
 use crate::{
     config::{config_enums::ConflictPolicyEnum, connection_auth_config::ConnectionAuthConfig},
     log_error, log_info,
     meta::ddl_meta::{ddl_data::DdlData, ddl_type::DdlType},
 };
-
-use super::mysql_meta_fetcher::MysqlMetaFetcher;
 
 #[derive(Clone)]
 pub struct MysqlDbEngineMetaCenter {

--- a/dt-common/src/meta/mysql/mysql_meta_fetcher.rs
+++ b/dt-common/src/meta/mysql/mysql_meta_fetcher.rs
@@ -1,7 +1,7 @@
-use futures::TryStreamExt;
 use std::collections::{HashMap, HashSet};
 
 use anyhow::{bail, Ok};
+use futures::TryStreamExt;
 use sqlx::{mysql::MySqlRow, MySql, Pool, Row};
 
 use super::{mysql_col_type::MysqlColType, mysql_tb_meta::MysqlTbMeta};

--- a/dt-common/src/meta/mysql/mysql_tb_meta.rs
+++ b/dt-common/src/meta/mysql/mysql_tb_meta.rs
@@ -3,13 +3,12 @@ use std::collections::HashMap;
 use serde::Serialize;
 use serde_json::json;
 
+use super::mysql_col_type::MysqlColType;
 use crate::meta::rdb_tb_meta::RdbTbMeta;
 use crate::{
     config::config_enums::DbType,
     error::{DtError, DtOptionExt, DtResultExt, ErrorObject},
 };
-
-use super::mysql_col_type::MysqlColType;
 
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct MysqlTbMeta {

--- a/dt-common/src/meta/pg/pg_col_type.rs
+++ b/dt-common/src/meta/pg/pg_col_type.rs
@@ -1,6 +1,7 @@
-use super::pg_value_type::{PgValueType, BPCHAR_OID, TEXT_OID, VARCHAR_OID};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+
+use super::pg_value_type::{PgValueType, BPCHAR_OID, TEXT_OID, VARCHAR_OID};
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct PgColType {

--- a/dt-common/src/meta/pg/pg_meta_manager.rs
+++ b/dt-common/src/meta/pg/pg_meta_manager.rs
@@ -1,20 +1,19 @@
 use std::collections::{HashMap, HashSet};
 
+use anyhow::bail;
+use futures::TryStreamExt;
+use sqlx::{Pool, Postgres, Row};
+
+use super::{pg_col_type::PgColType, pg_tb_meta::PgTbMeta, type_registry::TypeRegistry};
+use crate::meta::{
+    foreign_key::ForeignKey, rdb_meta_manager::RdbMetaManager, rdb_tb_meta::RdbTbMeta,
+    row_data::RowData,
+};
 use crate::{
     config::config_enums::DbType,
     error::{DtError, DtErrorContextExt, DtOptionExt, DtResultExt, ErrorObject},
     meta::{ddl_meta::ddl_data::DdlData, rdb_meta_manager::RDB_PRIMARY_KEY_FLAG},
 };
-use anyhow::bail;
-use futures::TryStreamExt;
-use sqlx::{Pool, Postgres, Row};
-
-use crate::meta::{
-    foreign_key::ForeignKey, rdb_meta_manager::RdbMetaManager, rdb_tb_meta::RdbTbMeta,
-    row_data::RowData,
-};
-
-use super::{pg_col_type::PgColType, pg_tb_meta::PgTbMeta, type_registry::TypeRegistry};
 
 #[derive(Clone)]
 pub struct PgMetaManager {

--- a/dt-common/src/meta/pg/pg_tb_meta.rs
+++ b/dt-common/src/meta/pg/pg_tb_meta.rs
@@ -3,13 +3,12 @@ use std::collections::HashMap;
 use serde::Serialize;
 use serde_json::json;
 
+use super::pg_col_type::PgColType;
 use crate::meta::rdb_tb_meta::RdbTbMeta;
 use crate::{
     config::config_enums::DbType,
     error::{DtError, DtOptionExt, DtResultExt, ErrorObject},
 };
-
-use super::pg_col_type::PgColType;
 
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct PgTbMeta {

--- a/dt-common/src/meta/pg/type_registry.rs
+++ b/dt-common/src/meta/pg/type_registry.rs
@@ -1,10 +1,10 @@
-use futures::TryStreamExt;
-use sqlx::{postgres::PgRow, Pool, Postgres, Row};
 use std::collections::HashMap;
 
-use crate::error::{DtResultExt, ErrorCode};
+use futures::TryStreamExt;
+use sqlx::{postgres::PgRow, Pool, Postgres, Row};
 
 use super::{pg_col_type::PgColType, pg_value_type::PgValueType};
+use crate::error::{DtResultExt, ErrorCode};
 
 #[derive(Clone)]
 pub struct TypeRegistry {

--- a/dt-common/src/meta/rdb_meta_manager.rs
+++ b/dt-common/src/meta/rdb_meta_manager.rs
@@ -2,12 +2,11 @@ use std::collections::{HashMap, HashSet};
 
 use anyhow::bail;
 
-use crate::error::DtError;
-
 use super::{
     ddl_meta::ddl_data::DdlData, mysql::mysql_meta_manager::MysqlMetaManager,
     pg::pg_meta_manager::PgMetaManager, rdb_tb_meta::RdbTbMeta,
 };
+use crate::error::DtError;
 
 pub const RDB_PRIMARY_KEY_FLAG: &str = "primary";
 

--- a/dt-common/src/meta/redis/command/key_parser.rs
+++ b/dt-common/src/meta/redis/command/key_parser.rs
@@ -2,12 +2,11 @@ use std::collections::{HashMap, HashSet};
 
 use anyhow::{bail, Context};
 
+use super::{cmd_constants::CmdConstants, cmd_meta::CmdMeta};
 use crate::{
     config::config_enums::DbType,
     error::{DtError, DtOptionExt},
 };
-
-use super::{cmd_constants::CmdConstants, cmd_meta::CmdMeta};
 
 pub struct KeyParser {
     pub container_cmds: HashSet<String>,

--- a/dt-common/src/meta/struct_meta/statement/mysql_create_database_statement.rs
+++ b/dt-common/src/meta/struct_meta/statement/mysql_create_database_statement.rs
@@ -1,6 +1,5 @@
-use crate::rdb_filter::RdbFilter;
-
 use crate::meta::struct_meta::structure::{database::Database, structure_type::StructureType};
+use crate::rdb_filter::RdbFilter;
 
 #[derive(Debug, Clone)]
 pub struct MysqlCreateDatabaseStatement {

--- a/dt-common/src/meta/struct_meta/statement/mysql_create_table_statement.rs
+++ b/dt-common/src/meta/struct_meta/statement/mysql_create_table_statement.rs
@@ -1,6 +1,4 @@
 use crate::meta::struct_meta::structure::column::ColumnDefault;
-use crate::{config::config_enums::DbType, rdb_filter::RdbFilter};
-
 use crate::meta::struct_meta::structure::index::IndexType;
 use crate::meta::struct_meta::structure::{
     column::Column,
@@ -9,6 +7,7 @@ use crate::meta::struct_meta::structure::{
     structure_type::StructureType,
     table::Table,
 };
+use crate::{config::config_enums::DbType, rdb_filter::RdbFilter};
 
 #[derive(Debug, Clone)]
 pub struct MysqlCreateTableStatement {

--- a/dt-common/src/meta/struct_meta/statement/pg_create_rbac_statement.rs
+++ b/dt-common/src/meta/struct_meta/statement/pg_create_rbac_statement.rs
@@ -1,8 +1,7 @@
-use crate::rdb_filter::RdbFilter;
-
 use crate::meta::struct_meta::structure::{
     rbac::PgPrivilege, rbac::PgRole, rbac::PgRoleMember, structure_type::StructureType,
 };
+use crate::rdb_filter::RdbFilter;
 
 #[derive(Debug, Clone)]
 pub struct PgCreateRbacStatement {
@@ -119,13 +118,14 @@ impl PgCreateRbacStatement {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::{HashMap, HashSet};
+
     use dashmap::DashMap;
 
     use super::*;
     use crate::config::config_enums::DbType;
     use crate::meta::struct_meta::structure::rbac::{PgPrivilege, PgRole, PgRoleMember};
     use crate::rdb_filter::RdbFilter;
-    use std::collections::{HashMap, HashSet};
 
     fn build_filter() -> RdbFilter {
         let mut filter = RdbFilter {

--- a/dt-common/src/meta/struct_meta/statement/pg_create_schema_statement.rs
+++ b/dt-common/src/meta/struct_meta/statement/pg_create_schema_statement.rs
@@ -1,6 +1,5 @@
-use crate::rdb_filter::RdbFilter;
-
 use crate::meta::struct_meta::structure::{schema::Schema, structure_type::StructureType};
+use crate::rdb_filter::RdbFilter;
 
 #[derive(Debug, Clone)]
 pub struct PgCreateSchemaStatement {

--- a/dt-common/src/meta/struct_meta/statement/pg_create_table_statement.rs
+++ b/dt-common/src/meta/struct_meta/statement/pg_create_table_statement.rs
@@ -5,8 +5,6 @@ use crate::error::DtError;
 use crate::meta::ddl_meta::ddl_parser::DdlParser;
 use crate::meta::ddl_meta::ddl_statement::DdlStatement;
 use crate::meta::struct_meta::structure::column::ColumnDefault;
-use crate::rdb_filter::RdbFilter;
-
 use crate::meta::struct_meta::structure::{
     column::Column,
     comment::Comment,
@@ -17,6 +15,7 @@ use crate::meta::struct_meta::structure::{
     structure_type::StructureType,
     table::Table,
 };
+use crate::rdb_filter::RdbFilter;
 
 #[derive(Debug, Clone)]
 pub struct PgCreateTableStatement {

--- a/dt-common/src/meta/struct_meta/statement/pg_create_udf_statement.rs
+++ b/dt-common/src/meta/struct_meta/statement/pg_create_udf_statement.rs
@@ -1,7 +1,6 @@
+use crate::meta::struct_meta::structure::structure_type::StructureType;
 use crate::meta::struct_meta::structure::user_defined::PgUdf;
 use crate::rdb_filter::RdbFilter;
-
-use crate::meta::struct_meta::structure::structure_type::StructureType;
 
 #[derive(Debug, Clone)]
 pub struct PgCreateUdfStatement {

--- a/dt-common/src/meta/struct_meta/statement/pg_create_udt_statement.rs
+++ b/dt-common/src/meta/struct_meta/statement/pg_create_udt_statement.rs
@@ -1,7 +1,6 @@
+use crate::meta::struct_meta::structure::structure_type::StructureType;
 use crate::meta::struct_meta::structure::user_defined::PgUdt;
 use crate::rdb_filter::RdbFilter;
-
-use crate::meta::struct_meta::structure::structure_type::StructureType;
 
 #[derive(Debug, Clone)]
 pub struct PgCreateUdtStatement {

--- a/dt-common/src/meta/struct_meta/statement/struct_statement.rs
+++ b/dt-common/src/meta/struct_meta/statement/struct_statement.rs
@@ -1,11 +1,3 @@
-use crate::{
-    meta::struct_meta::statement::{
-        pg_create_udf_statement::PgCreateUdfStatement,
-        pg_create_udt_statement::PgCreateUdtStatement,
-    },
-    rdb_filter::RdbFilter,
-};
-
 use super::{
     mongo_create_collection_statement::MongoCreateCollectionStatement,
     mongo_shard_key_statement::MongoShardKeyStatement,
@@ -14,6 +6,13 @@ use super::{
     pg_create_rbac_statement::PgCreateRbacStatement,
     pg_create_schema_statement::PgCreateSchemaStatement,
     pg_create_table_statement::PgCreateTableStatement,
+};
+use crate::{
+    meta::struct_meta::statement::{
+        pg_create_udf_statement::PgCreateUdfStatement,
+        pg_create_udt_statement::PgCreateUdtStatement,
+    },
+    rdb_filter::RdbFilter,
 };
 
 #[derive(Debug, Clone, Default)]

--- a/dt-common/src/monitor/monitor.rs
+++ b/dt-common/src/monitor/monitor.rs
@@ -1,8 +1,8 @@
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use dashmap::DashMap;
-use std::sync::Arc;
 
 use super::counter::Counter;
 use super::counter_type::{CounterType, WindowType};

--- a/dt-common/src/monitor/prometheus_metrics.rs
+++ b/dt-common/src/monitor/prometheus_metrics.rs
@@ -386,9 +386,8 @@ mod tests {
 
     use prometheus::TextEncoder;
 
-    use crate::{config::metrics_config::MetricsConfig, monitor::task_metrics::TaskMetricsType};
-
     use super::PrometheusMetrics;
+    use crate::{config::metrics_config::MetricsConfig, monitor::task_metrics::TaskMetricsType};
 
     #[test]
     fn exports_sinker_worker_metrics_with_public_units() -> anyhow::Result<()> {

--- a/dt-common/src/monitor/runtime_trace_monitor.rs
+++ b/dt-common/src/monitor/runtime_trace_monitor.rs
@@ -1,10 +1,9 @@
-use async_trait::async_trait;
-
 #[cfg(all(feature = "metrics", feature = "tracing"))]
 use std::sync::{Arc, Mutex};
 
 #[cfg(all(feature = "metrics", feature = "tracing"))]
 use anyhow::Context;
+use async_trait::async_trait;
 #[cfg(all(feature = "metrics", feature = "tracing"))]
 use prometheus::{core::Collector, CounterVec, IntCounterVec, Opts, Registry};
 

--- a/dt-common/src/monitor/task_monitor.rs
+++ b/dt-common/src/monitor/task_monitor.rs
@@ -896,6 +896,8 @@ fn calc_nowindow_metrics(
 
 #[cfg(test)]
 mod sinker_worker_tests {
+    use std::{collections::BTreeMap, sync::Arc};
+
     use super::{collect_sinker_worker_metrics, MonitorType, TaskMonitor};
     use crate::{
         config::config_enums::{TaskKind, TaskType},
@@ -904,7 +906,6 @@ mod sinker_worker_tests {
             sinker_worker_metrics::SinkerWorkerMetrics, task_metrics::TaskMetricsType,
         },
     };
-    use std::{collections::BTreeMap, sync::Arc};
 
     fn build_task_monitor() -> TaskMonitor {
         let task_type = TaskType::new(TaskKind::Cdc, None);
@@ -914,11 +915,12 @@ mod sinker_worker_tests {
         }
         #[cfg(feature = "metrics")]
         {
+            use std::collections::HashMap;
+
             use crate::{
                 config::metrics_config::MetricsConfig,
                 monitor::prometheus_metrics::PrometheusMetrics,
             };
-            use std::collections::HashMap;
 
             let prometheus = Arc::new(PrometheusMetrics::new(
                 Some(task_type),

--- a/dt-common/src/runtime_trace/mod.rs
+++ b/dt-common/src/runtime_trace/mod.rs
@@ -91,18 +91,17 @@ mod noop;
 #[cfg(feature = "tracing")]
 mod traced;
 
-#[cfg(feature = "tracing")]
-pub(crate) use traced::snapshot_global;
-#[cfg(feature = "tracing")]
-pub use traced::{
-    dump_global_summary, enable, init_tracing, instrument_wait, set_output_format,
-    set_task_summary_mode, trace_task_future,
-};
-
 #[cfg(not(feature = "tracing"))]
 pub(crate) use noop::snapshot_global;
 #[cfg(not(feature = "tracing"))]
 pub use noop::{
+    dump_global_summary, enable, init_tracing, instrument_wait, set_output_format,
+    set_task_summary_mode, trace_task_future,
+};
+#[cfg(feature = "tracing")]
+pub(crate) use traced::snapshot_global;
+#[cfg(feature = "tracing")]
+pub use traced::{
     dump_global_summary, enable, init_tracing, instrument_wait, set_output_format,
     set_task_summary_mode, trace_task_future,
 };

--- a/dt-common/src/utils/redis_util.rs
+++ b/dt-common/src/utils/redis_util.rs
@@ -1,8 +1,8 @@
-use regex::Regex;
 use std::{collections::HashMap, str::FromStr};
 
 use anyhow::{bail, Context};
 use redis::{Connection, ConnectionLike, Value};
+use regex::Regex;
 
 use crate::config::{config_enums::DbType, connection_auth_config::ConnectionAuthConfig};
 use crate::error::{DtError, DtOptionExt};

--- a/dt-common/src/utils/serialize_util.rs
+++ b/dt-common/src/utils/serialize_util.rs
@@ -53,9 +53,10 @@ impl SerializeUtil {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use serde::Serialize;
     use serde_json::json;
+
+    use super::*;
 
     #[derive(Serialize)]
     struct TestStruct {

--- a/dt-connector/src/checker/base_checker.rs
+++ b/dt-connector/src/checker/base_checker.rs
@@ -11,6 +11,25 @@ use anyhow::{Context, Result};
 use async_mutex::Mutex;
 use async_trait::async_trait;
 use chrono::Local;
+use dt_common::{
+    error::{DtError, DtOptionExt, DtResultExt, Stage},
+    log_error, log_info, log_summary, log_warn,
+    meta::{
+        col_value::ColValue,
+        ddl_meta::ddl_data::DdlData,
+        dt_data::{DtData, DtItem},
+        mysql::mysql_tb_meta::MysqlTbMeta,
+        pg::pg_tb_meta::PgTbMeta,
+        position::Position,
+        rdb_meta_manager::RdbMetaManager,
+        rdb_tb_meta::RdbTbMeta,
+        row_data::RowData,
+        row_type::RowType,
+        struct_meta::struct_data::StructData,
+    },
+    monitor::task_monitor_handle::TaskMonitorHandle,
+    utils::limit_queue::LimitedQueue,
+};
 use indexmap::{IndexMap, IndexSet};
 use opendal::Operator;
 use serde::{Deserialize, Serialize};
@@ -30,25 +49,6 @@ use crate::{
     rdb_router::RdbRouter,
     sinker::base_sinker::BaseSinker,
     sinker::mongo::mongo_cmd,
-};
-use dt_common::{
-    error::{DtError, DtOptionExt, DtResultExt, Stage},
-    log_error, log_info, log_summary, log_warn,
-    meta::{
-        col_value::ColValue,
-        ddl_meta::ddl_data::DdlData,
-        dt_data::{DtData, DtItem},
-        mysql::mysql_tb_meta::MysqlTbMeta,
-        pg::pg_tb_meta::PgTbMeta,
-        position::Position,
-        rdb_meta_manager::RdbMetaManager,
-        rdb_tb_meta::RdbTbMeta,
-        row_data::RowData,
-        row_type::RowType,
-        struct_meta::struct_data::StructData,
-    },
-    monitor::task_monitor_handle::TaskMonitorHandle,
-    utils::limit_queue::LimitedQueue,
 };
 
 #[path = "cdc_state.rs"]
@@ -1141,16 +1141,18 @@ impl<C: Checker> DirectDataChecker for DataChecker<C> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
     use anyhow::bail;
     use async_trait::async_trait;
     use dt_common::meta::row_type::RowType;
-    use std::collections::HashMap;
-    use std::sync::Arc;
     use tokio::{
         sync::{mpsc, Notify},
         time::{timeout, Duration},
     };
+
+    use super::*;
 
     #[derive(Clone)]
     struct BlockingFetchChecker {

--- a/dt-connector/src/checker/cdc_state.rs
+++ b/dt-connector/src/checker/cdc_state.rs
@@ -1,7 +1,10 @@
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+
 use anyhow::Context;
+use dt_common::meta::{position::Position, row_data::RowData, row_type::RowType};
+use dt_common::{log_info, log_warn};
 use openssl::sha::sha256;
 use serde::Serialize;
-use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use super::{
     BoundedLineBuffer, CheckEntry, CheckInconsistency, Checker, CheckerStoreKey, DataChecker,
@@ -9,8 +12,6 @@ use super::{
 };
 use crate::checker::check_log::{CheckLog, CheckSummaryLog, CheckTableSummaryLog};
 use crate::checker::state_store::{CheckerCheckpointCommit, CheckerStateRow};
-use dt_common::meta::{position::Position, row_data::RowData, row_type::RowType};
-use dt_common::{log_info, log_warn};
 
 #[derive(Serialize)]
 struct IdentityJsonPayload<'a> {
@@ -560,18 +561,20 @@ impl<C: Checker> DataChecker<C> {
 
 #[cfg(test)]
 mod tests {
-    use super::super::{CheckContext, Checker, CheckerIo, CheckerTbMeta, DataChecker};
-    use super::*;
-    use crate::checker::check_log::{CheckTableSummaryLog, DiffColValue};
-    use async_trait::async_trait;
-    use dt_common::{meta::col_value::ColValue, utils::limit_queue::LimitedQueue};
-    use opendal::{services::Memory, Operator};
     use std::collections::BTreeMap;
     use std::fs;
     use std::path::{Path, PathBuf};
     use std::sync::Arc;
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    use async_trait::async_trait;
+    use dt_common::{meta::col_value::ColValue, utils::limit_queue::LimitedQueue};
+    use opendal::{services::Memory, Operator};
     use tokio::sync::mpsc;
+
+    use super::super::{CheckContext, Checker, CheckerIo, CheckerTbMeta, DataChecker};
+    use super::*;
+    use crate::checker::check_log::{CheckTableSummaryLog, DiffColValue};
 
     struct NoopChecker;
 

--- a/dt-connector/src/checker/check_log.rs
+++ b/dt-connector/src/checker/check_log.rs
@@ -191,8 +191,9 @@ impl FromStr for CheckLog {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use serde_json::json;
+
+    use super::*;
 
     fn json_line<T: Serialize>(value: &T) -> serde_json::Value {
         serde_json::from_str(&to_json_line(value).unwrap()).unwrap()

--- a/dt-connector/src/checker/checker_engine.rs
+++ b/dt-connector/src/checker/checker_engine.rs
@@ -4,17 +4,6 @@ use std::{
 };
 
 use anyhow::Context;
-use mongodb::bson::Document;
-use tokio::time::{sleep, Duration, Instant};
-
-use super::{
-    cdc_state::build_identity_key, retry_buffer::RetryItem, CheckContext, CheckEntry,
-    CheckInconsistency, Checker, CheckerStoreKey, CheckerTbMeta, DataChecker, RecheckKey,
-};
-use crate::{
-    checker::check_log::{to_json_line, CheckLog, DiffColValue},
-    sinker::mongo::mongo_cmd,
-};
 use dt_common::{
     error::{ErrorCode, ErrorReport},
     log_diff, log_miss, log_sql, log_warn,
@@ -27,6 +16,17 @@ use dt_common::{
         task_monitor_handle::TaskMonitorHandle,
     },
     utils::limit_queue::LimitedQueue,
+};
+use mongodb::bson::Document;
+use tokio::time::{sleep, Duration, Instant};
+
+use super::{
+    cdc_state::build_identity_key, retry_buffer::RetryItem, CheckContext, CheckEntry,
+    CheckInconsistency, Checker, CheckerStoreKey, CheckerTbMeta, DataChecker, RecheckKey,
+};
+use crate::{
+    checker::check_log::{to_json_line, CheckLog, DiffColValue},
+    sinker::mongo::mongo_cmd,
 };
 
 impl<C: Checker> DataChecker<C> {
@@ -1086,13 +1086,15 @@ impl<C: Checker> DataChecker<C> {
 
 #[cfg(test)]
 mod tests {
-    use super::super::{CheckContext, CheckerIo};
-    use super::*;
-    use async_trait::async_trait;
     use std::sync::{
         atomic::{AtomicU64, Ordering},
         Arc, Mutex as StdMutex,
     };
+
+    use async_trait::async_trait;
+
+    use super::super::{CheckContext, CheckerIo};
+    use super::*;
 
     struct NoopChecker;
 

--- a/dt-connector/src/checker/mongo_checker.rs
+++ b/dt-connector/src/checker/mongo_checker.rs
@@ -3,13 +3,6 @@ use std::sync::Arc;
 
 use anyhow::Context;
 use async_trait::async_trait;
-use mongodb::{
-    bson::{doc, oid::ObjectId, Bson, Document},
-    Client,
-};
-use serde_json::Value as JsonValue;
-
-use crate::checker::base_checker::{Checker, CheckerTbMeta, CHECKER_MAX_QUERY_BATCH};
 use dt_common::{
     error::{DtError, DtErrorContextExt, ErrorObject, Stage},
     meta::{
@@ -21,6 +14,13 @@ use dt_common::{
     },
 };
 use dt_common::{log_error, log_warn};
+use mongodb::{
+    bson::{doc, oid::ObjectId, Bson, Document},
+    Client,
+};
+use serde_json::Value as JsonValue;
+
+use crate::checker::base_checker::{Checker, CheckerTbMeta, CHECKER_MAX_QUERY_BATCH};
 
 pub struct MongoChecker {
     mongo_client: Client,

--- a/dt-connector/src/checker/mysql_checker.rs
+++ b/dt-connector/src/checker/mysql_checker.rs
@@ -1,12 +1,11 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use futures::TryStreamExt;
-use sqlx::{MySql, Pool};
-
 use dt_common::meta::{
     ddl_meta::ddl_data::DdlData, mysql::mysql_meta_manager::MysqlMetaManager, row_data::RowData,
 };
+use futures::TryStreamExt;
+use sqlx::{MySql, Pool};
 
 use crate::checker::base_checker::{Checker, CheckerTbMeta, CHECKER_MAX_QUERY_BATCH};
 use crate::rdb_query_builder::RdbQueryBuilder;

--- a/dt-connector/src/checker/pg_checker.rs
+++ b/dt-connector/src/checker/pg_checker.rs
@@ -1,12 +1,11 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use futures::TryStreamExt;
-use sqlx::{Pool, Postgres};
-
 use dt_common::meta::{
     ddl_meta::ddl_data::DdlData, pg::pg_meta_manager::PgMetaManager, row_data::RowData,
 };
+use futures::TryStreamExt;
+use sqlx::{Pool, Postgres};
 
 use crate::checker::base_checker::{Checker, CheckerTbMeta, CHECKER_MAX_QUERY_BATCH};
 use crate::rdb_query_builder::RdbQueryBuilder;

--- a/dt-connector/src/checker/retry_buffer.rs
+++ b/dt-connector/src/checker/retry_buffer.rs
@@ -1,8 +1,7 @@
 use std::{collections::VecDeque, mem::size_of};
 
-use tokio::time::Instant;
-
 use dt_common::meta::row_data::RowData;
+use tokio::time::Instant;
 
 #[derive(Debug)]
 pub(super) struct RetryItem {

--- a/dt-connector/src/checker/state_store.rs
+++ b/dt-connector/src/checker/state_store.rs
@@ -2,9 +2,8 @@ use std::str::FromStr;
 
 use anyhow::{Context, Result};
 use chrono::Utc;
-use sqlx::{query, ColumnIndex, Database, Decode, MySql, Pool, Postgres, QueryBuilder, Row, Type};
-
 use dt_common::{config::resumer_config::ResumerConfig, error::DtError, meta::position::Position};
+use sqlx::{query, ColumnIndex, Database, Decode, MySql, Pool, Postgres, QueryBuilder, Row, Type};
 
 use crate::extractor::resumer::{utils::ResumerUtil, ResumerDbPool, ResumerType};
 

--- a/dt-connector/src/checker/struct_checker.rs
+++ b/dt-connector/src/checker/struct_checker.rs
@@ -7,9 +7,6 @@ use std::{
 use anyhow::{bail, Context};
 use async_mutex::Mutex;
 use chrono::Local;
-use sqlx::{MySql, Pool, Postgres};
-use tokio::time::sleep;
-
 use dt_common::{
     config::config_enums::DbType,
     error::{DtError, DtErrorContextExt, Stage},
@@ -21,6 +18,8 @@ use dt_common::{
     },
     rdb_filter::RdbFilter,
 };
+use sqlx::{MySql, Pool, Postgres};
+use tokio::time::sleep;
 
 use crate::{
     checker::check_log::{to_json_line, CheckSummaryLog, CheckTableSummaryLog, StructCheckLog},

--- a/dt-connector/src/common/mongo/oplog_parser.rs
+++ b/dt-connector/src/common/mongo/oplog_parser.rs
@@ -1,6 +1,5 @@
-use mongodb::bson::Document;
-
 use dt_common::meta::mongo::mongo_constant::MongoConstants;
+use mongodb::bson::Document;
 
 fn append_diff_path(prefix: &str, field: &str) -> String {
     if prefix.is_empty() {

--- a/dt-connector/src/extractor/base_extractor.rs
+++ b/dt-connector/src/extractor/base_extractor.rs
@@ -4,8 +4,6 @@ use std::sync::{
 };
 
 use anyhow::bail;
-
-use crate::{data_marker::DataMarker, rdb_router::RdbRouter};
 use dt_common::{
     config::{
         config_enums::DbType,
@@ -28,6 +26,7 @@ use dt_common::{
 };
 
 use super::extractor_monitor::ExtractorMonitor;
+use crate::{data_marker::DataMarker, rdb_router::RdbRouter};
 
 pub struct ExtractState {
     pub monitor: ExtractorMonitor,

--- a/dt-connector/src/extractor/base_splitter.rs
+++ b/dt-connector/src/extractor/base_splitter.rs
@@ -218,8 +218,9 @@ impl BaseSplitter {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use dt_common::meta::order_key::OrderKey;
+
+    use super::*;
 
     fn make_tb_meta() -> RdbTbMeta {
         RdbTbMeta {

--- a/dt-connector/src/extractor/extractor_monitor.rs
+++ b/dt-connector/src/extractor/extractor_monitor.rs
@@ -1,6 +1,5 @@
-use tokio::time::Instant;
-
 use dt_common::monitor::{counter_type::CounterType, task_monitor_handle::TaskMonitorHandle};
+use tokio::time::Instant;
 
 #[derive(Clone, Default)]
 pub struct ExtractorCounters {

--- a/dt-connector/src/extractor/kafka/kafka_extractor.rs
+++ b/dt-connector/src/extractor/kafka/kafka_extractor.rs
@@ -1,6 +1,11 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use dt_common::{
+    error::{DtResultExt, ErrorCode},
+    log_info, log_warn,
+    meta::{avro::avro_converter::AvroConverter, position::Position, syncer::Syncer},
+};
 use rdkafka::{
     consumer::{Consumer, StreamConsumer},
     ClientConfig, Message, Offset, TopicPartitionList,
@@ -13,11 +18,6 @@ use crate::{
         resumer::recovery::Recovery,
     },
     Extractor,
-};
-use dt_common::{
-    error::{DtResultExt, ErrorCode},
-    log_info, log_warn,
-    meta::{avro::avro_converter::AvroConverter, position::Position, syncer::Syncer},
 };
 
 pub struct KafkaExtractor {

--- a/dt-connector/src/extractor/mongo/mongo_cdc_extractor.rs
+++ b/dt-connector/src/extractor/mongo/mongo_cdc_extractor.rs
@@ -9,23 +9,6 @@ use std::{
 use anyhow::Context;
 use async_trait::async_trait;
 use chrono::Utc;
-use mongodb::{
-    bson::{doc, raw::RawDocument, raw::RawDocumentBuf, Bson, Document, Timestamp},
-    change_stream::event::ResumeToken,
-    options::{FullDocumentBeforeChangeType, FullDocumentType},
-    Client,
-};
-use serde_json::json;
-use tokio::{sync::Mutex, time::Instant};
-
-use crate::{
-    common::mongo::{changestream_parser, oplog_parser},
-    extractor::{
-        base_extractor::{BaseExtractor, ExtractState},
-        resumer::recovery::Recovery,
-    },
-    Extractor,
-};
 use dt_common::{
     config::config_enums::DbType,
     error::{DtError, DtOptionExt},
@@ -49,6 +32,23 @@ use dt_common::{
     rdb_filter::RdbFilter,
     system_dbs::SystemDb,
     utils::time_util::TimeUtil,
+};
+use mongodb::{
+    bson::{doc, raw::RawDocument, raw::RawDocumentBuf, Bson, Document, Timestamp},
+    change_stream::event::ResumeToken,
+    options::{FullDocumentBeforeChangeType, FullDocumentType},
+    Client,
+};
+use serde_json::json;
+use tokio::{sync::Mutex, time::Instant};
+
+use crate::{
+    common::mongo::{changestream_parser, oplog_parser},
+    extractor::{
+        base_extractor::{BaseExtractor, ExtractState},
+        resumer::recovery::Recovery,
+    },
+    Extractor,
 };
 
 pub struct MongoCdcExtractor {

--- a/dt-connector/src/extractor/mongo/mongo_check_extractor.rs
+++ b/dt-connector/src/extractor/mongo/mongo_check_extractor.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 
 use anyhow::Context;
 use async_trait::async_trait;
-
 use dt_common::log_info;
 use dt_common::meta::{
     col_value::ColValue,
@@ -11,7 +10,6 @@ use dt_common::meta::{
     row_data::RowData,
     row_type::RowType,
 };
-
 use mongodb::{
     bson::{doc, oid::ObjectId, Bson, Document},
     Client,

--- a/dt-connector/src/extractor/mongo/mongo_snapshot_extractor.rs
+++ b/dt-connector/src/extractor/mongo/mongo_snapshot_extractor.rs
@@ -2,6 +2,20 @@ use std::{collections::HashMap, sync::Arc};
 
 use anyhow::{anyhow, bail};
 use async_trait::async_trait;
+use dt_common::{
+    config::config_enums::{DbType, RdbParallelType},
+    error::{DtError, DtErrorContextExt, Stage},
+    log_error, log_info,
+    meta::{
+        col_value::ColValue,
+        mongo::{mongo_constant::MongoConstants, mongo_key::MongoKey},
+        order_key::OrderKey,
+        position::Position,
+        row_data::RowData,
+        row_type::RowType,
+    },
+    rdb_filter::RdbFilter,
+};
 use mongodb::{
     bson::{doc, oid::ObjectId, raw::RawDocumentBuf, Document},
     options::FindOptions,
@@ -17,20 +31,6 @@ use crate::{
         snapshot_dispatcher::SnapshotDispatcher,
     },
     Extractor,
-};
-use dt_common::{
-    config::config_enums::{DbType, RdbParallelType},
-    error::{DtError, DtErrorContextExt, Stage},
-    log_error, log_info,
-    meta::{
-        col_value::ColValue,
-        mongo::{mongo_constant::MongoConstants, mongo_key::MongoKey},
-        order_key::OrderKey,
-        position::Position,
-        row_data::RowData,
-        row_type::RowType,
-    },
-    rdb_filter::RdbFilter,
 };
 
 pub struct MongoSnapshotExtractor {

--- a/dt-connector/src/extractor/mongo/mongo_struct_extractor.rs
+++ b/dt-connector/src/extractor/mongo/mongo_struct_extractor.rs
@@ -1,13 +1,6 @@
 use std::collections::HashSet;
 
 use async_trait::async_trait;
-use mongodb::Client;
-
-use crate::{
-    extractor::base_extractor::{BaseExtractor, ExtractState},
-    meta_fetcher::mongo::mongo_struct_fetcher::MongoStructFetcher,
-    Extractor,
-};
 use dt_common::{
     config::task_config::DEFAULT_DB_BATCH_SIZE,
     log_info, log_warn,
@@ -16,6 +9,13 @@ use dt_common::{
         structure::structure_type::StructureType,
     },
     rdb_filter::RdbFilter,
+};
+use mongodb::Client;
+
+use crate::{
+    extractor::base_extractor::{BaseExtractor, ExtractState},
+    meta_fetcher::mongo::mongo_struct_fetcher::MongoStructFetcher,
+    Extractor,
 };
 
 pub struct MongoStructExtractor {

--- a/dt-connector/src/extractor/mysql/mysql_cdc_extractor.rs
+++ b/dt-connector/src/extractor/mysql/mysql_cdc_extractor.rs
@@ -11,26 +11,6 @@ use std::{
 use anyhow::{bail, Context as AnyhowContext};
 use async_recursion::async_recursion;
 use async_trait::async_trait;
-use sqlx::{mysql::MySqlArguments, query::Query, MySql, Pool};
-use tokio::{sync::Mutex, time::Instant};
-
-use mysql_binlog_connector_rust::{
-    binlog_client::{BinlogClient, StartPosition},
-    command::gtid_set::GtidSet,
-    event::{
-        event_data::EventData, event_header::EventHeader, query_event::QueryEvent,
-        row_event::RowEvent, table_map_event::TableMapEvent,
-    },
-};
-
-use crate::{
-    extractor::{
-        base_extractor::{BaseExtractor, ExtractState},
-        mysql::binlog_util::BinlogUtil,
-        resumer::recovery::Recovery,
-    },
-    Extractor,
-};
 use dt_common::{
     config::{config_enums::DbType, connection_auth_config::ConnectionAuthConfig},
     error::{DtError, DtOptionExt},
@@ -42,6 +22,25 @@ use dt_common::{
     },
     rdb_filter::RdbFilter,
     utils::time_util::TimeUtil,
+};
+use mysql_binlog_connector_rust::{
+    binlog_client::{BinlogClient, StartPosition},
+    command::gtid_set::GtidSet,
+    event::{
+        event_data::EventData, event_header::EventHeader, query_event::QueryEvent,
+        row_event::RowEvent, table_map_event::TableMapEvent,
+    },
+};
+use sqlx::{mysql::MySqlArguments, query::Query, MySql, Pool};
+use tokio::{sync::Mutex, time::Instant};
+
+use crate::{
+    extractor::{
+        base_extractor::{BaseExtractor, ExtractState},
+        mysql::binlog_util::BinlogUtil,
+        resumer::recovery::Recovery,
+    },
+    Extractor,
 };
 
 pub struct MysqlCdcExtractor {

--- a/dt-connector/src/extractor/mysql/mysql_check_extractor.rs
+++ b/dt-connector/src/extractor/mysql/mysql_check_extractor.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use async_trait::async_trait;
 use dt_common::log_info;
 use dt_common::meta::{
@@ -11,7 +13,6 @@ use dt_common::meta::{
 use dt_common::rdb_filter::RdbFilter;
 use futures::TryStreamExt;
 use sqlx::{MySql, Pool};
-use std::collections::HashMap;
 
 use crate::{
     checker::check_log::CheckLog,

--- a/dt-connector/src/extractor/mysql/mysql_snapshot_extractor.rs
+++ b/dt-connector/src/extractor/mysql/mysql_snapshot_extractor.rs
@@ -5,23 +5,6 @@ use std::{
 
 use anyhow::{anyhow, bail};
 use async_trait::async_trait;
-use futures::TryStreamExt;
-use sqlx::{MySql, Pool, Row};
-
-use crate::{
-    extractor::{
-        base_extractor::{BaseExtractor, ExtractState},
-        base_splitter::SnapshotChunk,
-        estimated_sample_limit,
-        mysql::mysql_snapshot_splitter::MySqlSnapshotSplitter,
-        rdb_snapshot_extract_statement::{OrderKeyPredicateType, RdbSnapshotExtractStatement},
-        resumer::recovery::Recovery,
-        snapshot_chunk_id_generator::SnapshotChunkIdGenerator,
-        snapshot_dispatcher::{SnapshotDispatcher, TableMonitorGuard},
-        snapshot_types::SnapshotTableId,
-    },
-    Extractor,
-};
 use dt_common::utils::sql_util::MYSQL_ESCAPE;
 use dt_common::{
     config::config_enums::{DbType, RdbParallelType},
@@ -43,8 +26,24 @@ use dt_common::{
     rdb_filter::RdbFilter,
     utils::serialize_util::SerializeUtil,
 };
-
+use futures::TryStreamExt;
 use quote_mysql as quote;
+use sqlx::{MySql, Pool, Row};
+
+use crate::{
+    extractor::{
+        base_extractor::{BaseExtractor, ExtractState},
+        base_splitter::SnapshotChunk,
+        estimated_sample_limit,
+        mysql::mysql_snapshot_splitter::MySqlSnapshotSplitter,
+        rdb_snapshot_extract_statement::{OrderKeyPredicateType, RdbSnapshotExtractStatement},
+        resumer::recovery::Recovery,
+        snapshot_chunk_id_generator::SnapshotChunkIdGenerator,
+        snapshot_dispatcher::{SnapshotDispatcher, TableMonitorGuard},
+        snapshot_types::SnapshotTableId,
+    },
+    Extractor,
+};
 
 pub struct MysqlSnapshotExtractor {
     pub shared: MysqlSnapshotShared,

--- a/dt-connector/src/extractor/mysql/mysql_snapshot_splitter.rs
+++ b/dt-connector/src/extractor/mysql/mysql_snapshot_splitter.rs
@@ -14,11 +14,10 @@ use dt_common::quote_mysql;
 use dt_common::utils::sql_util::*;
 use dt_common::{log_debug, log_info};
 use futures::TryStreamExt;
+use quote_mysql as quote;
 use sqlx::{MySql, Pool, Row};
 
 use crate::extractor::base_splitter::{BaseSplitter, ChunkRange, EvenSplitOutcome, SnapshotChunk};
-
-use quote_mysql as quote;
 
 #[derive(Debug)]
 pub struct MySqlSnapshotSplitter {

--- a/dt-connector/src/extractor/mysql/mysql_struct_extractor.rs
+++ b/dt-connector/src/extractor/mysql/mysql_struct_extractor.rs
@@ -1,13 +1,6 @@
 use std::collections::HashSet;
 
 use async_trait::async_trait;
-use sqlx::{MySql, Pool};
-
-use crate::{
-    extractor::base_extractor::{BaseExtractor, ExtractState},
-    meta_fetcher::mysql::mysql_struct_fetcher::MysqlStructFetcher,
-    Extractor,
-};
 use dt_common::{
     config::task_config::DEFAULT_DB_BATCH_SIZE,
     log_info, log_warn,
@@ -16,6 +9,13 @@ use dt_common::{
         struct_meta::{statement::struct_statement::StructStatement, struct_data::StructData},
     },
     rdb_filter::RdbFilter,
+};
+use sqlx::{MySql, Pool};
+
+use crate::{
+    extractor::base_extractor::{BaseExtractor, ExtractState},
+    meta_fetcher::mysql::mysql_struct_fetcher::MysqlStructFetcher,
+    Extractor,
 };
 
 pub struct MysqlStructExtractor {

--- a/dt-connector/src/extractor/pg/pg_cdc_client.rs
+++ b/dt-connector/src/extractor/pg/pg_cdc_client.rs
@@ -1,15 +1,6 @@
 use std::str::FromStr;
 
 use anyhow::Context;
-use openssl::ssl::{SslConnector, SslMethod, SslVerifyMode};
-use postgres_openssl::MakeTlsConnector;
-use postgres_types::PgLsn;
-use tokio_postgres::{
-    config::ReplicationMode, replication::LogicalReplicationStream, Client, Config, NoTls,
-    SimpleQueryMessage::Row,
-};
-use url::Url;
-
 use dt_common::{
     config::{
         config_enums::DbType,
@@ -19,6 +10,14 @@ use dt_common::{
     error::{DtError, DtOptionExt, DtResultExt, ErrorCode},
     log_info, log_warn,
 };
+use openssl::ssl::{SslConnector, SslMethod, SslVerifyMode};
+use postgres_openssl::MakeTlsConnector;
+use postgres_types::PgLsn;
+use tokio_postgres::{
+    config::ReplicationMode, replication::LogicalReplicationStream, Client, Config, NoTls,
+    SimpleQueryMessage::Row,
+};
+use url::Url;
 
 pub struct PgCdcClient {
     pub url: String,

--- a/dt-connector/src/extractor/pg/pg_cdc_extractor.rs
+++ b/dt-connector/src/extractor/pg/pg_cdc_extractor.rs
@@ -11,29 +11,6 @@ use std::{
 
 use anyhow::Error;
 use async_trait::async_trait;
-use futures::StreamExt;
-use postgres_protocol::message::backend::{
-    DeleteBody, InsertBody,
-    LogicalReplicationMessage::{
-        Begin, Commit, Delete, Insert, Origin, Relation, Truncate, Type, Update,
-    },
-    RelationBody,
-    ReplicationMessage::*,
-    TruncateBody, TupleData, UpdateBody,
-};
-use postgres_types::PgLsn;
-use sqlx::{postgres::PgArguments, query::Query, Pool, Postgres};
-use tokio::{sync::Mutex, time::Duration, time::Instant};
-use tokio_postgres::replication::LogicalReplicationStream;
-
-use crate::{
-    extractor::{
-        base_extractor::{BaseExtractor, ExtractState},
-        pg::pg_cdc_client::PgCdcClient,
-        resumer::recovery::Recovery,
-    },
-    Extractor,
-};
 use dt_common::{
     config::{
         config_enums::DbType, config_token_parser::ConfigTokenParser,
@@ -59,6 +36,29 @@ use dt_common::{
     },
     rdb_filter::RdbFilter,
     utils::time_util::TimeUtil,
+};
+use futures::StreamExt;
+use postgres_protocol::message::backend::{
+    DeleteBody, InsertBody,
+    LogicalReplicationMessage::{
+        Begin, Commit, Delete, Insert, Origin, Relation, Truncate, Type, Update,
+    },
+    RelationBody,
+    ReplicationMessage::*,
+    TruncateBody, TupleData, UpdateBody,
+};
+use postgres_types::PgLsn;
+use sqlx::{postgres::PgArguments, query::Query, Pool, Postgres};
+use tokio::{sync::Mutex, time::Duration, time::Instant};
+use tokio_postgres::replication::LogicalReplicationStream;
+
+use crate::{
+    extractor::{
+        base_extractor::{BaseExtractor, ExtractState},
+        pg::pg_cdc_client::PgCdcClient,
+        resumer::recovery::Recovery,
+    },
+    Extractor,
 };
 
 pub struct PgCdcExtractor {

--- a/dt-connector/src/extractor/pg/pg_check_extractor.rs
+++ b/dt-connector/src/extractor/pg/pg_check_extractor.rs
@@ -1,11 +1,6 @@
 use std::collections::HashMap;
 
 use async_trait::async_trait;
-
-use futures::TryStreamExt;
-
-use sqlx::{Pool, Postgres};
-
 use dt_common::{
     log_info,
     meta::{
@@ -18,6 +13,8 @@ use dt_common::{
     },
     rdb_filter::RdbFilter,
 };
+use futures::TryStreamExt;
+use sqlx::{Pool, Postgres};
 
 use crate::{
     checker::check_log::CheckLog,

--- a/dt-connector/src/extractor/pg/pg_snapshot_extractor.rs
+++ b/dt-connector/src/extractor/pg/pg_snapshot_extractor.rs
@@ -5,23 +5,6 @@ use std::{
 
 use anyhow::{anyhow, bail};
 use async_trait::async_trait;
-use futures::TryStreamExt;
-use sqlx::{Pool, Postgres, Row};
-
-use crate::{
-    extractor::{
-        base_extractor::{BaseExtractor, ExtractState},
-        base_splitter::SnapshotChunk,
-        estimated_sample_limit,
-        pg::pg_snapshot_splitter::PgSnapshotSplitter,
-        rdb_snapshot_extract_statement::{OrderKeyPredicateType, RdbSnapshotExtractStatement},
-        resumer::recovery::Recovery,
-        snapshot_chunk_id_generator::SnapshotChunkIdGenerator,
-        snapshot_dispatcher::{SnapshotDispatcher, TableMonitorGuard},
-        snapshot_types::SnapshotTableId,
-    },
-    Extractor,
-};
 use dt_common::utils::sql_util::PG_ESCAPE;
 use dt_common::{
     config::config_enums::{DbType, RdbParallelType},
@@ -40,8 +23,24 @@ use dt_common::{
     rdb_filter::RdbFilter,
     utils::serialize_util::SerializeUtil,
 };
-
+use futures::TryStreamExt;
 use quote_pg as quote;
+use sqlx::{Pool, Postgres, Row};
+
+use crate::{
+    extractor::{
+        base_extractor::{BaseExtractor, ExtractState},
+        base_splitter::SnapshotChunk,
+        estimated_sample_limit,
+        pg::pg_snapshot_splitter::PgSnapshotSplitter,
+        rdb_snapshot_extract_statement::{OrderKeyPredicateType, RdbSnapshotExtractStatement},
+        resumer::recovery::Recovery,
+        snapshot_chunk_id_generator::SnapshotChunkIdGenerator,
+        snapshot_dispatcher::{SnapshotDispatcher, TableMonitorGuard},
+        snapshot_types::SnapshotTableId,
+    },
+    Extractor,
+};
 
 pub struct PgSnapshotExtractor {
     pub shared: PgSnapshotShared,

--- a/dt-connector/src/extractor/pg/pg_snapshot_splitter.rs
+++ b/dt-connector/src/extractor/pg/pg_snapshot_splitter.rs
@@ -14,11 +14,10 @@ use dt_common::meta::{
 use dt_common::quote_pg;
 use dt_common::utils::sql_util::*;
 use futures::TryStreamExt;
+use quote_pg as quote;
 use sqlx::{Pool, Postgres, Row};
 
 use crate::extractor::base_splitter::{BaseSplitter, ChunkRange, EvenSplitOutcome, SnapshotChunk};
-
-use quote_pg as quote;
 
 pub struct PgSnapshotSplitter {
     basic: BaseSplitter,

--- a/dt-connector/src/extractor/pg/pg_struct_extractor.rs
+++ b/dt-connector/src/extractor/pg/pg_struct_extractor.rs
@@ -1,13 +1,6 @@
 use std::collections::HashSet;
 
 use async_trait::async_trait;
-use sqlx::{Pool, Postgres};
-
-use crate::{
-    extractor::base_extractor::{BaseExtractor, ExtractState},
-    meta_fetcher::pg::pg_struct_fetcher::PgStructFetcher,
-    Extractor,
-};
 use dt_common::{
     config::task_config::DEFAULT_DB_BATCH_SIZE,
     log_info, log_warn,
@@ -16,6 +9,13 @@ use dt_common::{
         structure::structure_type::StructureType,
     },
     rdb_filter::RdbFilter,
+};
+use sqlx::{Pool, Postgres};
+
+use crate::{
+    extractor::base_extractor::{BaseExtractor, ExtractState},
+    meta_fetcher::pg::pg_struct_fetcher::PgStructFetcher,
+    Extractor,
 };
 
 pub struct PgStructExtractor {

--- a/dt-connector/src/extractor/rdb_snapshot_extract_statement.rs
+++ b/dt-connector/src/extractor/rdb_snapshot_extract_statement.rs
@@ -344,13 +344,15 @@ impl<'r> RdbSnapshotExtractStatement<'r> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use std::collections::HashMap;
+
     use dt_common::meta::{
         mysql::mysql_col_type::MysqlColType, mysql::mysql_tb_meta::MysqlTbMeta,
         pg::pg_col_type::PgColType, pg::pg_tb_meta::PgTbMeta, pg::pg_value_type::PgValueType,
         rdb_tb_meta::RdbTbMeta,
     };
-    use std::collections::HashMap;
+
+    use super::*;
 
     fn create_mysql_tb_meta() -> MysqlTbMeta {
         let cols = vec![

--- a/dt-connector/src/extractor/redis/mod.rs
+++ b/dt-connector/src/extractor/redis/mod.rs
@@ -1,5 +1,6 @@
-use async_trait::async_trait;
 use std::io::{Cursor, Read};
+
+use async_trait::async_trait;
 
 pub mod rdb;
 pub mod redis_client;

--- a/dt-connector/src/extractor/redis/rdb/entry_parser/entry_parser.rs
+++ b/dt-connector/src/extractor/redis/rdb/entry_parser/entry_parser.rs
@@ -4,13 +4,12 @@ use dt_common::{
     meta::redis::redis_object::{RedisObject, RedisString},
 };
 
-use crate::extractor::redis::rdb::reader::rdb_reader::RdbReader;
-
 use super::{
     hash_parser::HashParser, list_parser::ListParser, module2_parser::ModuleParser,
     set_parser::SetParser, stream_parser::StreamParser, string_parser::StringParser,
     zset_parser::ZsetParser,
 };
+use crate::extractor::redis::rdb::reader::rdb_reader::RdbReader;
 
 pub struct EntryParser {}
 

--- a/dt-connector/src/extractor/redis/rdb/entry_parser/hash_parser.rs
+++ b/dt-connector/src/extractor/redis/rdb/entry_parser/hash_parser.rs
@@ -1,8 +1,8 @@
 use anyhow::bail;
-
-use crate::extractor::redis::rdb::reader::rdb_reader::RdbReader;
 use dt_common::error::DtError;
 use dt_common::meta::redis::redis_object::{HashObject, RedisString};
+
+use crate::extractor::redis::rdb::reader::rdb_reader::RdbReader;
 
 pub struct HashParser {}
 

--- a/dt-connector/src/extractor/redis/rdb/rdb_parser.rs
+++ b/dt-connector/src/extractor/redis/rdb/rdb_parser.rs
@@ -1,10 +1,10 @@
 use anyhow::{bail, Context};
+use dt_common::meta::redis::{redis_entry::RedisEntry, redis_object::RedisCmd};
+use dt_common::{error::DtError, log_debug, log_info};
 use sqlx::types::chrono;
 
 use super::{entry_parser::entry_parser::EntryParser, reader::rdb_reader::RdbReader};
 use crate::extractor::redis::{rdb::entry_parser::module2_parser::ModuleParser, StreamReader};
-use dt_common::meta::redis::{redis_entry::RedisEntry, redis_object::RedisCmd};
-use dt_common::{error::DtError, log_debug, log_info};
 
 const K_FLAG_SLOT_INFO: u8 = 0xf4; // (244) (Redis 7.4+) RDB_OPCODE_SLOT_INFO: slot info
 const _K_FLAG_FUNCTION2: u8 = 0xf5; // (245) function library data

--- a/dt-connector/src/extractor/redis/rdb/reader/byte.rs
+++ b/dt-connector/src/extractor/redis/rdb/reader/byte.rs
@@ -1,6 +1,5 @@
-use crate::extractor::redis::StreamReader;
-
 use super::rdb_reader::RdbReader;
+use crate::extractor::redis::StreamReader;
 
 impl RdbReader<'_> {
     pub async fn read_byte(&mut self) -> anyhow::Result<u8> {

--- a/dt-connector/src/extractor/redis/rdb/reader/float.rs
+++ b/dt-connector/src/extractor/redis/rdb/reader/float.rs
@@ -1,8 +1,7 @@
 use byteorder::{ByteOrder, LittleEndian};
 
-use crate::extractor::redis::StreamReader;
-
 use super::rdb_reader::RdbReader;
+use crate::extractor::redis::StreamReader;
 
 impl RdbReader<'_> {
     pub async fn read_float(&mut self) -> anyhow::Result<f64> {

--- a/dt-connector/src/extractor/redis/rdb/reader/int.rs
+++ b/dt-connector/src/extractor/redis/rdb/reader/int.rs
@@ -1,7 +1,7 @@
-use crate::extractor::redis::StreamReader;
+use byteorder::{BigEndian, ByteOrder, LittleEndian};
 
 use super::rdb_reader::RdbReader;
-use byteorder::{BigEndian, ByteOrder, LittleEndian};
+use crate::extractor::redis::StreamReader;
 
 impl RdbReader<'_> {
     pub async fn read_u8(&mut self) -> anyhow::Result<u8> {

--- a/dt-connector/src/extractor/redis/rdb/reader/length.rs
+++ b/dt-connector/src/extractor/redis/rdb/reader/length.rs
@@ -1,9 +1,9 @@
-use crate::extractor::redis::StreamReader;
-
-use super::rdb_reader::RdbReader;
 use anyhow::bail;
 use byteorder::{BigEndian, ByteOrder};
 use dt_common::error::DtError;
+
+use super::rdb_reader::RdbReader;
+use crate::extractor::redis::StreamReader;
 
 const RDB_6_BIT_LEN: u8 = 0;
 const RDB_14_BIT_LEN: u8 = 1;

--- a/dt-connector/src/extractor/redis/rdb/reader/list_pack.rs
+++ b/dt-connector/src/extractor/redis/rdb/reader/list_pack.rs
@@ -5,9 +5,8 @@ use byteorder::{LittleEndian, ReadBytesExt};
 use dt_common::error::DtError;
 use dt_common::meta::redis::redis_object::RedisString;
 
-use crate::extractor::redis::StreamReader;
-
 use super::rdb_reader::RdbReader;
+use crate::extractor::redis::StreamReader;
 
 const LP_ENCODING_7BIT_UINT_MASK: u8 = 0x80; // 10000000
 const LP_ENCODING_7BIT_UINT: u8 = 0x00; // 00000000

--- a/dt-connector/src/extractor/redis/rdb/reader/string.rs
+++ b/dt-connector/src/extractor/redis/rdb/reader/string.rs
@@ -1,9 +1,9 @@
 use anyhow::bail;
+use dt_common::error::DtError;
+use dt_common::meta::redis::redis_object::RedisString;
 
 use super::rdb_reader::RdbReader;
 use crate::extractor::redis::StreamReader;
-use dt_common::error::DtError;
-use dt_common::meta::redis::redis_object::RedisString;
 
 const RDB_ENC_INT8: u8 = 0;
 const RDB_ENC_INT16: u8 = 1;

--- a/dt-connector/src/extractor/redis/rdb/reader/zip_list.rs
+++ b/dt-connector/src/extractor/redis/rdb/reader/zip_list.rs
@@ -5,9 +5,8 @@ use byteorder::{BigEndian, ByteOrder, LittleEndian, ReadBytesExt};
 use dt_common::error::DtError;
 use dt_common::meta::redis::redis_object::RedisString;
 
-use crate::extractor::redis::StreamReader;
-
 use super::rdb_reader::RdbReader;
+use crate::extractor::redis::StreamReader;
 
 const ZIP_STR_06B: u8 = 0x00;
 const ZIP_STR_14B: u8 = 0x01;

--- a/dt-connector/src/extractor/redis/redis_client.rs
+++ b/dt-connector/src/extractor/redis/redis_client.rs
@@ -3,15 +3,15 @@ use std::{io::ErrorKind, net::Shutdown};
 use anyhow::{bail, Context, Error};
 use async_std::{io::BufReader, net::TcpStream, prelude::*};
 use async_trait::async_trait;
-use futures::executor::block_on;
-use url::Url;
-
-use super::{redis_resp_reader::RedisRespReader, redis_resp_types::Value, StreamReader};
 use dt_common::{
     config::{config_enums::DbType, connection_auth_config::ConnectionAuthConfig},
     error::{DtError, DtOptionExt},
     meta::redis::{command::cmd_encoder::CmdEncoder, redis_object::RedisCmd},
 };
+use futures::executor::block_on;
+use url::Url;
+
+use super::{redis_resp_reader::RedisRespReader, redis_resp_types::Value, StreamReader};
 
 pub struct RedisClient {
     pub url: String,

--- a/dt-connector/src/extractor/redis/redis_cluster_psync_extractor.rs
+++ b/dt-connector/src/extractor/redis/redis_cluster_psync_extractor.rs
@@ -2,6 +2,17 @@ use std::sync::{atomic::Ordering, Arc};
 
 use anyhow::{bail, Context};
 use async_trait::async_trait;
+use dt_common::{
+    config::{
+        config_enums::{DbType, ExtractType},
+        connection_auth_config::ConnectionAuthConfig,
+    },
+    error::{DtError, DtErrorContextExt, ErrorCode},
+    log_info, log_warn,
+    meta::{position::Position, redis::cluster_node::ClusterNode, syncer::Syncer},
+    rdb_filter::RdbFilter,
+    utils::redis_util::RedisUtil,
+};
 use tokio::{sync::Mutex, task::JoinSet};
 use url::Url;
 
@@ -16,17 +27,6 @@ use crate::{
         resumer::recovery::Recovery,
     },
     Extractor,
-};
-use dt_common::{
-    config::{
-        config_enums::{DbType, ExtractType},
-        connection_auth_config::ConnectionAuthConfig,
-    },
-    error::{DtError, DtErrorContextExt, ErrorCode},
-    log_info, log_warn,
-    meta::{position::Position, redis::cluster_node::ClusterNode, syncer::Syncer},
-    rdb_filter::RdbFilter,
-    utils::redis_util::RedisUtil,
 };
 
 pub struct RedisClusterPsyncExtractor {
@@ -269,9 +269,9 @@ mod tests {
     use std::collections::HashMap;
 
     use dt_common::meta::position::Position;
+    use dt_common::meta::redis::cluster_node::ClusterNode;
 
     use super::RedisClusterPsyncExtractor;
-    use dt_common::meta::redis::cluster_node::ClusterNode;
 
     fn node(id: &str, address: &str) -> ClusterNode {
         let (host, port) = address.split_once(':').unwrap();

--- a/dt-connector/src/extractor/redis/redis_psync_extractor.rs
+++ b/dt-connector/src/extractor/redis/redis_psync_extractor.rs
@@ -8,21 +8,6 @@ use std::{
 
 use anyhow::{bail, Context};
 use async_trait::async_trait;
-use tokio::{sync::Mutex, time::Instant};
-
-use super::redis_client::RedisClient;
-use crate::{
-    extractor::{
-        base_extractor::{BaseExtractor, ExtractState},
-        redis::{
-            rdb::{rdb_parser::RdbParser, reader::rdb_reader::RdbReader},
-            redis_resp_types::Value,
-            StreamReader,
-        },
-        resumer::{recovery::Recovery, utils::ResumerUtil},
-    },
-    Extractor,
-};
 use dt_common::{
     config::{
         config_enums::{DbType, ExtractType},
@@ -38,6 +23,21 @@ use dt_common::{
     },
     rdb_filter::RdbFilter,
     utils::{sql_util::SqlUtil, time_util::TimeUtil},
+};
+use tokio::{sync::Mutex, time::Instant};
+
+use super::redis_client::RedisClient;
+use crate::{
+    extractor::{
+        base_extractor::{BaseExtractor, ExtractState},
+        redis::{
+            rdb::{rdb_parser::RdbParser, reader::rdb_reader::RdbReader},
+            redis_resp_types::Value,
+            StreamReader,
+        },
+        resumer::{recovery::Recovery, utils::ResumerUtil},
+    },
+    Extractor,
 };
 
 pub struct RedisPsyncExtractor {

--- a/dt-connector/src/extractor/redis/redis_reshard_extractor.rs
+++ b/dt-connector/src/extractor/redis/redis_reshard_extractor.rs
@@ -1,12 +1,6 @@
-use async_trait::async_trait;
-use redis::{Connection, ConnectionLike};
 use std::{cmp, collections::HashMap};
-use url::Url;
 
-use crate::{
-    extractor::base_extractor::{BaseExtractor, ExtractState},
-    Extractor,
-};
+use async_trait::async_trait;
 use dt_common::{
     config::connection_auth_config::ConnectionAuthConfig,
     error::{DtError, DtOptionExt},
@@ -15,6 +9,13 @@ use dt_common::{
         cluster_node::ClusterNode, command::cmd_encoder::CmdEncoder, redis_object::RedisCmd,
     },
     utils::redis_util::RedisUtil,
+};
+use redis::{Connection, ConnectionLike};
+use url::Url;
+
+use crate::{
+    extractor::base_extractor::{BaseExtractor, ExtractState},
+    Extractor,
 };
 
 const SLOTS_COUNT: usize = 16384;

--- a/dt-connector/src/extractor/redis/redis_snapshot_file_extractor.rs
+++ b/dt-connector/src/extractor/redis/redis_snapshot_file_extractor.rs
@@ -1,5 +1,8 @@
 use anyhow::Context;
 use async_trait::async_trait;
+use dt_common::log_info;
+use dt_common::meta::position::Position;
+use dt_common::rdb_filter::RdbFilter;
 use tokio::{fs::metadata, fs::File, io::AsyncReadExt};
 
 use super::StreamReader;
@@ -8,9 +11,6 @@ use crate::extractor::redis::rdb::rdb_parser::RdbParser;
 use crate::extractor::redis::rdb::reader::rdb_reader::RdbReader;
 use crate::extractor::redis::redis_psync_extractor::RedisPsyncExtractor;
 use crate::Extractor;
-use dt_common::log_info;
-use dt_common::meta::position::Position;
-use dt_common::rdb_filter::RdbFilter;
 
 pub struct RedisSnapshotFileExtractor {
     pub file_path: String,

--- a/dt-connector/src/extractor/resumer/mod.rs
+++ b/dt-connector/src/extractor/resumer/mod.rs
@@ -1,15 +1,6 @@
 use std::sync::Arc;
 
 use anyhow::{bail, Result};
-use mongodb::Client;
-use sqlx::{MySql, Pool, Postgres};
-use strum::{Display, EnumString, IntoStaticStr};
-use tokio::time::Instant;
-
-use crate::extractor::resumer::{
-    recorder::{to_database::DatabaseRecorder, Recorder},
-    recovery::{from_database::DatabaseRecovery, from_log::LogRecovery, Recovery},
-};
 use dt_common::{
     config::{
         config_enums::TaskType, connection_auth_config::ConnectionAuthConfig,
@@ -18,6 +9,15 @@ use dt_common::{
     error::DtError,
     log_info, log_warn,
     meta::position::Position,
+};
+use mongodb::Client;
+use sqlx::{MySql, Pool, Postgres};
+use strum::{Display, EnumString, IntoStaticStr};
+use tokio::time::Instant;
+
+use crate::extractor::resumer::{
+    recorder::{to_database::DatabaseRecorder, Recorder},
+    recovery::{from_database::DatabaseRecovery, from_log::LogRecovery, Recovery},
 };
 pub mod recorder;
 pub mod recovery;

--- a/dt-connector/src/extractor/resumer/recorder/mod.rs
+++ b/dt-connector/src/extractor/resumer/recorder/mod.rs
@@ -1,5 +1,4 @@
 use async_trait::async_trait;
-
 use dt_common::meta::position::Position;
 
 pub mod to_database;

--- a/dt-connector/src/extractor/resumer/recorder/to_database.rs
+++ b/dt-connector/src/extractor/resumer/recorder/to_database.rs
@@ -1,5 +1,9 @@
 use anyhow::{bail, Context, Result};
 use async_trait::async_trait;
+use dt_common::{
+    config::resumer_config::ResumerConfig, error::DtError, log_info, meta::position::Position,
+    utils::redis_util::RedisUtil,
+};
 use mongodb::{
     bson::{doc, DateTime},
     options::IndexOptions,
@@ -11,10 +15,6 @@ use crate::extractor::resumer::{
     recorder::Recorder,
     utils::{RedisResumerRecord, ResumerUtil},
     ResumerDbPool, ResumerType,
-};
-use dt_common::{
-    config::resumer_config::ResumerConfig, error::DtError, log_info, meta::position::Position,
-    utils::redis_util::RedisUtil,
 };
 
 pub struct DatabaseRecorder {

--- a/dt-connector/src/extractor/resumer/recovery/from_database.rs
+++ b/dt-connector/src/extractor/resumer/recovery/from_database.rs
@@ -3,15 +3,6 @@ use std::str::FromStr;
 use anyhow::{bail, Context, Result};
 use async_trait::async_trait;
 use dashmap::DashMap;
-use futures::TryStreamExt;
-use mongodb::bson::doc;
-use sqlx::{query, Error as SqlxError, Row};
-
-use crate::extractor::resumer::{
-    recovery::Recovery,
-    utils::{RedisResumerRecord, ResumerUtil},
-    ResumerDbPool, ResumerType,
-};
 use dt_common::{
     config::resumer_config::ResumerConfig,
     error::{
@@ -21,6 +12,15 @@ use dt_common::{
     log_info, log_warn,
     meta::position::Position,
     utils::redis_util::RedisUtil,
+};
+use futures::TryStreamExt;
+use mongodb::bson::doc;
+use sqlx::{query, Error as SqlxError, Row};
+
+use crate::extractor::resumer::{
+    recovery::Recovery,
+    utils::{RedisResumerRecord, ResumerUtil},
+    ResumerDbPool, ResumerType,
 };
 
 pub struct DatabaseRecovery {

--- a/dt-connector/src/extractor/resumer/recovery/from_log.rs
+++ b/dt-connector/src/extractor/resumer/recovery/from_log.rs
@@ -2,13 +2,6 @@ use anyhow::{bail, Context, Result};
 use async_std::path::Path;
 use async_trait::async_trait;
 use dashmap::DashMap;
-use tokio::{fs::File, io::AsyncBufReadExt, io::BufReader};
-
-use crate::extractor::resumer::{
-    recovery::{Recovery, RecoverySnapshotCache},
-    utils::ResumerUtil,
-    CURRENT_POSITION_LOG_FLAG, TAIL_POSITION_COUNT,
-};
 use dt_common::{
     config::{
         config_enums::{TaskKind, TaskType},
@@ -18,6 +11,13 @@ use dt_common::{
     log_warn,
     meta::position::Position,
     utils::file_util::FileUtil,
+};
+use tokio::{fs::File, io::AsyncBufReadExt, io::BufReader};
+
+use crate::extractor::resumer::{
+    recovery::{Recovery, RecoverySnapshotCache},
+    utils::ResumerUtil,
+    CURRENT_POSITION_LOG_FLAG, TAIL_POSITION_COUNT,
 };
 
 const CDC_CURRENT_POSITION_KEY: &str = "current_position";
@@ -265,13 +265,13 @@ impl Recovery for LogRecovery {
 #[cfg(test)]
 mod tests {
     use dashmap::DashMap;
-
-    use super::{LogRecovery, RecoverySnapshotCache};
-    use crate::extractor::resumer::recovery::Recovery;
     use dt_common::{
         config::config_enums::{TaskKind, TaskType},
         meta::position::Position,
     };
+
+    use super::{LogRecovery, RecoverySnapshotCache};
+    use crate::extractor::resumer::recovery::Recovery;
 
     fn new_log_recovery() -> LogRecovery {
         LogRecovery {

--- a/dt-connector/src/extractor/resumer/recovery/mod.rs
+++ b/dt-connector/src/extractor/resumer/recovery/mod.rs
@@ -1,5 +1,4 @@
 use async_trait::async_trait;
-
 use dashmap::DashMap;
 use dt_common::meta::position::Position;
 

--- a/dt-connector/src/extractor/resumer/utils.rs
+++ b/dt-connector/src/extractor/resumer/utils.rs
@@ -1,6 +1,14 @@
 use std::{str::FromStr, time::Duration};
 
 use anyhow::{bail, Context, Result};
+use dt_common::{
+    config::{config_enums::DbType, connection_auth_config::ConnectionAuthConfig},
+    error::DtError,
+    log_info,
+    meta::position::Position,
+    meta::redis::cluster_node::ClusterNode,
+    utils::redis_util::RedisUtil,
+};
 use mongodb::options::ClientOptions;
 use redis::Connection;
 use serde::{Deserialize, Serialize};
@@ -13,14 +21,6 @@ use url::Url;
 use crate::extractor::resumer::{
     RedisResumerConn, ResumerDbPool, ResumerType, DEFAULT_POSITION_KEY, DEFAULT_RESUMER_SCHEMA,
     DEFAULT_RESUMER_TABLE,
-};
-use dt_common::{
-    config::{config_enums::DbType, connection_auth_config::ConnectionAuthConfig},
-    error::DtError,
-    log_info,
-    meta::position::Position,
-    meta::redis::cluster_node::ClusterNode,
-    utils::redis_util::RedisUtil,
 };
 
 pub struct ResumerUtil {}
@@ -276,10 +276,11 @@ impl ResumerUtil {
 
 #[cfg(test)]
 mod tests {
+    use dt_common::meta::position::Position;
+
     use crate::extractor::resumer::{
         utils::ResumerUtil, DEFAULT_RESUMER_SCHEMA, DEFAULT_RESUMER_TABLE,
     };
-    use dt_common::meta::position::Position;
 
     #[test]
     fn test_get_full_table_name() {

--- a/dt-connector/src/extractor/snapshot_dispatcher.rs
+++ b/dt-connector/src/extractor/snapshot_dispatcher.rs
@@ -1,12 +1,11 @@
 use std::{collections::VecDeque, future::Future, sync::Arc};
 
-use tokio::task::JoinSet;
-
 use dt_common::{
     error::{DtError, DtResultExt, ErrorCode},
     monitor::task_monitor_handle::TaskMonitorHandle,
     runtime_trace,
 };
+use tokio::task::JoinSet;
 
 use super::{
     base_extractor::ExtractState,

--- a/dt-connector/src/meta_fetcher/mongo/mongo_struct_fetcher.rs
+++ b/dt-connector/src/meta_fetcher/mongo/mongo_struct_fetcher.rs
@@ -1,11 +1,6 @@
 use std::collections::HashSet;
 
 use anyhow::Context;
-use mongodb::{
-    bson::{doc, Bson, Document},
-    Client,
-};
-
 use dt_common::{
     config::config_enums::DbType,
     error::{DtError, DtErrorContextExt},
@@ -17,6 +12,10 @@ use dt_common::{
         },
     },
     rdb_filter::RdbFilter,
+};
+use mongodb::{
+    bson::{doc, Bson, Document},
+    Client,
 };
 
 const STRUCT_CURSOR_BATCH_SIZE: i32 = 100;

--- a/dt-connector/src/meta_fetcher/mysql/mysql_struct_check_fetcher.rs
+++ b/dt-connector/src/meta_fetcher/mysql/mysql_struct_check_fetcher.rs
@@ -1,7 +1,6 @@
+use dt_common::utils::sql_util::SqlUtil;
 use futures::TryStreamExt;
 use sqlx::{MySql, Pool};
-
-use dt_common::utils::sql_util::SqlUtil;
 
 pub struct MysqlStructCheckFetcher {
     pub conn_pool: Pool<MySql>,

--- a/dt-connector/src/meta_fetcher/mysql/mysql_struct_fetcher.rs
+++ b/dt-connector/src/meta_fetcher/mysql/mysql_struct_fetcher.rs
@@ -4,9 +4,6 @@ use std::{
 };
 
 use anyhow::bail;
-use futures::TryStreamExt;
-use sqlx::{mysql::MySqlRow, MySql, Pool, Row};
-
 use dt_common::{
     config::config_enums::DbType,
     error::{DtError, DtErrorContextExt, ErrorCode},
@@ -29,6 +26,8 @@ use dt_common::{
     rdb_filter::RdbFilter,
     utils::sql_util::SqlUtil,
 };
+use futures::TryStreamExt;
+use sqlx::{mysql::MySqlRow, MySql, Pool, Row};
 
 pub struct MysqlStructFetcher {
     pub conn_pool: Pool<MySql>,

--- a/dt-connector/src/rdb_query_builder.rs
+++ b/dt-connector/src/rdb_query_builder.rs
@@ -1,8 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
 use anyhow::{bail, Context};
-use sqlx::{mysql::MySqlArguments, postgres::PgArguments, query::Query, MySql, Postgres};
-
 use dt_common::{
     config::config_enums::DbType,
     error::{DtError, DtErrorContextExt, ErrorObject},
@@ -21,6 +19,7 @@ use dt_common::{
     },
     utils::sql_util::SqlUtil,
 };
+use sqlx::{mysql::MySqlArguments, postgres::PgArguments, query::Query, MySql, Postgres};
 
 pub struct RdbQueryInfo<'a> {
     pub sql: String,

--- a/dt-connector/src/rdb_router.rs
+++ b/dt-connector/src/rdb_router.rs
@@ -1,4 +1,7 @@
+use std::collections::HashMap;
+
 use anyhow::{bail, Context, Ok};
+use dt_common::meta::{col_value::ColValue, row_data::RowData};
 use dt_common::{
     config::{
         config_enums::DbType, config_token_parser::ConfigTokenParser, router_config::RouterConfig,
@@ -10,9 +13,6 @@ use dt_common::{
     },
     utils::sql_util::SqlUtil,
 };
-use std::collections::HashMap;
-
-use dt_common::meta::{col_value::ColValue, row_data::RowData};
 use serde::{Deserialize, Serialize};
 
 type SchemaMap = HashMap<String, String>;

--- a/dt-connector/src/sinker/base_struct_sinker.rs
+++ b/dt-connector/src/sinker/base_struct_sinker.rs
@@ -1,10 +1,6 @@
 use std::cmp;
 
 use anyhow::bail;
-use sqlx::{query, MySql, Pool, Postgres};
-use tokio::time::Instant;
-
-use crate::sinker::base_sinker::BaseSinker;
 use dt_common::{
     config::config_enums::ConflictPolicyEnum,
     error::{DtErrorContextExt, ErrorCode},
@@ -13,6 +9,10 @@ use dt_common::{
     rdb_filter::RdbFilter,
     utils::limit_queue::LimitedQueue,
 };
+use sqlx::{query, MySql, Pool, Postgres};
+use tokio::time::Instant;
+
+use crate::sinker::base_sinker::BaseSinker;
 
 pub struct BaseStructSinker {}
 

--- a/dt-connector/src/sinker/busy_tracking_sinker.rs
+++ b/dt-connector/src/sinker/busy_tracking_sinker.rs
@@ -136,9 +136,8 @@ mod tests {
     };
     use tokio::sync::Notify;
 
-    use crate::Sinker;
-
     use super::BusyTrackingSinker;
+    use crate::Sinker;
 
     struct TestSinker {
         fail: Arc<AtomicBool>,

--- a/dt-connector/src/sinker/checkable_sinker.rs
+++ b/dt-connector/src/sinker/checkable_sinker.rs
@@ -1,11 +1,10 @@
 use async_trait::async_trait;
 use dt_common::log_warn;
+use dt_common::meta::position::Position;
 use dt_common::meta::{
     dcl_meta::dcl_data::DclData, ddl_meta::ddl_data::DdlData, dt_data::DtItem, row_data::RowData,
     struct_meta::struct_data::StructData,
 };
-
-use dt_common::meta::position::Position;
 
 use crate::{checker::CheckerHandle, Sinker};
 

--- a/dt-connector/src/sinker/clickhouse/clickhouse_sinker.rs
+++ b/dt-connector/src/sinker/clickhouse/clickhouse_sinker.rs
@@ -2,15 +2,14 @@ use std::{cmp, collections::HashMap};
 
 use async_trait::async_trait;
 use chrono::Utc;
-use reqwest::{Client, Method, Response, StatusCode};
-use tokio::time::Instant;
-
 use dt_common::{
     config::config_enums::DbType,
     error::{DtError, DtResultExt, ErrorCode},
     meta::{col_value::ColValue, row_data::RowData, row_type::RowType},
     utils::{limit_queue::LimitedQueue, sql_util::SqlUtil},
 };
+use reqwest::{Client, Method, Response, StatusCode};
+use tokio::time::Instant;
 
 use crate::{call_batch_fn, sinker::base_sinker::BaseSinker, Sinker};
 

--- a/dt-connector/src/sinker/clickhouse/clickhouse_struct_sinker.rs
+++ b/dt-connector/src/sinker/clickhouse/clickhouse_struct_sinker.rs
@@ -1,6 +1,5 @@
-use crate::{rdb_router::RdbRouter, Sinker};
-
 use anyhow::bail;
+use async_trait::async_trait;
 use clickhouse::Client;
 use dt_common::{
     config::config_enums::{ConflictPolicyEnum, DbType},
@@ -19,7 +18,7 @@ use dt_common::{
     rdb_filter::RdbFilter,
 };
 
-use async_trait::async_trait;
+use crate::{rdb_router::RdbRouter, Sinker};
 
 const SIGN_COL_NAME: &str = "_ape_dts_is_deleted";
 const SIGN_COL_TYPE: &str = "Int8";

--- a/dt-connector/src/sinker/kafka/kafka_sinker.rs
+++ b/dt-connector/src/sinker/kafka/kafka_sinker.rs
@@ -1,12 +1,11 @@
 use async_trait::async_trait;
-use kafka::producer::{Producer, Record};
-use tokio::time::Instant;
-
 use dt_common::{
     error::{DtResultExt, ErrorCode},
     meta::{avro::avro_converter::AvroConverter, ddl_meta::ddl_data::DdlData, row_data::RowData},
     utils::limit_queue::LimitedQueue,
 };
+use kafka::producer::{Producer, Record};
+use tokio::time::Instant;
 
 use crate::{call_batch_fn, rdb_router::RdbRouter, sinker::base_sinker::BaseSinker, Sinker};
 

--- a/dt-connector/src/sinker/kafka/rdkafka_sinker.rs
+++ b/dt-connector/src/sinker/kafka/rdkafka_sinker.rs
@@ -1,14 +1,13 @@
 use std::cmp;
 
 use async_trait::async_trait;
-use rdkafka::producer::{FutureProducer, FutureRecord};
-use tokio::{time::Duration, time::Instant};
-
 use dt_common::{
     error::{DtErrorContextExt, ErrorCode},
     meta::{avro::avro_converter::AvroConverter, row_data::RowData},
     utils::limit_queue::LimitedQueue,
 };
+use rdkafka::producer::{FutureProducer, FutureRecord};
+use tokio::{time::Duration, time::Instant};
 
 use crate::{rdb_router::RdbRouter, sinker::base_sinker::BaseSinker, Sinker};
 

--- a/dt-connector/src/sinker/mongo/mongo_cmd.rs
+++ b/dt-connector/src/sinker/mongo/mongo_cmd.rs
@@ -1,10 +1,9 @@
 use std::collections::HashMap;
 
-use mongodb::bson::{doc, Bson, Document, Regex};
-
 use dt_common::meta::{
     col_value::ColValue, mongo::mongo_constant::MongoConstants, row_data::RowData,
 };
+use mongodb::bson::{doc, Bson, Document, Regex};
 
 use crate::checker::check_log::DiffColValue;
 

--- a/dt-connector/src/sinker/mongo/mongo_sinker.rs
+++ b/dt-connector/src/sinker/mongo/mongo_sinker.rs
@@ -2,19 +2,6 @@ use std::{cmp, collections::HashMap};
 
 use anyhow::{bail, Context, Result};
 use async_trait::async_trait;
-use mongodb::{
-    bson::{doc, raw::RawDocumentBuf, Bson, Document},
-    Client, Collection,
-};
-use tokio::time::Instant;
-
-use crate::{
-    call_batch_fn,
-    common::mongo::{changestream_parser, oplog_parser},
-    rdb_router::RdbRouter,
-    sinker::{base_sinker::BaseSinker, checkable_sinker::CheckableSink},
-    Sinker,
-};
 use dt_common::{
     error::{DtResultExt, ErrorCode},
     log_error, log_warn,
@@ -30,6 +17,19 @@ use dt_common::{
         row_type::RowType,
     },
     utils::limit_queue::LimitedQueue,
+};
+use mongodb::{
+    bson::{doc, raw::RawDocumentBuf, Bson, Document},
+    Client, Collection,
+};
+use tokio::time::Instant;
+
+use crate::{
+    call_batch_fn,
+    common::mongo::{changestream_parser, oplog_parser},
+    rdb_router::RdbRouter,
+    sinker::{base_sinker::BaseSinker, checkable_sinker::CheckableSink},
+    Sinker,
 };
 
 #[derive(Clone)]

--- a/dt-connector/src/sinker/mongo/mongo_struct_sinker.rs
+++ b/dt-connector/src/sinker/mongo/mongo_struct_sinker.rs
@@ -2,10 +2,6 @@ use std::{cmp, collections::HashMap};
 
 use anyhow::Context;
 use async_trait::async_trait;
-use mongodb::{bson::doc, Client};
-use tokio::time::Instant;
-
-use crate::{sinker::base_sinker::BaseSinker, Sinker};
 use dt_common::{
     config::config_enums::ConflictPolicyEnum,
     error::{DtResultExt, ErrorCode},
@@ -25,6 +21,10 @@ use dt_common::{
     rdb_filter::RdbFilter,
     utils::limit_queue::LimitedQueue,
 };
+use mongodb::{bson::doc, Client};
+use tokio::time::Instant;
+
+use crate::{sinker::base_sinker::BaseSinker, Sinker};
 
 #[derive(Clone)]
 pub struct MongoStructSinker {

--- a/dt-connector/src/sinker/mysql/mysql_sinker.rs
+++ b/dt-connector/src/sinker/mysql/mysql_sinker.rs
@@ -2,17 +2,6 @@ use std::{cmp, str::FromStr, sync::Arc, time::Duration};
 
 use anyhow::Context;
 use async_trait::async_trait;
-use sqlx::{
-    mysql::{MySqlConnectOptions, MySqlPoolOptions},
-    MySql, Pool,
-};
-use tokio::{sync::RwLock, time::Instant};
-
-use crate::sinker::checkable_sinker::CheckableSink;
-use crate::{
-    call_batch_fn, data_marker::DataMarker, rdb_query_builder::RdbQueryBuilder,
-    rdb_router::RdbRouter, sinker::base_sinker::BaseSinker, Sinker,
-};
 use dt_common::{
     config::connection_auth_config::ConnectionAuthConfig,
     error::{DtResultExt, ErrorCode},
@@ -27,6 +16,17 @@ use dt_common::{
         row_type::RowType,
     },
     utils::limit_queue::LimitedQueue,
+};
+use sqlx::{
+    mysql::{MySqlConnectOptions, MySqlPoolOptions},
+    MySql, Pool,
+};
+use tokio::{sync::RwLock, time::Instant};
+
+use crate::sinker::checkable_sinker::CheckableSink;
+use crate::{
+    call_batch_fn, data_marker::DataMarker, rdb_query_builder::RdbQueryBuilder,
+    rdb_router::RdbRouter, sinker::base_sinker::BaseSinker, Sinker,
 };
 
 #[derive(Clone)]

--- a/dt-connector/src/sinker/mysql/mysql_struct_sinker.rs
+++ b/dt-connector/src/sinker/mysql/mysql_struct_sinker.rs
@@ -1,5 +1,9 @@
 use anyhow::Context;
 use async_trait::async_trait;
+use dt_common::{
+    config::config_enums::ConflictPolicyEnum, meta::struct_meta::struct_data::StructData,
+    rdb_filter::RdbFilter,
+};
 use sqlx::{MySql, Pool};
 
 use crate::{
@@ -9,10 +13,6 @@ use crate::{
         base_struct_sinker::{BaseStructSinker, DBConnPool},
     },
     Sinker,
-};
-use dt_common::{
-    config::config_enums::ConflictPolicyEnum, meta::struct_meta::struct_data::StructData,
-    rdb_filter::RdbFilter,
 };
 
 #[derive(Clone)]

--- a/dt-connector/src/sinker/pg/pg_sinker.rs
+++ b/dt-connector/src/sinker/pg/pg_sinker.rs
@@ -2,17 +2,6 @@ use std::{cmp, str::FromStr, sync::Arc};
 
 use anyhow::Context;
 use async_trait::async_trait;
-use sqlx::{
-    postgres::{PgConnectOptions, PgPoolOptions},
-    Executor, Pool, Postgres,
-};
-use tokio::{sync::RwLock, time::Instant};
-
-use crate::sinker::checkable_sinker::CheckableSink;
-use crate::{
-    call_batch_fn, data_marker::DataMarker, rdb_query_builder::RdbQueryBuilder,
-    rdb_router::RdbRouter, sinker::base_sinker::BaseSinker, Sinker,
-};
 use dt_common::{
     config::connection_auth_config::ConnectionAuthConfig,
     error::{DtResultExt, ErrorCode},
@@ -26,6 +15,17 @@ use dt_common::{
         row_type::RowType,
     },
     utils::limit_queue::LimitedQueue,
+};
+use sqlx::{
+    postgres::{PgConnectOptions, PgPoolOptions},
+    Executor, Pool, Postgres,
+};
+use tokio::{sync::RwLock, time::Instant};
+
+use crate::sinker::checkable_sinker::CheckableSink;
+use crate::{
+    call_batch_fn, data_marker::DataMarker, rdb_query_builder::RdbQueryBuilder,
+    rdb_router::RdbRouter, sinker::base_sinker::BaseSinker, Sinker,
 };
 
 #[derive(Clone)]

--- a/dt-connector/src/sinker/pg/pg_struct_sinker.rs
+++ b/dt-connector/src/sinker/pg/pg_struct_sinker.rs
@@ -1,5 +1,9 @@
 use anyhow::Context;
 use async_trait::async_trait;
+use dt_common::{
+    config::config_enums::ConflictPolicyEnum, meta::struct_meta::struct_data::StructData,
+    rdb_filter::RdbFilter,
+};
 use sqlx::{Pool, Postgres};
 
 use crate::{
@@ -9,10 +13,6 @@ use crate::{
         base_struct_sinker::{BaseStructSinker, DBConnPool},
     },
     Sinker,
-};
-use dt_common::{
-    config::config_enums::ConflictPolicyEnum, meta::struct_meta::struct_data::StructData,
-    rdb_filter::RdbFilter,
 };
 
 #[derive(Clone)]

--- a/dt-connector/src/sinker/redis/redis_sinker.rs
+++ b/dt-connector/src/sinker/redis/redis_sinker.rs
@@ -2,9 +2,6 @@ use std::sync::Arc;
 
 use anyhow::bail;
 use async_trait::async_trait;
-use redis::{Connection, ConnectionLike, Value};
-use tokio::{sync::RwLock, time::Instant};
-
 use dt_common::{
     error::{DtError, DtErrorContextExt, DtOptionExt, ErrorCode},
     log_debug,
@@ -23,6 +20,8 @@ use dt_common::{
     },
     utils::limit_queue::LimitedQueue,
 };
+use redis::{Connection, ConnectionLike, Value};
+use tokio::{sync::RwLock, time::Instant};
 
 use super::entry_rewriter::EntryRewriter;
 use crate::{

--- a/dt-connector/src/sinker/redis/redis_statistic_sinker.rs
+++ b/dt-connector/src/sinker/redis/redis_statistic_sinker.rs
@@ -1,11 +1,10 @@
 use async_trait::async_trait;
-use serde::Serialize;
-use serde_json::json;
-
 use dt_common::log_statistic;
 use dt_common::meta::dt_data::DtData;
 use dt_common::meta::dt_data::DtItem;
 use dt_common::meta::redis::redis_statistic_type::RedisStatisticType;
+use serde::Serialize;
+use serde_json::json;
 
 use crate::sinker::base_sinker::BaseSinker;
 use crate::Sinker;

--- a/dt-connector/src/sinker/sql_sinker.rs
+++ b/dt-connector/src/sinker/sql_sinker.rs
@@ -1,11 +1,12 @@
-use crate::{
-    rdb_query_builder::RdbQueryBuilder, rdb_router::RdbRouter, sinker::base_sinker::BaseSinker,
-    Sinker,
-};
 use async_trait::async_trait;
 use dt_common::{
     log_sql,
     meta::{rdb_meta_manager::RdbMetaManager, row_data::RowData},
+};
+
+use crate::{
+    rdb_query_builder::RdbQueryBuilder, rdb_router::RdbRouter, sinker::base_sinker::BaseSinker,
+    Sinker,
 };
 
 #[derive(Clone)]

--- a/dt-connector/src/sinker/starrocks/starrocks_sinker.rs
+++ b/dt-connector/src/sinker/starrocks/starrocks_sinker.rs
@@ -3,10 +3,6 @@ use std::{cmp, collections::HashMap, str::FromStr};
 use anyhow::Context;
 use async_trait::async_trait;
 use chrono::Utc;
-use reqwest::{header, Client, Method, Response, StatusCode};
-use serde_json::Value;
-use tokio::time::Instant;
-
 use dt_common::{
     config::config_enums::DbType,
     error::{DtError, DtResultExt, ErrorCode},
@@ -22,6 +18,9 @@ use dt_common::{
     },
     utils::{limit_queue::LimitedQueue, sql_util::SqlUtil},
 };
+use reqwest::{header, Client, Method, Response, StatusCode};
+use serde_json::Value;
+use tokio::time::Instant;
 
 use crate::{call_batch_fn, sinker::base_sinker::BaseSinker, Sinker};
 

--- a/dt-connector/src/sinker/starrocks/starrocks_struct_sinker.rs
+++ b/dt-connector/src/sinker/starrocks/starrocks_struct_sinker.rs
@@ -1,8 +1,7 @@
 use std::cmp;
 
-use crate::{close_conn_pool, rdb_router::RdbRouter, Sinker};
-
 use anyhow::bail;
+use async_trait::async_trait;
 use dt_common::{
     config::config_enums::{ConflictPolicyEnum, DbType},
     error::{DtError, DtErrorContextExt},
@@ -20,10 +19,10 @@ use dt_common::{
     },
     rdb_filter::RdbFilter,
 };
-
-use async_trait::async_trait;
 use futures::TryStreamExt;
 use sqlx::{MySql, Pool};
+
+use crate::{close_conn_pool, rdb_router::RdbRouter, Sinker};
 
 const SIGN_COL_NAME: &str = "_ape_dts_is_deleted";
 const SIGN_COL_TYPE: &str = "BOOLEAN";

--- a/dt-main/src/main.rs
+++ b/dt-main/src/main.rs
@@ -6,8 +6,6 @@ use std::{
 };
 
 use clap::Parser;
-use tokio::{signal::ctrl_c, spawn, time::sleep};
-
 use dt_common::{
     config::{ini_loader::IniLoader, task_config::TaskConfig},
     error::{DtResultExt, ErrorReport, Stage},
@@ -16,6 +14,7 @@ use dt_common::{
 };
 use dt_precheck::{config::task_config::PrecheckTaskConfig, do_precheck};
 use dt_task::task_runner::TaskRunner;
+use tokio::{signal::ctrl_c, spawn, time::sleep};
 
 const ENV_SHUTDOWN_TIMEOUT_SECS: &str = "SHUTDOWN_TIMEOUT_SECS";
 

--- a/dt-parallelizer/src/base_parallelizer.rs
+++ b/dt-parallelizer/src/base_parallelizer.rs
@@ -2,8 +2,6 @@ use std::{collections::VecDeque, future::Future, sync::Arc};
 
 use async_mutex::Mutex;
 use concurrent_queue::PopError;
-use tokio::task::JoinSet;
-
 use dt_common::{
     error::DtError,
     meta::{
@@ -18,6 +16,7 @@ use dt_common::{
     },
 };
 use dt_connector::Sinker;
+use tokio::task::JoinSet;
 
 type SharedSinker = Arc<Mutex<Box<dyn Sinker + Send>>>;
 

--- a/dt-parallelizer/src/chunk_partitioner.rs
+++ b/dt-parallelizer/src/chunk_partitioner.rs
@@ -748,9 +748,10 @@ impl ChunkPartitioner {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use dt_common::config::parallelizer_config::ChunkPartitionerRebalanceStrategy;
     use dt_common::meta::row_type::RowType;
+
+    use super::*;
 
     fn config(strategy: ChunkPartitionerRebalanceStrategy) -> ChunkPartitionerRebalanceConfig {
         ChunkPartitionerRebalanceConfig {

--- a/dt-parallelizer/src/merge_parallelizer.rs
+++ b/dt-parallelizer/src/merge_parallelizer.rs
@@ -2,7 +2,6 @@ use std::{cmp, sync::Arc};
 
 use async_mutex::Mutex;
 use async_trait::async_trait;
-
 use dt_common::{
     config::sinker_config::BasicSinkerConfig,
     error::DtError,

--- a/dt-parallelizer/src/redis_parallelizer.rs
+++ b/dt-parallelizer/src/redis_parallelizer.rs
@@ -2,7 +2,6 @@ use std::{collections::HashMap, sync::Arc};
 
 use anyhow::bail;
 use async_trait::async_trait;
-
 use dt_common::{
     error::{DtError, DtOptionExt},
     log_warn,

--- a/dt-parallelizer/src/serial_parallelizer.rs
+++ b/dt-parallelizer/src/serial_parallelizer.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-
 use dt_common::meta::{
     dcl_meta::dcl_data::DclData, ddl_meta::ddl_data::DdlData, dt_data::DtItem, dt_queue::DtQueue,
     row_data::RowData, struct_meta::struct_data::StructData,

--- a/dt-parallelizer/src/snapshot_parallelizer.rs
+++ b/dt-parallelizer/src/snapshot_parallelizer.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-
 use dt_common::{
     config::parallelizer_config::ChunkPartitionerRebalanceConfig,
     meta::{dt_data::DtItem, dt_queue::DtQueue, row_data::RowData},

--- a/dt-parallelizer/src/table_parallelizer.rs
+++ b/dt-parallelizer/src/table_parallelizer.rs
@@ -1,6 +1,5 @@
 use std::{collections::HashMap, sync::Arc};
 
-use crate::{DataSize, Parallelizer};
 use async_trait::async_trait;
 use dt_common::meta::{
     ddl_meta::ddl_data::DdlData,
@@ -11,6 +10,7 @@ use dt_common::meta::{
 use dt_connector::Sinker;
 
 use super::base_parallelizer::BaseParallelizer;
+use crate::{DataSize, Parallelizer};
 
 pub struct TableParallelizer {
     pub base_parallelizer: BaseParallelizer,

--- a/dt-pipeline/src/base_pipeline.rs
+++ b/dt-pipeline/src/base_pipeline.rs
@@ -1,15 +1,10 @@
-use async_trait::async_trait;
 use std::collections::HashMap;
 use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc,
 };
-use tokio::{
-    sync::{Mutex, RwLock},
-    time::{Duration, Instant},
-};
 
-use crate::{lua_processor::LuaProcessor, Pipeline};
+use async_trait::async_trait;
 use dt_common::{
     config::sinker_config::SinkerConfig,
     error::{DtResultExt, Stage},
@@ -35,6 +30,12 @@ use dt_connector::{
     Sinker,
 };
 use dt_parallelizer::{DataSize, Parallelizer};
+use tokio::{
+    sync::{Mutex, RwLock},
+    time::{Duration, Instant},
+};
+
+use crate::{lua_processor::LuaProcessor, Pipeline};
 
 pub struct BasePipeline {
     pub buffer: Arc<DtQueue>,

--- a/dt-pipeline/src/checker_pipeline.rs
+++ b/dt-pipeline/src/checker_pipeline.rs
@@ -1,6 +1,4 @@
 use async_trait::async_trait;
-
-use crate::{base_pipeline::BasePipeline, Pipeline};
 use dt_common::{
     log_warn,
     meta::{position::Position, row_data::RowData, struct_meta::struct_data::StructData},
@@ -8,6 +6,8 @@ use dt_common::{
 use dt_connector::{
     checker::CheckerHandle, sinker::busy_tracking_sinker::BusyTrackingSinker, Sinker,
 };
+
+use crate::{base_pipeline::BasePipeline, Pipeline};
 
 pub struct CheckerPipeline {
     inner: BasePipeline,

--- a/dt-precheck/src/fetcher/mongo/mongo_fetcher.rs
+++ b/dt-precheck/src/fetcher/mongo/mongo_fetcher.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 
 use anyhow::bail;
 use async_trait::async_trait;
-
 use dt_common::{
     config::{
         config_enums::DbType, connection_auth_config::ConnectionAuthConfig, task_config::APE_DTS,

--- a/dt-precheck/src/fetcher/mysql/mysql_fetcher.rs
+++ b/dt-precheck/src/fetcher/mysql/mysql_fetcher.rs
@@ -1,20 +1,20 @@
-use futures::{Stream, TryStreamExt};
 use std::collections::HashMap;
 
 use anyhow::bail;
 use async_trait::async_trait;
-use sqlx::{mysql::MySqlRow, query, Error, MySql, Pool};
-
-use crate::{
-    fetcher::traits::Fetcher,
-    meta::database_mode::{Constraint, Database, Schema, Table},
-};
 use dt_common::{
     config::{config_enums::DbType, connection_auth_config::ConnectionAuthConfig},
     rdb_filter::RdbFilter,
     utils::sql_util::SqlUtil,
 };
 use dt_task::task_util::TaskUtil;
+use futures::{Stream, TryStreamExt};
+use sqlx::{mysql::MySqlRow, query, Error, MySql, Pool};
+
+use crate::{
+    fetcher::traits::Fetcher,
+    meta::database_mode::{Constraint, Database, Schema, Table},
+};
 
 pub struct MysqlFetcher {
     pub pool: Option<Pool<MySql>>,

--- a/dt-precheck/src/prechecker/mongo_prechecker.rs
+++ b/dt-precheck/src/prechecker/mongo_prechecker.rs
@@ -1,16 +1,15 @@
 use async_trait::async_trait;
 use dt_common::config::{config_enums::DbType, filter_config::FilterConfig};
+use dt_common::error::DtError;
 use mongodb::bson::Bson;
 use regex::Regex;
 
+use super::traits::Prechecker;
 use crate::{
     config::precheck_config::PrecheckConfig,
     fetcher::{mongo::mongo_fetcher::MongoFetcher, traits::Fetcher},
     meta::{check_item::CheckItem, check_result::CheckResult},
 };
-
-use super::traits::Prechecker;
-use dt_common::error::DtError;
 
 const MONGO_SUPPORTED_VERSION_REGEX: &str = r"4.*|5.0.*|6.0.*|7.0.*";
 

--- a/dt-precheck/src/prechecker/mysql_prechecker.rs
+++ b/dt-precheck/src/prechecker/mysql_prechecker.rs
@@ -3,17 +3,16 @@ use std::collections::HashSet;
 use anyhow::bail;
 use async_trait::async_trait;
 use dt_common::config::{config_enums::DbType, filter_config::FilterConfig};
+use dt_common::error::DtError;
 use regex::Regex;
 
+use super::traits::Prechecker;
 use crate::{
     config::precheck_config::PrecheckConfig,
     fetcher::{mysql::mysql_fetcher::MysqlFetcher, traits::Fetcher},
     meta::{check_item::CheckItem, check_result::CheckResult, db_table_model::DbTable},
     prechecker::basic::BasicPrechecker,
 };
-
-use super::traits::Prechecker;
-use dt_common::error::DtError;
 
 const MYSQL_SUPPORT_DB_VERSION_REGEX: &str = r"5\..*|8\..*";
 

--- a/dt-precheck/src/prechecker/pg_prechecker.rs
+++ b/dt-precheck/src/prechecker/pg_prechecker.rs
@@ -7,6 +7,7 @@ use dt_common::{
     error::{DtError, DtOptionExt},
 };
 
+use super::{basic::BasicPrechecker, traits::Prechecker};
 use crate::{
     config::precheck_config::PrecheckConfig,
     fetcher::{postgresql::pg_fetcher::PgFetcher, traits::Fetcher},
@@ -15,8 +16,6 @@ use crate::{
         pg_enums::ConstraintTypeEnum,
     },
 };
-
-use super::{basic::BasicPrechecker, traits::Prechecker};
 
 const PG_SUPPORT_DB_VERSION_NUM_MIN: i32 = 120000;
 

--- a/dt-precheck/src/prechecker/redis_prechecker.rs
+++ b/dt-precheck/src/prechecker/redis_prechecker.rs
@@ -2,15 +2,6 @@ use std::sync::{atomic::AtomicBool, Arc};
 
 use anyhow::{Context, Error};
 use async_trait::async_trait;
-use tokio::sync::Mutex;
-use url::Url;
-
-use super::traits::Prechecker;
-use crate::{
-    config::precheck_config::PrecheckConfig,
-    fetcher::{redis::redis_fetcher::RedisFetcher, traits::Fetcher},
-    meta::{check_item::CheckItem, check_result::CheckResult},
-};
 use dt_common::{
     config::{
         config_enums::{DbType, ExtractType},
@@ -31,6 +22,15 @@ use dt_connector::{
         redis::{redis_client::RedisClient, redis_psync_extractor::RedisPsyncExtractor},
     },
     rdb_router::RdbRouter,
+};
+use tokio::sync::Mutex;
+use url::Url;
+
+use super::traits::Prechecker;
+use crate::{
+    config::precheck_config::PrecheckConfig,
+    fetcher::{redis::redis_fetcher::RedisFetcher, traits::Fetcher},
+    meta::{check_item::CheckItem, check_result::CheckResult},
 };
 
 pub struct RedisPrechecker {
@@ -260,8 +260,9 @@ impl Prechecker for RedisPrechecker {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use dt_common::meta::redis::cluster_node::ClusterNode;
+
+    use super::*;
 
     fn cluster_node(address: &str) -> ClusterNode {
         let (host, port) = address.split_once(':').unwrap();

--- a/dt-task/src/extractor_util.rs
+++ b/dt-task/src/extractor_util.rs
@@ -5,9 +5,6 @@ use std::{
 };
 
 use anyhow::{bail, Context};
-use serde::{Deserialize, Serialize};
-use tokio::sync::Mutex;
-
 use dt_common::{
     config::{
         config_enums::{CheckMode, DbType, ExtractType, SinkType, TaskKind},
@@ -62,10 +59,11 @@ use dt_connector::{
     rdb_router::RdbRouter,
     Extractor,
 };
-
-use crate::task_util::ConnClient;
+use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
 
 use super::task_util::TaskUtil;
+use crate::task_util::ConnClient;
 
 pub type PartitionCols = HashMap<(String, String), String>;
 

--- a/dt-task/src/parallelizer_util.rs
+++ b/dt-task/src/parallelizer_util.rs
@@ -1,6 +1,5 @@
 use std::collections::{HashMap, VecDeque};
 
-use super::task_util::TaskUtil;
 use dt_common::{
     config::{config_enums::ParallelType, task_config::TaskConfig},
     error::{DtError, DtOptionExt},
@@ -15,6 +14,8 @@ use dt_parallelizer::{
     serial_parallelizer::SerialParallelizer, snapshot_parallelizer::SnapshotParallelizer,
     table_parallelizer::TableParallelizer, Merger, Parallelizer,
 };
+
+use super::task_util::TaskUtil;
 
 pub struct ParallelizerUtil {}
 

--- a/dt-task/src/sinker_util.rs
+++ b/dt-task/src/sinker_util.rs
@@ -1,11 +1,6 @@
 use std::{collections::HashMap, str::FromStr, sync::Arc, time::Duration};
 
 use anyhow::{bail, Context};
-use kafka::producer::{Producer, RequiredAcks};
-use reqwest::{redirect::Policy, Url};
-use sqlx::types::chrono::Utc;
-use tokio::sync::RwLock;
-
 use dt_common::{
     config::{config_enums::DbType, sinker_config::SinkerConfig, task_config::TaskConfig},
     error::{DtError, DtOptionExt, DtResultExt, ErrorCode},
@@ -24,9 +19,6 @@ use dt_common::{
     rdb_filter::RdbFilter,
     utils::redis_util::RedisUtil,
 };
-
-use super::task_util::TaskUtil;
-use crate::{extractor_util::ExtractorUtil, task_util::ConnClient};
 use dt_connector::{
     checker::CheckerHandle,
     data_marker::DataMarker,
@@ -51,6 +43,13 @@ use dt_connector::{
     },
     Sinker,
 };
+use kafka::producer::{Producer, RequiredAcks};
+use reqwest::{redirect::Policy, Url};
+use sqlx::types::chrono::Utc;
+use tokio::sync::RwLock;
+
+use super::task_util::TaskUtil;
+use crate::{extractor_util::ExtractorUtil, task_util::ConnClient};
 
 type Sinkers = Vec<Arc<async_mutex::Mutex<Box<dyn Sinker + Send>>>>;
 

--- a/dt-task/src/task_runner.rs
+++ b/dt-task/src/task_runner.rs
@@ -9,15 +9,8 @@ use std::{
 use anyhow::{bail, Context};
 use async_mutex::Mutex as AsyncMutex;
 use chrono::Local;
-use opendal::Operator;
-use tokio::{
-    fs::{self as tokio_fs, metadata},
-    runtime::Handle,
-    sync::{Mutex, RwLock},
-    task::JoinSet,
-};
-use tokio_util::sync::CancellationToken;
-
+#[cfg(feature = "metrics")]
+use dt_common::monitor::prometheus_metrics::PrometheusMetrics;
 use dt_common::{
     config::{
         checker_config::CheckerConfig,
@@ -62,14 +55,19 @@ use dt_pipeline::{
     base_pipeline::BasePipeline, checker_pipeline::CheckerPipeline, lua_processor::LuaProcessor,
     Pipeline,
 };
+use opendal::Operator;
+use tokio::{
+    fs::{self as tokio_fs, metadata},
+    runtime::Handle,
+    sync::{Mutex, RwLock},
+    task::JoinSet,
+};
+use tokio_util::sync::CancellationToken;
 
 use super::{
     extractor_util::ExtractorUtil, parallelizer_util::ParallelizerUtil, sinker_util::SinkerUtil,
 };
 use crate::task_util::{ConnClient, TaskUtil};
-
-#[cfg(feature = "metrics")]
-use dt_common::monitor::prometheus_metrics::PrometheusMetrics;
 
 #[derive(Clone)]
 pub struct TaskInfo {
@@ -1547,8 +1545,9 @@ impl TaskRunner {
 mod tests {
     use std::{fs, time::SystemTime};
 
-    use super::TaskRunner;
     use opendal::{services::Memory, Operator};
+
+    use super::TaskRunner;
 
     #[tokio::test]
     async fn upload_local_check_logs_to_s3_deletes_empty_optional_logs() {

--- a/dt-task/src/task_util.rs
+++ b/dt-task/src/task_util.rs
@@ -1,15 +1,6 @@
 use std::{str::FromStr, sync::Arc, time::Duration};
 
 use anyhow::bail;
-use futures::{future::join_all, TryStreamExt};
-use mongodb::{bson::doc, options::ClientOptions, Client};
-use opendal::Operator;
-use sqlx::{
-    mysql::{MySqlConnectOptions, MySqlPoolOptions},
-    postgres::{PgConnectOptions, PgPoolOptions},
-    ConnectOptions, Executor, MySql, Pool, Postgres, Row,
-};
-
 use dt_common::{
     config::{
         config_enums::{DbType, RdbTransactionIsolation, SinkType, TaskKind, TaskType},
@@ -43,6 +34,14 @@ use dt_connector::{
     extractor::resumer::{
         build_recorder, build_recovery, recorder::Recorder, recovery::Recovery, utils::ResumerUtil,
     },
+};
+use futures::{future::join_all, TryStreamExt};
+use mongodb::{bson::doc, options::ClientOptions, Client};
+use opendal::Operator;
+use sqlx::{
+    mysql::{MySqlConnectOptions, MySqlPoolOptions},
+    postgres::{PgConnectOptions, PgPoolOptions},
+    ConnectOptions, Executor, MySql, Pool, Postgres, Row,
 };
 use tokio::select;
 use tokio_util::sync::CancellationToken;

--- a/dt-tests/tests/mongo_to_mongo/precheck_tests.rs
+++ b/dt-tests/tests/mongo_to_mongo/precheck_tests.rs
@@ -1,9 +1,10 @@
 #[cfg(test)]
 mod test {
 
+    use std::collections::{HashMap, HashSet};
+
     use dt_precheck::meta::check_item::CheckItem;
     use serial_test::serial;
-    use std::collections::{HashMap, HashSet};
 
     use crate::test_runner::test_base::TestBase;
 

--- a/dt-tests/tests/pg_to_pg/tb_meta_tests.rs
+++ b/dt-tests/tests/pg_to_pg/tb_meta_tests.rs
@@ -1,8 +1,9 @@
 #[cfg(test)]
 mod test {
-    use crate::test_runner::rdb_test_runner::RdbTestRunner;
     use dt_common::meta::pg::pg_meta_manager::PgMetaManager;
     use serial_test::serial;
+
+    use crate::test_runner::rdb_test_runner::RdbTestRunner;
 
     #[tokio::test]
     #[serial]

--- a/dt-tests/tests/redis_to_redis/cdc_2_8_tests.rs
+++ b/dt-tests/tests/redis_to_redis/cdc_2_8_tests.rs
@@ -1,7 +1,8 @@
 #[cfg(test)]
 mod test {
-    use crate::test_runner::test_base::TestBase;
     use serial_test::serial;
+
+    use crate::test_runner::test_base::TestBase;
 
     #[tokio::test]
     #[serial]

--- a/dt-tests/tests/redis_to_redis/cdc_4_0_tests.rs
+++ b/dt-tests/tests/redis_to_redis/cdc_4_0_tests.rs
@@ -1,7 +1,8 @@
 #[cfg(test)]
 mod test {
-    use crate::test_runner::test_base::TestBase;
     use serial_test::serial;
+
+    use crate::test_runner::test_base::TestBase;
 
     #[tokio::test]
     #[serial]

--- a/dt-tests/tests/redis_to_redis/cdc_5_0_tests.rs
+++ b/dt-tests/tests/redis_to_redis/cdc_5_0_tests.rs
@@ -1,7 +1,8 @@
 #[cfg(test)]
 mod test {
-    use crate::test_runner::test_base::TestBase;
     use serial_test::serial;
+
+    use crate::test_runner::test_base::TestBase;
 
     #[tokio::test]
     #[serial]

--- a/dt-tests/tests/redis_to_redis/cdc_6_0_tests.rs
+++ b/dt-tests/tests/redis_to_redis/cdc_6_0_tests.rs
@@ -1,7 +1,8 @@
 #[cfg(test)]
 mod test {
-    use crate::test_runner::test_base::TestBase;
     use serial_test::serial;
+
+    use crate::test_runner::test_base::TestBase;
 
     #[tokio::test]
     #[serial]

--- a/dt-tests/tests/redis_to_redis/cdc_6_2_tests.rs
+++ b/dt-tests/tests/redis_to_redis/cdc_6_2_tests.rs
@@ -1,7 +1,8 @@
 #[cfg(test)]
 mod test {
-    use crate::test_runner::test_base::TestBase;
     use serial_test::serial;
+
+    use crate::test_runner::test_base::TestBase;
 
     #[tokio::test]
     #[serial]

--- a/dt-tests/tests/redis_to_redis/cdc_7_0_tests.rs
+++ b/dt-tests/tests/redis_to_redis/cdc_7_0_tests.rs
@@ -1,8 +1,8 @@
 #[cfg(test)]
 mod test {
-    use crate::test_runner::{redis_cycle_test_runner::RedisCycleTestRunner, test_base::TestBase};
-
     use serial_test::serial;
+
+    use crate::test_runner::{redis_cycle_test_runner::RedisCycleTestRunner, test_base::TestBase};
 
     #[tokio::test]
     #[serial]

--- a/dt-tests/tests/redis_to_redis/cdc_8_0_tests.rs
+++ b/dt-tests/tests/redis_to_redis/cdc_8_0_tests.rs
@@ -1,7 +1,8 @@
 #[cfg(test)]
 mod test {
-    use crate::test_runner::test_base::TestBase;
     use serial_test::serial;
+
+    use crate::test_runner::test_base::TestBase;
 
     #[tokio::test]
     #[serial]

--- a/dt-tests/tests/redis_to_redis/cdc_cross_version_tests.rs
+++ b/dt-tests/tests/redis_to_redis/cdc_cross_version_tests.rs
@@ -1,8 +1,9 @@
 #[cfg(test)]
 mod test {
 
-    use crate::test_runner::test_base::TestBase;
     use serial_test::serial;
+
+    use crate::test_runner::test_base::TestBase;
 
     #[tokio::test]
     #[serial]

--- a/dt-tests/tests/redis_to_redis/cdc_graph_tests.rs
+++ b/dt-tests/tests/redis_to_redis/cdc_graph_tests.rs
@@ -1,7 +1,8 @@
 #[cfg(test)]
 mod test {
-    use crate::test_runner::test_base::TestBase;
     use serial_test::serial;
+
+    use crate::test_runner::test_base::TestBase;
 
     #[tokio::test]
     #[serial]

--- a/dt-tests/tests/redis_to_redis/cdc_rebloom_tests.rs
+++ b/dt-tests/tests/redis_to_redis/cdc_rebloom_tests.rs
@@ -1,7 +1,8 @@
 #[cfg(test)]
 mod test {
-    use crate::test_runner::test_base::TestBase;
     use serial_test::serial;
+
+    use crate::test_runner::test_base::TestBase;
 
     #[tokio::test]
     #[serial]

--- a/dt-tests/tests/redis_to_redis/cdc_redisearch_tests.rs
+++ b/dt-tests/tests/redis_to_redis/cdc_redisearch_tests.rs
@@ -1,7 +1,8 @@
 #[cfg(test)]
 mod test {
-    use crate::test_runner::test_base::TestBase;
     use serial_test::serial;
+
+    use crate::test_runner::test_base::TestBase;
 
     // TODO, fix psync for redisearch
     // #[tokio::test]

--- a/dt-tests/tests/redis_to_redis/cdc_rejson_tests.rs
+++ b/dt-tests/tests/redis_to_redis/cdc_rejson_tests.rs
@@ -1,7 +1,8 @@
 #[cfg(test)]
 mod test {
-    use crate::test_runner::test_base::TestBase;
     use serial_test::serial;
+
+    use crate::test_runner::test_base::TestBase;
 
     #[tokio::test]
     #[serial]

--- a/dt-tests/tests/redis_to_redis/precheck_tests.rs
+++ b/dt-tests/tests/redis_to_redis/precheck_tests.rs
@@ -2,8 +2,9 @@
 mod test {
     use std::collections::{HashMap, HashSet};
 
-    use crate::test_runner::test_base::TestBase;
     use serial_test::serial;
+
+    use crate::test_runner::test_base::TestBase;
 
     #[tokio::test]
     #[serial]

--- a/dt-tests/tests/redis_to_redis/snapshot_2_8_tests.rs
+++ b/dt-tests/tests/redis_to_redis/snapshot_2_8_tests.rs
@@ -1,7 +1,8 @@
 #[cfg(test)]
 mod test {
-    use crate::test_runner::test_base::TestBase;
     use serial_test::serial;
+
+    use crate::test_runner::test_base::TestBase;
 
     #[tokio::test]
     #[serial]

--- a/dt-tests/tests/redis_to_redis/snapshot_4_0_tests.rs
+++ b/dt-tests/tests/redis_to_redis/snapshot_4_0_tests.rs
@@ -1,7 +1,8 @@
 #[cfg(test)]
 mod test {
-    use crate::test_runner::test_base::TestBase;
     use serial_test::serial;
+
+    use crate::test_runner::test_base::TestBase;
 
     #[tokio::test]
     #[serial]

--- a/dt-tests/tests/redis_to_redis/snapshot_5_0_tests.rs
+++ b/dt-tests/tests/redis_to_redis/snapshot_5_0_tests.rs
@@ -1,7 +1,8 @@
 #[cfg(test)]
 mod test {
-    use crate::test_runner::test_base::TestBase;
     use serial_test::serial;
+
+    use crate::test_runner::test_base::TestBase;
 
     #[tokio::test]
     #[serial]

--- a/dt-tests/tests/redis_to_redis/snapshot_6_0_tests.rs
+++ b/dt-tests/tests/redis_to_redis/snapshot_6_0_tests.rs
@@ -1,7 +1,8 @@
 #[cfg(test)]
 mod test {
-    use crate::test_runner::test_base::TestBase;
     use serial_test::serial;
+
+    use crate::test_runner::test_base::TestBase;
 
     #[tokio::test]
     #[serial]

--- a/dt-tests/tests/redis_to_redis/snapshot_6_2_tests.rs
+++ b/dt-tests/tests/redis_to_redis/snapshot_6_2_tests.rs
@@ -1,7 +1,8 @@
 #[cfg(test)]
 mod test {
-    use crate::test_runner::test_base::TestBase;
     use serial_test::serial;
+
+    use crate::test_runner::test_base::TestBase;
 
     #[tokio::test]
     #[serial]

--- a/dt-tests/tests/redis_to_redis/snapshot_7_0_tests.rs
+++ b/dt-tests/tests/redis_to_redis/snapshot_7_0_tests.rs
@@ -1,8 +1,9 @@
 #[cfg(test)]
 mod test {
 
-    use crate::test_runner::test_base::TestBase;
     use serial_test::serial;
+
+    use crate::test_runner::test_base::TestBase;
 
     #[tokio::test]
     #[serial]

--- a/dt-tests/tests/redis_to_redis/snapshot_8_0_tests.rs
+++ b/dt-tests/tests/redis_to_redis/snapshot_8_0_tests.rs
@@ -1,7 +1,8 @@
 #[cfg(test)]
 mod test {
-    use crate::test_runner::test_base::TestBase;
     use serial_test::serial;
+
+    use crate::test_runner::test_base::TestBase;
 
     #[tokio::test]
     #[serial]

--- a/dt-tests/tests/redis_to_redis/snapshot_and_cdc_7_0_tests.rs
+++ b/dt-tests/tests/redis_to_redis/snapshot_and_cdc_7_0_tests.rs
@@ -1,8 +1,8 @@
 #[cfg(test)]
 mod test {
-    use crate::test_runner::test_base::TestBase;
-
     use serial_test::serial;
+
+    use crate::test_runner::test_base::TestBase;
 
     #[tokio::test]
     #[serial]

--- a/dt-tests/tests/redis_to_redis/snapshot_cross_version_tests.rs
+++ b/dt-tests/tests/redis_to_redis/snapshot_cross_version_tests.rs
@@ -1,8 +1,9 @@
 #[cfg(test)]
 mod test {
 
-    use crate::test_runner::test_base::TestBase;
     use serial_test::serial;
+
+    use crate::test_runner::test_base::TestBase;
 
     #[tokio::test]
     #[serial]

--- a/dt-tests/tests/redis_to_redis/snapshot_graph_tests.rs
+++ b/dt-tests/tests/redis_to_redis/snapshot_graph_tests.rs
@@ -1,7 +1,8 @@
 #[cfg(test)]
 mod test {
-    use crate::test_runner::test_base::TestBase;
     use serial_test::serial;
+
+    use crate::test_runner::test_base::TestBase;
 
     #[tokio::test]
     #[serial]

--- a/dt-tests/tests/redis_to_redis/snapshot_rebloom_tests.rs
+++ b/dt-tests/tests/redis_to_redis/snapshot_rebloom_tests.rs
@@ -1,7 +1,8 @@
 #[cfg(test)]
 mod test {
-    use crate::test_runner::test_base::TestBase;
     use serial_test::serial;
+
+    use crate::test_runner::test_base::TestBase;
 
     #[tokio::test]
     #[serial]

--- a/dt-tests/tests/redis_to_redis/snapshot_redisearch_tests.rs
+++ b/dt-tests/tests/redis_to_redis/snapshot_redisearch_tests.rs
@@ -1,7 +1,8 @@
 #[cfg(test)]
 mod test {
-    use crate::test_runner::test_base::TestBase;
     use serial_test::serial;
+
+    use crate::test_runner::test_base::TestBase;
 
     // TODO, fix psync for redisearch
     // #[tokio::test]

--- a/dt-tests/tests/redis_to_redis/snapshot_rejson_tests.rs
+++ b/dt-tests/tests/redis_to_redis/snapshot_rejson_tests.rs
@@ -1,7 +1,8 @@
 #[cfg(test)]
 mod test {
-    use crate::test_runner::test_base::TestBase;
     use serial_test::serial;
+
+    use crate::test_runner::test_base::TestBase;
 
     #[tokio::test]
     #[serial]

--- a/dt-tests/tests/test_runner/base_test_runner.rs
+++ b/dt-tests/tests/test_runner/base_test_runner.rs
@@ -1,10 +1,11 @@
-use dt_common::{config::task_config::TaskConfig, logger::TaskLogger, utils::time_util::TimeUtil};
-use dt_connector::data_marker::DataMarker;
-use dt_task::task_runner::TaskRunner;
 use std::{
     fs::{self, File},
     io::{BufRead, BufReader},
 };
+
+use dt_common::{config::task_config::TaskConfig, logger::TaskLogger, utils::time_util::TimeUtil};
+use dt_connector::data_marker::DataMarker;
+use dt_task::task_runner::TaskRunner;
 use tokio::task::JoinHandle;
 
 use crate::test_config_util::TestConfigUtil;

--- a/dt-tests/tests/test_runner/check_test_runner.rs
+++ b/dt-tests/tests/test_runner/check_test_runner.rs
@@ -1,8 +1,5 @@
-use super::{
-    base_test_runner::BaseTestRunner, check_util::CheckUtil, rdb_test_runner::RdbTestRunner,
-    rdb_util::RdbUtil,
-};
-use crate::test_config_util::TestConfigUtil;
+use std::{fs::File, path::Path};
+
 use anyhow::Context;
 use chrono::Utc;
 use dt_common::utils::time_util::TimeUtil;
@@ -22,7 +19,12 @@ use dt_connector::extractor::resumer::{
 };
 use serde_json::Value;
 use sqlx::{query, Row};
-use std::{fs::File, path::Path};
+
+use super::{
+    base_test_runner::BaseTestRunner, check_util::CheckUtil, rdb_test_runner::RdbTestRunner,
+    rdb_util::RdbUtil,
+};
+use crate::test_config_util::TestConfigUtil;
 
 pub struct CheckTestRunner {
     base: RdbTestRunner,

--- a/dt-tests/tests/test_runner/check_util.rs
+++ b/dt-tests/tests/test_runner/check_util.rs
@@ -1,7 +1,7 @@
-use serde_json::Value;
 use std::{collections::HashSet, fs, fs::File};
 
 use dt_common::config::config_enums::DbType;
+use serde_json::Value;
 
 use super::base_test_runner::BaseTestRunner;
 
@@ -335,8 +335,9 @@ impl CheckUtil {
 
 #[cfg(test)]
 mod tests {
-    use super::CheckUtil;
     use serde_json::json;
+
+    use super::CheckUtil;
 
     fn summary_log(diff_count: usize) -> String {
         format!(

--- a/dt-tests/tests/test_runner/mock_data/mock_data.rs
+++ b/dt-tests/tests/test_runner/mock_data/mock_data.rs
@@ -256,9 +256,9 @@ impl<T: MockColType + DeserializeOwned> MockData<T> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use dt_common::config::config_enums::DbType;
 
+    use super::*;
     use crate::test_runner::mock_data::{
         context::MockDbContext, mysql_type::MysqlType, pg_type::PgType,
     };

--- a/dt-tests/tests/test_runner/mock_data/mock_stmt.rs
+++ b/dt-tests/tests/test_runner/mock_data/mock_stmt.rs
@@ -387,9 +387,9 @@ impl<T: MockColType> MockStmt<T> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use dt_common::config::config_enums::DbType;
 
+    use super::*;
     use crate::test_runner::mock_data::{
         context::MockDbContext, mysql_type::MysqlType, pg_type::PgType,
         types::mysql::charset::MysqlCharAttrs,

--- a/dt-tests/tests/test_runner/mock_data/pg_type.rs
+++ b/dt-tests/tests/test_runner/mock_data/pg_type.rs
@@ -1017,8 +1017,9 @@ impl MockColType for PgType {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use dt_common::config::config_enums::DbType;
+
+    use super::*;
 
     fn pg_ctx() -> MockDbContext {
         MockDbContext::new(DbType::Pg, "17.0")

--- a/dt-tests/tests/test_runner/mock_data/types/money.rs
+++ b/dt-tests/tests/test_runner/mock_data/types/money.rs
@@ -1,6 +1,7 @@
+use std::fmt;
+
 use crate::test_runner::mock_data::constants::ConstantValues;
 use crate::test_runner::mock_data::random::{Random, RandomValue};
-use std::fmt;
 
 /// PostgreSQL money: currency amount with fixed fractional precision
 /// Range: -92233720368547758.08 to +92233720368547758.07

--- a/dt-tests/tests/test_runner/mock_data/types/mysql/geo.rs
+++ b/dt-tests/tests/test_runner/mock_data/types/mysql/geo.rs
@@ -1,6 +1,7 @@
+use fake::{Fake, Faker};
+
 use crate::test_runner::mock_data::constants::ConstantValues;
 use crate::test_runner::mock_data::random::{Random, RandomValue};
-use fake::{Fake, Faker};
 
 // =============================================================================
 // WKT (Well-Known Text) formatting utilities

--- a/dt-tests/tests/test_runner/mock_data/types/net.rs
+++ b/dt-tests/tests/test_runner/mock_data/types/net.rs
@@ -1,10 +1,12 @@
-use crate::test_runner::mock_data::constants::ConstantValues;
-use crate::test_runner::mock_data::random::{Random, RandomValue};
+use std::fmt;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
 use fake::faker::internet::raw::{IPv4, IPv6};
 use fake::locales::EN;
 use fake::Fake;
-use std::fmt;
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+use crate::test_runner::mock_data::constants::ConstantValues;
+use crate::test_runner::mock_data::random::{Random, RandomValue};
 
 /// PostgreSQL inet: IPv4 or IPv6 host address with optional subnet
 /// Format: address/y where y is the netmask bits (optional)

--- a/dt-tests/tests/test_runner/mock_data/types/pg/array.rs
+++ b/dt-tests/tests/test_runner/mock_data/types/pg/array.rs
@@ -141,8 +141,9 @@ impl Array {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use dt_common::config::config_enums::DbType;
+
+    use super::*;
 
     fn pg_ctx() -> MockDbContext {
         MockDbContext::new(DbType::Pg, "16.0")

--- a/dt-tests/tests/test_runner/mock_data/types/pg/geo.rs
+++ b/dt-tests/tests/test_runner/mock_data/types/pg/geo.rs
@@ -1,6 +1,7 @@
+use fake::{Fake, Faker};
+
 use crate::test_runner::mock_data::constants::ConstantValues;
 use crate::test_runner::mock_data::random::{Random, RandomValue};
-use fake::{Fake, Faker};
 
 /// PostgreSQL point: (x,y)
 pub struct Point(pub geo_types::Point<f64>);

--- a/dt-tests/tests/test_runner/mongo_test_runner.rs
+++ b/dt-tests/tests/test_runner/mongo_test_runner.rs
@@ -1,4 +1,3 @@
-use serde_json::Value;
 use std::collections::{HashMap, HashSet};
 use std::convert::TryFrom;
 
@@ -17,11 +16,11 @@ use mongodb::{
     Client,
 };
 use regex::{Captures, Regex};
+use serde_json::Value;
 use sqlx::types::chrono::Utc;
 
-use crate::test_config_util::TestConfigUtil;
-
 use super::base_test_runner::BaseTestRunner;
+use crate::test_config_util::TestConfigUtil;
 
 pub struct MongoTestRunner {
     pub base: BaseTestRunner,
@@ -1389,8 +1388,9 @@ impl MongoTestRunner {
 
 #[cfg(test)]
 mod tests {
-    use super::MongoTestRunner;
     use serde_json::Value;
+
+    use super::MongoTestRunner;
 
     #[test]
     fn normalize_doc_string_quotes_dollar_prefixed_keys() {

--- a/dt-tests/tests/test_runner/precheck_test_runner.rs
+++ b/dt-tests/tests/test_runner/precheck_test_runner.rs
@@ -4,7 +4,6 @@ use dt_common::{
     config::{config_enums::DbType, task_config::TaskConfig},
     logger::TaskLogger,
 };
-
 use dt_precheck::{
     builder::prechecker_builder::PrecheckerBuilder, config::task_config::PrecheckTaskConfig,
     meta::check_result::CheckResult,

--- a/dt-tests/tests/test_runner/rdb_cycle_test_runner.rs
+++ b/dt-tests/tests/test_runner/rdb_cycle_test_runner.rs
@@ -1,12 +1,12 @@
+use std::collections::HashMap;
+
 use anyhow::Context;
 use dt_common::utils::time_util::TimeUtil;
 use dt_connector::data_marker::DataMarker;
-use std::collections::HashMap;
 use tokio::task::JoinHandle;
 
-use crate::{test_config_util::TestConfigUtil, test_runner::mongo_test_runner::SRC};
-
 use super::rdb_test_runner::RdbTestRunner;
+use crate::{test_config_util::TestConfigUtil, test_runner::mongo_test_runner::SRC};
 
 pub struct RdbCycleTestRunner {
     base: RdbTestRunner,

--- a/dt-tests/tests/test_runner/rdb_kafka_rdb_test_runner.rs
+++ b/dt-tests/tests/test_runner/rdb_kafka_rdb_test_runner.rs
@@ -1,9 +1,5 @@
 use std::time::Duration;
 
-use crate::test_config_util::TestConfigUtil;
-
-use super::base_test_runner::BaseTestRunner;
-use super::rdb_test_runner::RdbTestRunner;
 use dt_common::config::sinker_config::SinkerConfig;
 use dt_common::config::task_config::TaskConfig;
 use dt_common::utils::time_util::TimeUtil;
@@ -13,6 +9,10 @@ use rdkafka::consumer::{BaseConsumer, Consumer};
 use rdkafka::metadata::Metadata;
 use rdkafka::ClientConfig;
 use regex::Regex;
+
+use super::base_test_runner::BaseTestRunner;
+use super::rdb_test_runner::RdbTestRunner;
+use crate::test_config_util::TestConfigUtil;
 
 /// This is used for test cases: rdb(src) -> kafka -> rdb(dst).
 /// There are 2 tasks running:

--- a/dt-tests/tests/test_runner/rdb_redis_test_runner.rs
+++ b/dt-tests/tests/test_runner/rdb_redis_test_runner.rs
@@ -11,12 +11,11 @@ use dt_task::task_util::TaskUtil;
 use redis::{Connection, Value};
 use sqlx::{MySql, Pool};
 
-use crate::test_runner::rdb_util::RdbUtil;
-
 use super::{
     base_test_runner::BaseTestRunner, rdb_test_runner::RdbTestRunner,
     redis_test_util::RedisTestUtil,
 };
+use crate::test_runner::rdb_util::RdbUtil;
 
 pub struct RdbRedisTestRunner {
     pub base: BaseTestRunner,

--- a/dt-tests/tests/test_runner/rdb_sql_test_runner.rs
+++ b/dt-tests/tests/test_runner/rdb_sql_test_runner.rs
@@ -3,9 +3,8 @@ use std::fs::File;
 use chrono::{Duration, Utc};
 use dt_common::{config::config_enums::DbType, utils::time_util::TimeUtil};
 
-use crate::test_config_util::TestConfigUtil;
-
 use super::{base_test_runner::BaseTestRunner, rdb_test_runner::RdbTestRunner};
+use crate::test_config_util::TestConfigUtil;
 
 /// This is used for test cases: rdb(src) -> sql log.
 /// We need one task runner to generate sql log

--- a/dt-tests/tests/test_runner/rdb_struct_test_runner.rs
+++ b/dt-tests/tests/test_runner/rdb_struct_test_runner.rs
@@ -1,3 +1,5 @@
+use std::collections::{HashMap, HashSet};
+
 use anyhow::bail;
 use dt_common::{
     config::{config_enums::DbType, task_config::TaskConfig},
@@ -7,7 +9,6 @@ use dt_connector::meta_fetcher::{
     mysql::mysql_struct_check_fetcher::MysqlStructCheckFetcher,
     pg::pg_struct_check_fetcher::PgStructCheckFetcher,
 };
-use std::collections::{HashMap, HashSet};
 
 use super::{base_test_runner::BaseTestRunner, rdb_test_runner::RdbTestRunner};
 

--- a/dt-tests/tests/test_runner/rdb_test_runner.rs
+++ b/dt-tests/tests/test_runner/rdb_test_runner.rs
@@ -4,6 +4,10 @@ use std::{
 };
 
 use chrono::{Duration, Utc};
+use dt_common::meta::{
+    col_value::ColValue, ddl_meta::ddl_parser::DdlParser,
+    mysql::mysql_meta_manager::MysqlMetaManager, row_data::RowData,
+};
 use dt_common::{
     config::{
         config_enums::{DbType, TaskKind},
@@ -17,28 +21,21 @@ use dt_common::{
     rdb_filter::RdbFilter,
     utils::{sql_util::SqlUtil, time_util::TimeUtil},
 };
-use serde::de::DeserializeOwned;
-
-use dt_common::meta::{
-    col_value::ColValue, ddl_meta::ddl_parser::DdlParser,
-    mysql::mysql_meta_manager::MysqlMetaManager, row_data::RowData,
-};
 use dt_connector::{
     meta_fetcher::mysql::mysql_struct_check_fetcher::MysqlStructCheckFetcher, rdb_router::RdbRouter,
 };
 use dt_task::task_util::TaskUtil;
-
+use serde::de::DeserializeOwned;
 use sqlx::{query, types::BigDecimal, MySql, Pool, Postgres, Row};
 use tokio::{sync::Semaphore, task::JoinHandle};
 
+use super::{base_test_runner::BaseTestRunner, rdb_util::RdbUtil};
 use crate::{
     test_config_util::TestConfigUtil,
     test_runner::mock_data::{
         context::MockDbContext, mysql_type::MysqlType, pg_type::PgType, MockData,
     },
 };
-
-use super::{base_test_runner::BaseTestRunner, rdb_util::RdbUtil};
 
 #[derive(Clone)]
 pub struct RdbTestRunner {
@@ -1414,12 +1411,13 @@ impl RdbTestRunner {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::{
         fs,
         sync::atomic::{AtomicU64, Ordering},
         time::{SystemTime, UNIX_EPOCH},
     };
+
+    use super::*;
 
     static TMP_CONFIG_SUFFIX: AtomicU64 = AtomicU64::new(0);
 

--- a/dt-tests/tests/test_runner/redis_cluster_connection.rs
+++ b/dt-tests/tests/test_runner/redis_cluster_connection.rs
@@ -1,10 +1,11 @@
+use std::collections::{HashMap, HashSet};
+
 use dt_common::utils::redis_util::RedisUtil;
 use dt_common::{
     config::connection_auth_config::ConnectionAuthConfig,
     meta::redis::command::key_parser::KeyParser,
 };
 use redis::Connection;
-use std::collections::{HashMap, HashSet};
 use url::Url;
 
 pub struct RedisClusterConnection {

--- a/dt-tests/tests/test_runner/redis_cycle_test_runner.rs
+++ b/dt-tests/tests/test_runner/redis_cycle_test_runner.rs
@@ -3,9 +3,8 @@ use std::collections::HashMap;
 use dt_common::utils::time_util::TimeUtil;
 use tokio::task::JoinHandle;
 
-use crate::test_config_util::TestConfigUtil;
-
 use super::redis_test_runner::RedisTestRunner;
+use crate::test_config_util::TestConfigUtil;
 
 pub struct RedisCycleTestRunner {
     base: RedisTestRunner,

--- a/dt-tests/tests/test_runner/redis_statistic_runner.rs
+++ b/dt-tests/tests/test_runner/redis_statistic_runner.rs
@@ -5,9 +5,8 @@ use dt_common::{
     utils::redis_util::RedisUtil,
 };
 
-use crate::test_runner::redis_test_util::RedisTestUtil;
-
 use super::base_test_runner::{BaseTestRunner, SqlLoadStrategy};
+use crate::test_runner::redis_test_util::RedisTestUtil;
 
 pub struct RedisStatisticTestRunner {
     pub base: BaseTestRunner,

--- a/dt-tests/tests/test_runner/redis_test_runner.rs
+++ b/dt-tests/tests/test_runner/redis_test_runner.rs
@@ -12,7 +12,6 @@ use dt_common::{
     utils::{redis_util::RedisUtil, sql_util::SqlUtil, time_util::TimeUtil},
 };
 use dt_connector::rdb_router::RdbRouter;
-
 use redis::Value;
 
 use super::{

--- a/dt-tests/tests/test_runner/test_base.rs
+++ b/dt-tests/tests/test_runner/test_base.rs
@@ -1,10 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use dt_common::config::config_enums::DbType;
-
 use futures::executor::block_on;
-
-use crate::test_runner::rdb_test_runner::DST;
 
 use super::{
     check_test_runner::CheckTestRunner, mongo_check_test_runner::MongoCheckTestRunner,
@@ -15,6 +12,7 @@ use super::{
     rdb_test_runner::RdbTestRunner, redis_statistic_runner::RedisStatisticTestRunner,
     redis_test_runner::RedisTestRunner,
 };
+use crate::test_runner::rdb_test_runner::DST;
 
 pub struct TestBase {}
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,3 @@
 unstable_features = true
-# group_imports = "StdExternalCrate"
+group_imports = "StdExternalCrate"
 reorder_imports = true

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,3 @@
+unstable_features = true
+# group_imports = "StdExternalCrate"
+reorder_imports = true


### PR DESCRIPTION
added stricter import formatting rules in `rustfmt.toml`.
you can use `make format-check` and `make format` to check and automatically adjust the formatting.